### PR TITLE
bump jackson-databind to 2.10.0 to avoid security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10</version>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-472980

detected at https://app.snyk.io/org/checkstyle/project/6464a1a8-78eb-4b93-aa92-c6889786636a?utm_campaign=vuln_alert&utm_medium=email&utm_source=Project&fromGitHubAuth=true