### PR TITLE
Simplify creation of PagedIterables from requests

### DIFF
--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -107,17 +107,11 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public PagedIterable<GHAppInstallation> listInstallations() {
-        return new PagedIterable<GHAppInstallation>() {
-            public PagedIterator<GHAppInstallation> _iterator(int pageSize) {
-                return new PagedIterator<GHAppInstallation>(root.retrieve().withPreview(MACHINE_MAN).asIterator("/app/installations", GHAppInstallation[].class, pageSize)) {
-                    protected void wrapUp(GHAppInstallation[] page) {
-                        for (GHAppInstallation appInstallation : page) {
-                            appInstallation.wrapUp(root);
-                        }
-                    }
-                };
-            }
-        };
+        return root.retrieve().withPreview(MACHINE_MAN)
+            .asPagedIterable(
+                "/app/installations",
+                GHAppInstallation[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -327,17 +327,11 @@ public class GHCommit {
      * Lists up all the commit comments in this repository.
      */
     public PagedIterable<GHCommitComment> listComments() {
-        return new PagedIterable<GHCommitComment>() {
-            public PagedIterator<GHCommitComment> _iterator(int pageSize) {
-                return new PagedIterator<GHCommitComment>(owner.root.retrieve().asIterator(String.format("/repos/%s/%s/commits/%s/comments", owner.getOwnerName(), owner.getName(), sha), GHCommitComment[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHCommitComment[] page) {
-                        for (GHCommitComment c : page)
-                            c.wrap(owner);
-                    }
-                };
-            }
-        };
+        return owner.root.retrieve()
+            .asPagedIterable(
+                String.format("/repos/%s/%s/commits/%s/comments", owner.getOwnerName(), owner.getName(), sha),
+                GHCommitComment[].class,
+                item -> item.wrap(owner) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCommitComment.java
+++ b/src/main/java/org/kohsuke/github/GHCommitComment.java
@@ -98,17 +98,11 @@ public class GHCommitComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return new PagedIterable<GHReaction>() {
-            public PagedIterator<GHReaction> _iterator(int pageSize) {
-                return new PagedIterator<GHReaction>(owner.root.retrieve().withPreview(SQUIRREL_GIRL).asIterator(getApiTail()+"/reactions", GHReaction[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHReaction[] page) {
-                        for (GHReaction c : page)
-                            c.wrap(owner.root);
-                    }
-                };
-            }
-        };
+        return owner.root.retrieve().withPreview(SQUIRREL_GIRL)
+            .asPagedIterable(
+                getApiTail()+"/reactions",
+                GHReaction[].class,
+                item -> item.wrap(owner.root) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
@@ -91,15 +91,10 @@ public class GHCommitQueryBuilder {
      * Lists up the commits with the criteria built so far.
      */
     public PagedIterable<GHCommit> list() {
-        return new PagedIterable<GHCommit>() {
-            public PagedIterator<GHCommit> _iterator(int pageSize) {
-                return new PagedIterator<GHCommit>(req.asIterator(repo.getApiTailUrl("commits"), GHCommit[].class, pageSize)) {
-                    protected void wrapUp(GHCommit[] page) {
-                        for (GHCommit c : page)
-                            c.wrapUp(repo);
-                    }
-                };
-            }
-        };
+        return req
+            .asPagedIterable(
+                repo.getApiTailUrl("commits"),
+                GHCommit[].class,
+                item -> item.wrapUp(repo) );
     }
 }

--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -150,16 +150,11 @@ public class GHContent {
         if (!isDirectory())
             throw new IllegalStateException(path+" is not a directory");
 
-        return new PagedIterable<GHContent>() {
-            public PagedIterator<GHContent> _iterator(int pageSize) {
-                return new PagedIterator<GHContent>(root.retrieve().asIterator(url, GHContent[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHContent[] page) {
-                        GHContent.wrap(page, repository);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                url,
+                GHContent[].class,
+                item -> item.wrap(repository) );
     }
 
     @SuppressFBWarnings("DM_DEFAULT_ENCODING")

--- a/src/main/java/org/kohsuke/github/GHDeployment.java
+++ b/src/main/java/org/kohsuke/github/GHDeployment.java
@@ -71,17 +71,11 @@ public class GHDeployment extends GHObject {
     }
 
     public PagedIterable<GHDeploymentStatus> listStatuses() {
-        return new PagedIterable<GHDeploymentStatus>() {
-            public PagedIterator<GHDeploymentStatus> _iterator(int pageSize) {
-                return new PagedIterator<GHDeploymentStatus>(root.retrieve().asIterator(statuses_url, GHDeploymentStatus[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHDeploymentStatus[] page) {
-                        for (GHDeploymentStatus c : page)
-                            c.wrap(owner);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                statuses_url,
+                GHDeploymentStatus[].class,
+                item -> item.wrap(owner) );
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHGist.java
+++ b/src/main/java/org/kohsuke/github/GHGist.java
@@ -145,17 +145,11 @@ public class GHGist extends GHObject {
     }
 
     public PagedIterable<GHGist> listForks() {
-        return new PagedIterable<GHGist>() {
-            public PagedIterator<GHGist> _iterator(int pageSize) {
-                return new PagedIterator<GHGist>(root.retrieve().asIterator(getApiTailUrl("forks"), GHGist[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHGist[] page) {
-                        for (GHGist c : page)
-                            c.wrapUp(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiTailUrl("forks"),
+                GHGist[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -425,16 +425,9 @@ public class GHIssue extends GHObject implements Reactable{
      * See https://developer.github.com/v3/issues/events/
      */
     public PagedIterable<GHIssueEvent> listEvents() throws IOException {
-        return new PagedIterable<GHIssueEvent>() {
-            public PagedIterator<GHIssueEvent> _iterator(int pageSize) {
-                return new PagedIterator<GHIssueEvent>(root.retrieve().asIterator(owner.getApiTailUrl(String.format("/issues/%s/events", number)), GHIssueEvent[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHIssueEvent[] page) {
-                        for (GHIssueEvent c : page)
-                            c.wrapUp(GHIssue.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve().asPagedIterable(
+            owner.getApiTailUrl(String.format("/issues/%s/events", number)),
+            GHIssueEvent[].class,
+            item -> item.wrapUp(GHIssue.this) );
     }
 }

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -292,16 +292,11 @@ public class GHIssue extends GHObject implements Reactable{
      * Obtains all the comments associated with this issue.
      */
     public PagedIterable<GHIssueComment> listComments() throws IOException {
-        return new PagedIterable<GHIssueComment>() {
-            public PagedIterator<GHIssueComment> _iterator(int pageSize) {
-                return new PagedIterator<GHIssueComment>(root.retrieve().asIterator(getIssuesApiRoute() + "/comments", GHIssueComment[].class, pageSize)) {
-                    protected void wrapUp(GHIssueComment[] page) {
-                        for (GHIssueComment c : page)
-                            c.wrapUp(GHIssue.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getIssuesApiRoute() + "/comments",
+                GHIssueComment[].class,
+                item -> item.wrapUp(GHIssue.this) );
     }
 
     @Preview @Deprecated
@@ -314,17 +309,11 @@ public class GHIssue extends GHObject implements Reactable{
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return new PagedIterable<GHReaction>() {
-            public PagedIterator<GHReaction> _iterator(int pageSize) {
-                return new PagedIterator<GHReaction>(owner.root.retrieve().withPreview(SQUIRREL_GIRL).asIterator(getApiRoute()+"/reactions", GHReaction[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHReaction[] page) {
-                        for (GHReaction c : page)
-                            c.wrap(owner.root);
-                    }
-                };
-            }
-        };
+        return owner.root.retrieve().withPreview(SQUIRREL_GIRL)
+            .asPagedIterable(
+                getApiRoute()+"/reactions",
+                GHReaction[].class,
+                item -> item.wrap(owner.root) );
     }
 
     public void addAssignees(GHUser... assignees) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHIssueComment.java
+++ b/src/main/java/org/kohsuke/github/GHIssueComment.java
@@ -109,17 +109,12 @@ public class GHIssueComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return new PagedIterable<GHReaction>() {
-            public PagedIterator<GHReaction> _iterator(int pageSize) {
-                return new PagedIterator<GHReaction>(owner.root.retrieve().withPreview(SQUIRREL_GIRL).asIterator(getApiRoute()+"/reactions", GHReaction[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHReaction[] page) {
-                        for (GHReaction c : page)
-                            c.wrap(owner.root);
-                    }
-                };
-            }
-        };
+        return owner.root.retrieve()
+            .withPreview(SQUIRREL_GIRL)
+            .asPagedIterable(
+                getApiRoute()+"/reactions",
+                GHReaction[].class,
+                item -> item.wrap(owner.root) );
     }
 
     private String getApiRoute() {

--- a/src/main/java/org/kohsuke/github/GHMyself.java
+++ b/src/main/java/org/kohsuke/github/GHMyself.java
@@ -156,17 +156,13 @@ public class GHMyself extends GHUser {
      * @param repoType type of repository returned in the listing
      */
     public PagedIterable<GHRepository> listRepositories(final int pageSize, final RepositoryListFilter repoType) {
-        return new PagedIterable<GHRepository>() {
-            public PagedIterator<GHRepository> _iterator(int pageSize) {
-                return new PagedIterator<GHRepository>(root.retrieve().with("type",repoType).asIterator("/user/repos", GHRepository[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHRepository[] page) {
-                        for (GHRepository c : page)
-                            c.wrap(root);
-                    }
-                };
-            }
-        }.withPageSize(pageSize);
+        return root.retrieve()
+            .with("type",repoType)
+            .asPagedIterable(
+                "/user/repos",
+                GHRepository[].class,
+                item -> item.wrap(root)
+            ).withPageSize(pageSize);
     }
 
     /**
@@ -191,16 +187,12 @@ public class GHMyself extends GHUser {
      *      Filter by a specific state
      */
     public PagedIterable<GHMembership> listOrgMemberships(final GHMembership.State state) {
-        return new PagedIterable<GHMembership>() {
-            public PagedIterator<GHMembership> _iterator(int pageSize) {
-                return new PagedIterator<GHMembership>(root.retrieve().with("state",state).asIterator("/user/memberships/orgs", GHMembership[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHMembership[] page) {
-                        GHMembership.wrap(page,root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .with("state",state)
+            .asPagedIterable(
+                "/user/memberships/orgs",
+                GHMembership[].class,
+                item -> item.wrap(root) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -70,16 +70,11 @@ public class GHOrganization extends GHPerson {
      * List up all the teams.
      */
     public PagedIterable<GHTeam> listTeams() throws IOException {
-        return new PagedIterable<GHTeam>() {
-            public PagedIterator<GHTeam> _iterator(int pageSize) {
-                return new PagedIterator<GHTeam>(root.retrieve().asIterator(String.format("/orgs/%s/teams", login), GHTeam[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHTeam[] page) {
-                        GHTeam.wrapUp(page, GHOrganization.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/orgs/%s/teams", login),
+                GHTeam[].class,
+                item -> item.wrapUp(GHOrganization.this) );
     }
 
     /**
@@ -189,17 +184,12 @@ public class GHOrganization extends GHPerson {
     }
 
     private PagedIterable<GHUser> listMembers(final String suffix, final String filter) throws IOException {
-        return new PagedIterable<GHUser>() {
-            public PagedIterator<GHUser> _iterator(int pageSize) {
-                String filterParams = (filter == null) ? "" : ("?filter=" + filter);
-                return new PagedIterator<GHUser>(root.retrieve().asIterator(String.format("/orgs/%s/%s%s", login, suffix, filterParams), GHUser[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHUser[] users) {
-                        GHUser.wrap(users, root);
-                    }
-                };
-            }
-        };
+        String filterParams = (filter == null) ? "" : ("?filter=" + filter);
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/orgs/%s/%s%s", login, suffix, filterParams),
+                GHUser[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**
@@ -214,19 +204,12 @@ public class GHOrganization extends GHPerson {
      * @param status The status filter (all, open or closed).
      */
     public PagedIterable<GHProject> listProjects(final GHProject.ProjectStateFilter status) throws IOException {
-        return new PagedIterable<GHProject>() {
-            public PagedIterator<GHProject> _iterator(int pageSize) {
-                return new PagedIterator<GHProject>(root.retrieve().withPreview(INERTIA)
+        return root.retrieve().withPreview(INERTIA)
                         .with("state", status)
-                        .asIterator(String.format("/orgs/%s/projects", login), GHProject[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHProject[] page) {
-                        for (GHProject c : page)
-                            c.wrap(root);
-                    }
-                };
-            }
-        };
+                        .asPagedIterable(
+                            String.format("/orgs/%s/projects", login),
+                            GHProject[].class,
+                            item -> item.wrap(root) );
     }
 
     /**
@@ -299,17 +282,11 @@ public class GHOrganization extends GHPerson {
      * Lists events performed by a user (this includes private events if the caller is authenticated.
      */
     public PagedIterable<GHEventInfo> listEvents() throws IOException {
-        return new PagedIterable<GHEventInfo>() {
-            public PagedIterator<GHEventInfo> _iterator(int pageSize) {
-                return new PagedIterator<GHEventInfo>(root.retrieve().asIterator(String.format("/orgs/%s/events", login), GHEventInfo[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHEventInfo[] page) {
-                        for (GHEventInfo c : page)
-                            c.wrapUp(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/orgs/%s/events", login),
+                GHEventInfo[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**
@@ -321,17 +298,12 @@ public class GHOrganization extends GHPerson {
      */
     @Override
     public PagedIterable<GHRepository> listRepositories(final int pageSize) {
-        return new PagedIterable<GHRepository>() {
-            public PagedIterator<GHRepository> _iterator(int pageSize) {
-                return new PagedIterator<GHRepository>(root.retrieve().asIterator("/orgs/" + login + "/repos", GHRepository[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHRepository[] page) {
-                        for (GHRepository c : page)
-                            c.wrap(root);
-                    }
-                };
-            }
-        }.withPageSize(pageSize);
+        return root.retrieve()
+            .asPagedIterable(
+                "/orgs/" + login + "/repos",
+                GHRepository[].class,
+                item -> item.wrap(root)
+            ).withPageSize(pageSize);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -79,32 +79,28 @@ public abstract class GHPerson extends GHObject {
      * Unlike {@link #getRepositories()}, this does not wait until all the repositories are returned.
      */
     public PagedIterable<GHRepository> listRepositories(final int pageSize) {
-        return new PagedIterable<GHRepository>() {
-            public PagedIterator<GHRepository> _iterator(int pageSize) {
-                return new PagedIterator<GHRepository>(root.retrieve().asIterator("/users/" + login + "/repos", GHRepository[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHRepository[] page) {
-                        for (GHRepository c : page)
-                            c.wrap(root);
-                    }
-                };
-            }
-        }.withPageSize(pageSize);
+        return root.retrieve()
+            .asPagedIterable(
+                "/users/" + login + "/repos",
+                GHRepository[].class,
+                item -> item.wrap(root)
+            ).withPageSize(pageSize);
     }
 
     /**
      * Loads repository list in a paginated fashion.
-     * 
+     *
      * <p>
      * For a person with a lot of repositories, GitHub returns the list of repositories in a paginated fashion.
      * Unlike {@link #getRepositories()}, this method allows the caller to start processing data as it arrives.
-     * 
+     *
      * Every {@link Iterator#next()} call results in I/O. Exceptions that occur during the processing is wrapped
      * into {@link Error}.
      *
      * @deprecated
      *      Use {@link #listRepositories()}
      */
+    @Deprecated
     public synchronized Iterable<List<GHRepository>> iterateRepositories(final int pageSize) {
         return new Iterable<List<GHRepository>>() {
             public Iterator<List<GHRepository>> iterator() {

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -166,18 +166,12 @@ public class GHProject extends GHObject {
 
     public PagedIterable<GHProjectColumn> listColumns() throws IOException {
         final GHProject project = this;
-        return new PagedIterable<GHProjectColumn>() {
-            public PagedIterator<GHProjectColumn> _iterator(int pageSize) {
-                return new PagedIterator<GHProjectColumn>(root.retrieve().withPreview(INERTIA)
-                        .asIterator(String.format("/projects/%d/columns", id), GHProjectColumn[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHProjectColumn[] page) {
-                        for (GHProjectColumn c : page)
-                            c.wrap(project);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .withPreview(INERTIA)
+            .asPagedIterable(
+                String.format("/projects/%d/columns", id),
+                GHProjectColumn[].class,
+                item -> item.wrap(project) );
     }
 
     public GHProjectColumn createColumn(String name) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -73,18 +73,12 @@ public class GHProjectColumn extends GHObject {
 
 	public PagedIterable<GHProjectCard> listCards() throws IOException {
 		final GHProjectColumn column = this;
-		return new PagedIterable<GHProjectCard>() {
-			public PagedIterator<GHProjectCard> _iterator(int pageSize) {
-				return new PagedIterator<GHProjectCard>(root.retrieve().withPreview(INERTIA)
-						.asIterator(String.format("/projects/columns/%d/cards", id), GHProjectCard[].class, pageSize)) {
-					@Override
-					protected void wrapUp(GHProjectCard[] page) {
-						for (GHProjectCard c : page)
-							c.wrap(column);
-					}
-				};
-			}
-		};
+		return root.retrieve()
+			.withPreview(INERTIA)
+			.asPagedIterable(
+				String.format("/projects/columns/%d/cards", id),
+				GHProjectCard[].class,
+				item -> item.wrap(column) );
 	}
 
 	public GHProjectCard createCard(String note) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -269,72 +269,44 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      * Retrieves all the files associated to this pull request.
      */
     public PagedIterable<GHPullRequestFileDetail> listFiles() {
-        return new PagedIterable<GHPullRequestFileDetail>() {
-            public PagedIterator<GHPullRequestFileDetail> _iterator(int pageSize) {
-                return new PagedIterator<GHPullRequestFileDetail>(root.retrieve().asIterator(String.format("%s/files", getApiRoute()),
-                        GHPullRequestFileDetail[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHPullRequestFileDetail[] page) {
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("%s/files", getApiRoute()),
+                GHPullRequestFileDetail[].class,
+                null);
     }
 
     /**
      * Retrieves all the reviews associated to this pull request.
      */
     public PagedIterable<GHPullRequestReview> listReviews() {
-        return new PagedIterable<GHPullRequestReview>() {
-            public PagedIterator<GHPullRequestReview> _iterator(int pageSize) {
-                return new PagedIterator<GHPullRequestReview>(root.retrieve()
-                        .asIterator(String.format("%s/reviews", getApiRoute()),
-                        GHPullRequestReview[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHPullRequestReview[] page) {
-                        for (GHPullRequestReview r: page) {
-                            r.wrapUp(GHPullRequest.this);
-                        }
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("%s/reviews", getApiRoute()),
+                GHPullRequestReview[].class,
+                item -> item.wrapUp(GHPullRequest.this));
     }
 
     /**
      * Obtains all the review comments associated with this pull request.
      */
     public PagedIterable<GHPullRequestReviewComment> listReviewComments() throws IOException {
-        return new PagedIterable<GHPullRequestReviewComment>() {
-            public PagedIterator<GHPullRequestReviewComment> _iterator(int pageSize) {
-                return new PagedIterator<GHPullRequestReviewComment>(root.retrieve().asIterator(getApiRoute() + COMMENTS_ACTION,
-                        GHPullRequestReviewComment[].class, pageSize)) {
-                    protected void wrapUp(GHPullRequestReviewComment[] page) {
-                        for (GHPullRequestReviewComment c : page)
-                            c.wrapUp(GHPullRequest.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiRoute() + COMMENTS_ACTION,
+                        GHPullRequestReviewComment[].class,
+                        item -> item.wrapUp(GHPullRequest.this) );
     }
 
     /**
      * Retrieves all the commits associated to this pull request.
      */
     public PagedIterable<GHPullRequestCommitDetail> listCommits() {
-        return new PagedIterable<GHPullRequestCommitDetail>() {
-            public PagedIterator<GHPullRequestCommitDetail> _iterator(int pageSize) {
-                return new PagedIterator<GHPullRequestCommitDetail>(root.retrieve().asIterator(
+        return root.retrieve()
+            .asPagedIterable(
                         String.format("%s/commits", getApiRoute()),
-                        GHPullRequestCommitDetail[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHPullRequestCommitDetail[] page) {
-                        for (GHPullRequestCommitDetail c : page)
-                            c.wrapUp(GHPullRequest.this);
-                    }
-                };
-            }
-        };
+                        GHPullRequestCommitDetail[].class,
+                        item -> item.wrapUp(GHPullRequest.this) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
@@ -46,16 +46,9 @@ public class GHPullRequestQueryBuilder extends GHQueryBuilder<GHPullRequest> {
 
     @Override
     public PagedIterable<GHPullRequest> list() {
-        return new PagedIterable<GHPullRequest>() {
-            public PagedIterator<GHPullRequest> _iterator(int pageSize) {
-                return new PagedIterator<GHPullRequest>(req.asIterator(repo.getApiTailUrl("pulls"), GHPullRequest[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHPullRequest[] page) {
-                        for (GHPullRequest pr : page)
-                            pr.wrapUp(repo);
-                    }
-                };
-            }
-        };
+        return req.asPagedIterable(
+            repo.getApiTailUrl("pulls"),
+            GHPullRequest[].class,
+            item -> item.wrapUp(repo) );
     }
 }

--- a/src/main/java/org/kohsuke/github/GHPullRequestReview.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReview.java
@@ -148,18 +148,10 @@ public class GHPullRequestReview extends GHObject {
      * Obtains all the review comments associated with this pull request review.
      */
     public PagedIterable<GHPullRequestReviewComment> listReviewComments() throws IOException {
-        return new PagedIterable<GHPullRequestReviewComment>() {
-            public PagedIterator<GHPullRequestReviewComment> _iterator(int pageSize) {
-                return new PagedIterator<GHPullRequestReviewComment>(
-                        owner.root.retrieve()
-                                .asIterator(getApiRoute() + "/comments",
-                                GHPullRequestReviewComment[].class, pageSize)) {
-                    protected void wrapUp(GHPullRequestReviewComment[] page) {
-                        for (GHPullRequestReviewComment c : page)
-                            c.wrapUp(owner);
-                    }
-                };
-            }
-        };
+        return owner.root.retrieve()
+            .asPagedIterable(
+                getApiRoute() + "/comments",
+                GHPullRequestReviewComment[].class,
+                item -> item.wrapUp(owner) );
     }
 }

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
@@ -148,16 +148,11 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return new PagedIterable<GHReaction>() {
-            public PagedIterator<GHReaction> _iterator(int pageSize) {
-                return new PagedIterator<GHReaction>(owner.root.retrieve().withPreview(SQUIRREL_GIRL).asIterator(getApiRoute() + "/reactions", GHReaction[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHReaction[] page) {
-                        for (GHReaction c : page)
-                            c.wrap(owner.root);
-                    }
-                };
-            }
-        };
+        return owner.root.retrieve()
+            .withPreview(SQUIRREL_GIRL)
+            .asPagedIterable(
+                getApiRoute() + "/reactions",
+                GHReaction[].class,
+                item -> item.wrap(owner.root) );
     }
 }

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1701,17 +1701,10 @@ public class GHRepository extends GHObject {
      * See https://developer.github.com/v3/issues/events/#list-events-for-a-repository
      */
     public PagedIterable<GHIssueEvent> listIssueEvents() throws IOException {
-        return new PagedIterable<GHIssueEvent>() {
-            public PagedIterator<GHIssueEvent> _iterator(int pageSize) {
-                return new PagedIterator<GHIssueEvent>(root.retrieve().asIterator(getApiTailUrl("issues/events"), GHIssueEvent[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHIssueEvent[] page) {
-                        for (GHIssueEvent c : page)
-                            c.wrapUp(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve().asPagedIterable(
+            getApiTailUrl("issues/events"),
+            GHIssueEvent[].class,
+            item -> item.wrapUp(root) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -118,17 +118,11 @@ public class GHRepository extends GHObject {
     public PagedIterable<GHDeployment> listDeployments(String sha,String ref,String task,String environment){
         List<String> params = Arrays.asList(getParam("sha", sha), getParam("ref", ref), getParam("task", task), getParam("environment", environment));
         final String deploymentsUrl = getApiTailUrl("deployments") + "?"+ join(params,"&");
-        return new PagedIterable<GHDeployment>() {
-            public PagedIterator<GHDeployment> _iterator(int pageSize) {
-                return new PagedIterator<GHDeployment>(root.retrieve().asIterator(deploymentsUrl, GHDeployment[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHDeployment[] page) {
-                        for (GHDeployment c : page)
-                            c.wrap(GHRepository.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                deploymentsUrl,
+                GHDeployment[].class,
+                item -> item.wrap(GHRepository.this) );
     }
 
     /**
@@ -284,17 +278,11 @@ public class GHRepository extends GHObject {
      * Lists up all the issues in this repository.
      */
     public PagedIterable<GHIssue> listIssues(final GHIssueState state) {
-        return new PagedIterable<GHIssue>() {
-            public PagedIterator<GHIssue> _iterator(int pageSize) {
-                return new PagedIterator<GHIssue>(root.retrieve().with("state",state).asIterator(getApiTailUrl("issues"), GHIssue[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHIssue[] page) {
-                        for (GHIssue c : page)
-                            c.wrap(GHRepository.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve().with("state",state)
+            .asPagedIterable(
+                getApiTailUrl("issues"),
+                GHIssue[].class,
+                item -> item.wrap(GHRepository.this) );
     }
 
     public GHReleaseBuilder createRelease(String tag) {
@@ -348,31 +336,19 @@ public class GHRepository extends GHObject {
     }
 
     public PagedIterable<GHRelease> listReleases() throws IOException {
-        return new PagedIterable<GHRelease>() {
-            public PagedIterator<GHRelease> _iterator(int pageSize) {
-                return new PagedIterator<GHRelease>(root.retrieve().asIterator(getApiTailUrl("releases"), GHRelease[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHRelease[] page) {
-                        for (GHRelease c : page)
-                            c.wrap(GHRepository.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiTailUrl("releases"),
+                GHRelease[].class,
+                item -> item.wrap(GHRepository.this) );
     }
 
     public PagedIterable<GHTag> listTags() throws IOException {
-        return new PagedIterable<GHTag>() {
-            public PagedIterator<GHTag> _iterator(int pageSize) {
-                return new PagedIterator<GHTag>(root.retrieve().asIterator(getApiTailUrl("tags"), GHTag[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHTag[] page) {
-                        for (GHTag c : page)
-                            c.wrap(GHRepository.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiTailUrl("tags"),
+                GHTag[].class,
+                item -> item.wrap(GHRepository.this) );
     }
 
     /**
@@ -714,18 +690,11 @@ public class GHRepository extends GHObject {
      * currently {@link ForkSort#NEWEST ForkSort.NEWEST}.
      */
     public PagedIterable<GHRepository> listForks(final ForkSort sort) {
-        return new PagedIterable<GHRepository>() {
-            public PagedIterator<GHRepository> _iterator(int pageSize) {
-                return new PagedIterator<GHRepository>(root.retrieve().with("sort",sort).asIterator(getApiTailUrl("forks"), GHRepository[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHRepository[] page) {
-                        for (GHRepository c : page) {
-                            c.wrap(root);
-                        }
-                    }
-                };
-            }
-        };
+        return root.retrieve().with("sort",sort)
+            .asPagedIterable(
+                getApiTailUrl("forks"),
+                GHRepository[].class,
+                item -> item.wrap(root) );
     }
 
     /**
@@ -920,17 +889,11 @@ public class GHRepository extends GHObject {
      */
     public PagedIterable<GHRef> listRefs() throws IOException {
         final String url = String.format("/repos/%s/%s/git/refs", getOwnerName(), name);
-        return new PagedIterable<GHRef>() {
-            public PagedIterator<GHRef> _iterator(int pageSize) {
-                return new PagedIterator<GHRef>(root.retrieve().asIterator(url, GHRef[].class, pageSize)) {
-                    protected void wrapUp(GHRef[] page) {
-                        for(GHRef p: page) {
-                            p.wrap(root);
-                        }
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                url,
+                GHRef[].class,
+                item -> item.wrap(root) );
     }
 
     /**
@@ -952,15 +915,11 @@ public class GHRepository extends GHObject {
      */
     public PagedIterable<GHRef> listRefs(String refType) throws IOException {
         final String url = String.format("/repos/%s/%s/git/refs/%s", getOwnerName(), name, refType);
-        return new PagedIterable<GHRef>() {
-            public PagedIterator<GHRef> _iterator(int pageSize) {
-                return new PagedIterator<GHRef>(root.retrieve().asIterator(url, GHRef[].class, pageSize)) {
-                    protected void wrapUp(GHRef[] page) {
-                        // no-op
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                url,
+                GHRef[].class,
+                item -> item.wrap(root));
     }
 
     /**
@@ -991,7 +950,7 @@ public class GHRepository extends GHObject {
     public GHTagObject getTagObject(String sha) throws IOException {
         return root.retrieve().to(getApiTailUrl("git/tags/" + sha), GHTagObject.class).wrap(this);
     }
-    
+
     /**
      * Retrive a tree of the given type for the current GitHub repository.
      *
@@ -1074,16 +1033,11 @@ public class GHRepository extends GHObject {
      * Lists all the commits.
      */
     public PagedIterable<GHCommit> listCommits() {
-        return new PagedIterable<GHCommit>() {
-            public PagedIterator<GHCommit> _iterator(int pageSize) {
-                return new PagedIterator<GHCommit>(root.retrieve().asIterator(String.format("/repos/%s/%s/commits", getOwnerName(), name), GHCommit[].class, pageSize)) {
-                    protected void wrapUp(GHCommit[] page) {
-                        for (GHCommit c : page)
-                            c.wrapUp(GHRepository.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/repos/%s/%s/commits", getOwnerName(), name),
+                GHCommit[].class,
+                item -> item.wrapUp(GHRepository.this) );
     }
 
     /**
@@ -1097,17 +1051,11 @@ public class GHRepository extends GHObject {
      * Lists up all the commit comments in this repository.
      */
     public PagedIterable<GHCommitComment> listCommitComments() {
-        return new PagedIterable<GHCommitComment>() {
-            public PagedIterator<GHCommitComment> _iterator(int pageSize) {
-                return new PagedIterator<GHCommitComment>(root.retrieve().asIterator(String.format("/repos/%s/%s/comments", getOwnerName(), name), GHCommitComment[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHCommitComment[] page) {
-                        for (GHCommitComment c : page)
-                            c.wrap(GHRepository.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/repos/%s/%s/comments", getOwnerName(), name),
+                GHCommitComment[].class,
+                item -> item.wrap(GHRepository.this) );
     }
 
     /**
@@ -1148,17 +1096,11 @@ public class GHRepository extends GHObject {
      * Lists all the commit statues attached to the given commit, newer ones first.
      */
     public PagedIterable<GHCommitStatus> listCommitStatuses(final String sha1) throws IOException {
-        return new PagedIterable<GHCommitStatus>() {
-            public PagedIterator<GHCommitStatus> _iterator(int pageSize) {
-                return new PagedIterator<GHCommitStatus>(root.retrieve().asIterator(String.format("/repos/%s/%s/statuses/%s", getOwnerName(), name, sha1), GHCommitStatus[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHCommitStatus[] page) {
-                        for (GHCommitStatus c : page)
-                            c.wrapUp(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/repos/%s/%s/statuses/%s", getOwnerName(), name, sha1),
+                GHCommitStatus[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**
@@ -1199,17 +1141,11 @@ public class GHRepository extends GHObject {
      * Lists repository events.
      */
     public PagedIterable<GHEventInfo> listEvents() throws IOException {
-        return new PagedIterable<GHEventInfo>() {
-            public PagedIterator<GHEventInfo> _iterator(int pageSize) {
-                return new PagedIterator<GHEventInfo>(root.retrieve().asIterator(String.format("/repos/%s/%s/events", getOwnerName(), name), GHEventInfo[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHEventInfo[] page) {
-                        for (GHEventInfo c : page)
-                            c.wrapUp(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/repos/%s/%s/events", getOwnerName(), name),
+                GHEventInfo[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**
@@ -1218,19 +1154,12 @@ public class GHRepository extends GHObject {
      * https://developer.github.com/v3/issues/labels/#list-all-labels-for-this-repository
      */
     public PagedIterable<GHLabel> listLabels() throws IOException {
-        return new PagedIterable<GHLabel>() {
-            public PagedIterator<GHLabel> _iterator(int pageSize) {
-                return new PagedIterator<GHLabel>(root.retrieve()
+        return root.retrieve()
                     .withPreview(SYMMETRA)
-                    .asIterator(getApiTailUrl("labels"), GHLabel[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHLabel[] page) {
-                        for (GHLabel c : page)
-                            c.wrapUp(GHRepository.this);
-                    }
-                };
-            }
-        };
+                    .asPagedIterable(
+                        getApiTailUrl("labels"),
+                        GHLabel[].class,
+                        item -> item.wrapUp(GHRepository.this) );
     }
 
     public GHLabel getLabel(String name) throws IOException {
@@ -1266,16 +1195,11 @@ public class GHRepository extends GHObject {
      * Lists all the invitations.
      */
     public PagedIterable<GHInvitation> listInvitations() {
-        return new PagedIterable<GHInvitation>() {
-            public PagedIterator<GHInvitation> _iterator(int pageSize) {
-                return new PagedIterator<GHInvitation>(root.retrieve().asIterator(String.format("/repos/%s/%s/invitations", getOwnerName(), name), GHInvitation[].class, pageSize)) {
-                    protected void wrapUp(GHInvitation[] page) {
-                        for (GHInvitation c : page)
-                            c.wrapUp(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/repos/%s/%s/invitations", getOwnerName(), name),
+                GHInvitation[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**
@@ -1301,34 +1225,20 @@ public class GHRepository extends GHObject {
      * see {@link #listStargazers()}
      */
     public PagedIterable<GHStargazer> listStargazers2() {
-        return new PagedIterable<GHStargazer>() {
-            @Override
-            public PagedIterator<GHStargazer> _iterator(int pageSize) {
-                Requester requester = root.retrieve();
-                requester.setHeader("Accept", "application/vnd.github.v3.star+json");
-                return new PagedIterator<GHStargazer>(requester.asIterator(getApiTailUrl("stargazers"), GHStargazer[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHStargazer[] page) {
-                        for (GHStargazer c : page) {
-                            c.wrapUp(GHRepository.this);
-                        }
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+                    .withPreview("application/vnd.github.v3.star+json")
+                    .asPagedIterable(
+                        getApiTailUrl("stargazers"),
+                        GHStargazer[].class,
+                        item -> item.wrapUp(GHRepository.this) );
     }
 
     private PagedIterable<GHUser> listUsers(final String suffix) {
-        return new PagedIterable<GHUser>() {
-            public PagedIterator<GHUser> _iterator(int pageSize) {
-                return new PagedIterator<GHUser>(root.retrieve().asIterator(getApiTailUrl(suffix), GHUser[].class, pageSize)) {
-                    protected void wrapUp(GHUser[] page) {
-                        for (GHUser c : page)
-                            c.wrapUp(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiTailUrl(suffix),
+                GHUser[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**
@@ -1491,17 +1401,11 @@ public class GHRepository extends GHObject {
      * Lists up all the milestones in this repository.
      */
     public PagedIterable<GHMilestone> listMilestones(final GHIssueState state) {
-        return new PagedIterable<GHMilestone>() {
-            public PagedIterator<GHMilestone> _iterator(int pageSize) {
-                return new PagedIterator<GHMilestone>(root.retrieve().with("state",state).asIterator(getApiTailUrl("milestones"), GHMilestone[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHMilestone[] page) {
-                        for (GHMilestone c : page)
-                            c.wrap(GHRepository.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve().with("state",state)
+            .asPagedIterable(
+                getApiTailUrl("milestones"),
+                GHMilestone[].class,
+                item -> item.wrap(GHRepository.this) );
     }
 
     public GHMilestone getMilestone(int number) throws IOException {
@@ -1666,17 +1570,11 @@ public class GHRepository extends GHObject {
     }
 
     public PagedIterable<Contributor> listContributors() throws IOException {
-        return new PagedIterable<Contributor>() {
-            public PagedIterator<Contributor> _iterator(int pageSize) {
-                return new PagedIterator<Contributor>(root.retrieve().asIterator(getApiTailUrl("contributors"), Contributor[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(Contributor[] page) {
-                        for (Contributor c : page)
-                            c.wrapUp(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiTailUrl("contributors"),
+                Contributor[].class,
+                item -> item.wrapUp(root) );
     }
 
     public static class Contributor extends GHUser {
@@ -1724,19 +1622,12 @@ public class GHRepository extends GHObject {
      * @param status The status filter (all, open or closed).
      */
     public PagedIterable<GHProject> listProjects(final GHProject.ProjectStateFilter status) throws IOException {
-         return new PagedIterable<GHProject>() {
-            public PagedIterator<GHProject> _iterator(int pageSize) {
-                return new PagedIterator<GHProject>(root.retrieve().withPreview(INERTIA)
+         return root.retrieve().withPreview(INERTIA)
                         .with("state", status)
-                        .asIterator(getApiTailUrl("projects"), GHProject[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHProject[] page) {
-                        for (GHProject c : page)
-                            c.wrap(GHRepository.this);
-                    }
-                };
-            }
-        };
+                        .asPagedIterable(
+                            getApiTailUrl("projects"),
+                            GHProject[].class,
+                            item -> item.wrap(GHRepository.this) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
@@ -68,19 +68,11 @@ public class GHRepositoryStatistics {
      * are still being cached.
      */
     private PagedIterable<ContributorStats> getContributorStatsImpl() throws IOException {
-        return new PagedIterable<ContributorStats>() {
-            @Override
-            public PagedIterator<ContributorStats> _iterator(int pageSize) {
-                return new PagedIterator<ContributorStats>(root.retrieve().asIterator(getApiTailUrl("contributors"), ContributorStats[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(ContributorStats[] page) {
-                        for (ContributorStats c : page) {
-                            c.wrapUp(root);
-                        }
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiTailUrl("contributors"),
+                ContributorStats[].class,
+                item -> item.wrapUp(root) );
     }
 
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
@@ -202,18 +194,11 @@ public class GHRepositoryStatistics {
      * https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data
      */
     public PagedIterable<CommitActivity> getCommitActivity() throws IOException {
-        return new PagedIterable<CommitActivity>() {
-            public PagedIterator<CommitActivity> _iterator(int pageSize) {
-                return new PagedIterator<CommitActivity>(root.retrieve().asIterator(getApiTailUrl("commit_activity"), CommitActivity[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(CommitActivity[] page) {
-                        for (CommitActivity c : page) {
-                            c.wrapUp(root);
-                        }
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiTailUrl("commit_activity"),
+                CommitActivity[].class,
+                item -> item.wrapUp(root) );
     }
 
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -85,16 +85,11 @@ public class GHTeam implements Refreshable {
      * Retrieves the current members.
      */
     public PagedIterable<GHUser> listMembers() throws IOException {
-        return new PagedIterable<GHUser>() {
-            public PagedIterator<GHUser> _iterator(int pageSize) {
-                return new PagedIterator<GHUser>(root.retrieve().asIterator(api("/members"), GHUser[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHUser[] page) {
-                        GHUser.wrap(page, root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                api("/members"),
+                GHUser[].class,
+                item -> item.wrapUp(root) );
     }
 
     public Set<GHUser> getMembers() throws IOException {
@@ -122,17 +117,11 @@ public class GHTeam implements Refreshable {
     }
 
     public PagedIterable<GHRepository> listRepositories() {
-        return new PagedIterable<GHRepository>() {
-            public PagedIterator<GHRepository> _iterator(int pageSize) {
-                return new PagedIterator<GHRepository>(root.retrieve().asIterator(api("/repos"), GHRepository[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHRepository[] page) {
-                        for (GHRepository r : page)
-                            r.wrap(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                api("/repos"),
+                GHRepository[].class,
+                item -> item.wrap(root) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -84,15 +84,11 @@ public class GHUser extends GHPerson {
     }
 
     private PagedIterable<GHUser> listUser(final String suffix) {
-        return new PagedIterable<GHUser>() {
-            public PagedIterator<GHUser> _iterator(int pageSize) {
-                return new PagedIterator<GHUser>(root.retrieve().asIterator(getApiTailUrl(suffix), GHUser[].class, pageSize)) {
-                    protected void wrapUp(GHUser[] page) {
-                        GHUser.wrap(page,root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiTailUrl(suffix),
+                GHUser[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**
@@ -112,16 +108,11 @@ public class GHUser extends GHPerson {
     }
 
     private PagedIterable<GHRepository> listRepositories(final String suffix) {
-        return new PagedIterable<GHRepository>() {
-            public PagedIterator<GHRepository> _iterator(int pageSize) {
-                return new PagedIterator<GHRepository>(root.retrieve().asIterator(getApiTailUrl(suffix), GHRepository[].class, pageSize)) {
-                    protected void wrapUp(GHRepository[] page) {
-                        for (GHRepository c : page)
-                            c.wrap(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                getApiTailUrl(suffix),
+                GHRepository[].class,
+                item -> item.wrap(root) );
     }
 
     /**
@@ -169,34 +160,22 @@ public class GHUser extends GHPerson {
      * Lists events performed by a user (this includes private events if the caller is authenticated.
      */
     public PagedIterable<GHEventInfo> listEvents() throws IOException {
-        return new PagedIterable<GHEventInfo>() {
-            public PagedIterator<GHEventInfo> _iterator(int pageSize) {
-                return new PagedIterator<GHEventInfo>(root.retrieve().asIterator(String.format("/users/%s/events", login), GHEventInfo[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHEventInfo[] page) {
-                        for (GHEventInfo c : page)
-                            c.wrapUp(root);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/users/%s/events", login),
+                GHEventInfo[].class,
+                item -> item.wrapUp(root) );
     }
 
     /**
      * Lists Gists created by this user.
      */
     public PagedIterable<GHGist> listGists() throws IOException {
-        return new PagedIterable<GHGist>() {
-            public PagedIterator<GHGist> _iterator(int pageSize) {
-                return new PagedIterator<GHGist>(root.retrieve().asIterator(String.format("/users/%s/gists", login), GHGist[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHGist[] page) {
-                        for (GHGist c : page)
-                            c.wrapUp(GHUser.this);
-                    }
-                };
-            }
-        };
+        return root.retrieve()
+            .asPagedIterable(
+                String.format("/users/%s/gists", login),
+                GHGist[].class,
+                item -> item.wrapUp(GHUser.this) );
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -683,17 +683,11 @@ public class GitHub {
      * @see <a href="https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations">List your authorizations</a>
      */
     public PagedIterable<GHAuthorization> listMyAuthorizations() throws IOException {
-        return new PagedIterable<GHAuthorization>() {
-            public PagedIterator<GHAuthorization> _iterator(int pageSize) {
-                return new PagedIterator<GHAuthorization>(retrieve().asIterator("/authorizations", GHAuthorization[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHAuthorization[] page) {
-                        for (GHAuthorization u : page)
-                            u.wrap(GitHub.this);
-                    }
-                };
-            }
-        };
+        return retrieve()
+            .asPagedIterable(
+                "/authorizations",
+                GHAuthorization[].class,
+                item -> item.wrap(GitHub.this) );
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -447,19 +447,12 @@ public class GitHub {
      * @see <a href="https://developer.github.com/v3/orgs/#parameters">List All Orgs - Parameters</a>
      */
     public PagedIterable<GHOrganization> listOrganizations(final String since) {
-        return new PagedIterable<GHOrganization>() {
-            @Override
-            public PagedIterator<GHOrganization> _iterator(int pageSize) {
-                return new PagedIterator<GHOrganization>(retrieve().with("since",since)
-                        .asIterator("/organizations", GHOrganization[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHOrganization[] page) {
-                        for (GHOrganization c : page)
-                            c.wrapUp(GitHub.this);
-                    }
-                };
-            }
-        };
+        return retrieve()
+            .with("since",since)
+            .asPagedIterable(
+                "/organizations",
+                GHOrganization[].class,
+                item -> item.wrapUp(GitHub.this) );
     }
 
     /**
@@ -487,34 +480,22 @@ public class GitHub {
      * @return a list of popular open source licenses
      */
     public PagedIterable<GHLicense> listLicenses() throws IOException {
-        return new PagedIterable<GHLicense>() {
-            public PagedIterator<GHLicense> _iterator(int pageSize) {
-                return new PagedIterator<GHLicense>(retrieve().asIterator("/licenses", GHLicense[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHLicense[] page) {
-                        for (GHLicense c : page)
-                            c.wrap(GitHub.this);
-                    }
-                };
-            }
-        };
+        return retrieve()
+            .asPagedIterable(
+                "/licenses",
+                GHLicense[].class,
+                item -> item.wrap(GitHub.this) );
     }
 
     /**
      * Returns a list of all users.
      */
     public PagedIterable<GHUser> listUsers() throws IOException {
-        return new PagedIterable<GHUser>() {
-            public PagedIterator<GHUser> _iterator(int pageSize) {
-                return new PagedIterator<GHUser>(retrieve().asIterator("/users", GHUser[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHUser[] page) {
-                        for (GHUser u : page)
-                            u.wrapUp(GitHub.this);
-                    }
-                };
-            }
-        };
+        return retrieve()
+            .asPagedIterable(
+                "/users",
+                GHUser[].class,
+                item -> item.wrapUp(GitHub.this) );
     }
 
     /**
@@ -902,17 +883,11 @@ public class GitHub {
      * @see <a href="https://developer.github.com/v3/repos/#list-all-public-repositories">documentation</a>
      */
     public PagedIterable<GHRepository> listAllPublicRepositories(final String since) {
-        return new PagedIterable<GHRepository>() {
-            public PagedIterator<GHRepository> _iterator(int pageSize) {
-                return new PagedIterator<GHRepository>(retrieve().with("since",since).asIterator("/repositories", GHRepository[].class, pageSize)) {
-                    @Override
-                    protected void wrapUp(GHRepository[] page) {
-                        for (GHRepository c : page)
-                            c.wrap(GitHub.this);
-                    }
-                };
-            }
-        };
+        return retrieve().with("since",since)
+            .asPagedIterable(
+                "/repositories",
+                GHRepository[].class,
+                item -> item.wrap(GitHub.this) );
     }
 
     /**


### PR DESCRIPTION
This change eliminates a whole bunch of cruft from the creation of PagedIterables. Dependent on Java 8+ closures. 