### PR TITLE
Make low-level requester available to public

### DIFF
--- a/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
@@ -22,7 +22,7 @@ public class GHAppCreateTokenBuilder {
     /*package*/ GHAppCreateTokenBuilder(GitHub root, String apiUrlTail, Map<String, GHPermissionType> permissions) {
         this.root = root;
         this.apiUrlTail = apiUrlTail;
-        this.builder = new Requester(root);
+        this.builder = root.createRequester();
         this.builder.withPermissions("permissions",permissions);
     }
 

--- a/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
@@ -1,6 +1,7 @@
 package org.kohsuke.github;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -23,7 +24,7 @@ public class GHAppCreateTokenBuilder {
         this.root = root;
         this.apiUrlTail = apiUrlTail;
         this.builder = root.createRequester();
-        this.builder.withPermissions("permissions",permissions);
+        withPermissions(builder, permissions);
     }
 
     /**
@@ -48,6 +49,14 @@ public class GHAppCreateTokenBuilder {
     @Preview @Deprecated
     public GHAppInstallationToken create() throws IOException {
         return builder.method("POST").withPreview(MACHINE_MAN).to(apiUrlTail, GHAppInstallationToken.class).wrapUp(root);
+    }
+
+    private static Requester withPermissions(Requester builder, Map<String, GHPermissionType> value) {
+        Map<String,String> retMap = new HashMap<String, String>();
+        for (Map.Entry<String, GHPermissionType> entry : value.entrySet()) {
+            retMap.put(entry.getKey(), Requester.transformEnum(entry.getValue()));
+        }
+        return builder.with("permissions", retMap);
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHAsset.java
+++ b/src/main/java/org/kohsuke/github/GHAsset.java
@@ -74,7 +74,7 @@ public class GHAsset extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        root.createRequester()._with(key, value).method("PATCH").to(getApiRoute());
+        root.createRequester().with(key, value).method("PATCH").to(getApiRoute());
     }
 
     public void delete() throws IOException {

--- a/src/main/java/org/kohsuke/github/GHAsset.java
+++ b/src/main/java/org/kohsuke/github/GHAsset.java
@@ -74,11 +74,11 @@ public class GHAsset extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(root)._with(key, value).method("PATCH").to(getApiRoute());
+        root.createRequester()._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").to(getApiRoute());
+        root.createRequester().method("DELETE").to(getApiRoute());
     }
 
 

--- a/src/main/java/org/kohsuke/github/GHBlobBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHBlobBuilder.java
@@ -14,7 +14,7 @@ public class GHBlobBuilder {
 
     GHBlobBuilder(GHRepository repo) {
         this.repo = repo;
-        req = new Requester(repo.root);
+        req = repo.root.createRequester();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHBranch.java
+++ b/src/main/java/org/kohsuke/github/GHBranch.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;
 
-import static org.kohsuke.github.Previews.*;
-
 /**
  * A branch in a repository.
  *
@@ -80,7 +78,7 @@ public class GHBranch {
      * Disables branch protection and allows anyone with push access to push changes.
      */
     public void disableProtection() throws IOException {
-        new Requester(root).method("DELETE").to(protection_url);
+        root.createRequester().method("DELETE").to(protection_url);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHBranchProtection.java
+++ b/src/main/java/org/kohsuke/github/GHBranchProtection.java
@@ -74,7 +74,7 @@ public class GHBranchProtection {
     }
 
     private Requester requester() {
-        return new Requester(root).withPreview(ZZZAX);
+        return root.createRequester().withPreview(ZZZAX);
     }
 
     public static class EnforceAdmins {

--- a/src/main/java/org/kohsuke/github/GHBranchProtectionBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHBranchProtectionBuilder.java
@@ -203,7 +203,7 @@ public class GHBranchProtectionBuilder {
     }
 
     private Requester requester() {
-        return new Requester(branch.getRoot()).withPreview(LUKE_CAGE);
+        return branch.getRoot().createRequester().withPreview(LUKE_CAGE);
     }
 
     private static class Restrictions {

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -340,8 +340,8 @@ public class GHCommit {
      * I'm not sure how path/line/position parameters interact with each other.
      */
     public GHCommitComment createComment(String body, String path, Integer line, Integer position) throws IOException {
-        GHCommitComment r = new Requester(owner.root)
-                .with("body",body)
+        GHCommitComment r = owner.root.createRequester()
+            .with("body",body)
                 .with("path",path)
                 .with("line",line)
                 .with("position",position)

--- a/src/main/java/org/kohsuke/github/GHCommitBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitBuilder.java
@@ -66,7 +66,7 @@ public class GHCommitBuilder {
      * Configures the author of this commit.
      */
     public GHCommitBuilder author(String name, String email, Date date) {
-        req._with("author", new UserInfo(name, email, date));
+        req.with("author", new UserInfo(name, email, date));
         return this;
     }
 
@@ -74,7 +74,7 @@ public class GHCommitBuilder {
      * Configures the committer of this commit.
      */
     public GHCommitBuilder committer(String name, String email, Date date) {
-        req._with("committer", new UserInfo(name, email, date));
+        req.with("committer", new UserInfo(name, email, date));
         return this;
     }
 
@@ -86,7 +86,7 @@ public class GHCommitBuilder {
      * Creates a blob based on the parameters specified thus far.
      */
     public GHCommit create() throws IOException {
-        req._with("parents", parents);
+        req.with("parents", parents);
         return req.method("POST").to(getApiTail(), GHCommit.class).wrapUp(repo);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHCommitBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitBuilder.java
@@ -35,7 +35,7 @@ public class GHCommitBuilder {
 
     GHCommitBuilder(GHRepository repo) {
         this.repo = repo;
-        req = new Requester(repo.root);
+        req = repo.root.createRequester();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCommitComment.java
+++ b/src/main/java/org/kohsuke/github/GHCommitComment.java
@@ -82,16 +82,16 @@ public class GHCommitComment extends GHObject implements Reactable {
      * Updates the body of the commit message.
      */
     public void update(String body) throws IOException {
-        new Requester(owner.root)
-                .with("body", body)
+        owner.root.createRequester()
+            .with("body", body)
                 .method("PATCH").to(getApiTail(), GHCommitComment.class);
         this.body = body;
     }
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.root)
-                .withPreview(SQUIRREL_GIRL)
+        return owner.root.createRequester()
+            .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
                 .to(getApiTail()+"/reactions", GHReaction.class).wrap(owner.root);
     }
@@ -109,7 +109,7 @@ public class GHCommitComment extends GHObject implements Reactable {
      * Deletes this comment.
      */
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE").to(getApiTail());
+        owner.root.createRequester().method("DELETE").to(getApiTail());
     }
 
     private String getApiTail() {

--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -184,7 +184,7 @@ public class GHContent implements Refreshable {
     public GHContentUpdateResponse update(byte[] newContentBytes, String commitMessage, String branch) throws IOException {
         String encodedContent = Base64.encodeBase64String(newContentBytes);
 
-        Requester requester = new Requester(root)
+        Requester requester = root.createRequester()
             .with("path", path)
             .with("message", commitMessage)
             .with("sha", sha)
@@ -209,7 +209,7 @@ public class GHContent implements Refreshable {
     }
 
     public GHContentUpdateResponse delete(String commitMessage, String branch) throws IOException {
-        Requester requester = new Requester(root)
+        Requester requester = root.createRequester()
             .with("path", path)
             .with("message", commitMessage)
             .with("sha", sha)

--- a/src/main/java/org/kohsuke/github/GHContentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHContentBuilder.java
@@ -21,7 +21,7 @@ public final class GHContentBuilder {
 
     GHContentBuilder(GHRepository repo) {
         this.repo = repo;
-        this.req = new Requester(repo.root).method("PUT");
+        this.req = repo.root.createRequester().method("PUT");
     }
 
     public GHContentBuilder path(String path) {

--- a/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
@@ -16,7 +16,7 @@ public class GHCreateRepositoryBuilder {
     /*package*/ GHCreateRepositoryBuilder(GitHub root, String apiUrlTail, String name) {
         this.root = root;
         this.apiUrlTail = apiUrlTail;
-        this.builder = new Requester(root);
+        this.builder = root.createRequester();
         this.builder.with("name",name);
     }
 

--- a/src/main/java/org/kohsuke/github/GHDeployKey.java
+++ b/src/main/java/org/kohsuke/github/GHDeployKey.java
@@ -41,6 +41,6 @@ public class GHDeployKey {
     }
     
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE").to(String.format("/repos/%s/%s/keys/%d", owner.getOwnerName(), owner.getName(), id));
+        owner.root.createRequester().method("DELETE").to(String.format("/repos/%s/%s/keys/%d", owner.getOwnerName(), owner.getName(), id));
     }
 }

--- a/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
@@ -10,7 +10,7 @@ public class GHDeploymentBuilder {
 
     public GHDeploymentBuilder(GHRepository repo) {
         this.repo = repo;
-        this.builder = new Requester(repo.root);
+        this.builder = repo.root.createRequester();
     }
 
     public GHDeploymentBuilder(GHRepository repo, String ref) {

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
@@ -24,7 +24,7 @@ public class GHDeploymentStatusBuilder {
     /*package*/ GHDeploymentStatusBuilder(GHRepository repo, long deploymentId, GHDeploymentState state) {
         this.repo = repo;
         this.deploymentId = deploymentId;
-        this.builder = new Requester(repo.root);
+        this.builder = repo.root.createRequester();
         this.builder.with("state",state);
     }
 

--- a/src/main/java/org/kohsuke/github/GHGist.java
+++ b/src/main/java/org/kohsuke/github/GHGist.java
@@ -126,11 +126,11 @@ public class GHGist extends GHObject {
     }
 
     public void star() throws IOException {
-        new Requester(root).method("PUT").to(getApiTailUrl("star"));
+        root.createRequester().method("PUT").to(getApiTailUrl("star"));
     }
 
     public void unstar() throws IOException {
-        new Requester(root).method("DELETE").to(getApiTailUrl("star"));
+        root.createRequester().method("DELETE").to(getApiTailUrl("star"));
     }
 
     public boolean isStarred() throws IOException {
@@ -141,7 +141,7 @@ public class GHGist extends GHObject {
      * Forks this gist into your own.
      */
     public GHGist fork() throws IOException {
-        return new Requester(root).to(getApiTailUrl("forks"),GHGist.class).wrapUp(root);
+        return root.createRequester().to(getApiTailUrl("forks"),GHGist.class).wrapUp(root);
     }
 
     public PagedIterable<GHGist> listForks() {
@@ -156,7 +156,7 @@ public class GHGist extends GHObject {
      * Deletes this gist.
      */
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").to("/gists/" + id);
+        root.createRequester().method("DELETE").to("/gists/" + id);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHGistBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHGistBuilder.java
@@ -42,7 +42,7 @@ public class GHGistBuilder {
      * Creates a Gist based on the parameters specified thus far.
      */
     public GHGist create() throws IOException {
-        req._with("files",files);
+        req.with("files",files);
         return req.to("/gists",GHGist.class).wrapUp(root);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHGistBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHGistBuilder.java
@@ -17,7 +17,7 @@ public class GHGistBuilder {
 
     public GHGistBuilder(GitHub root) {
         this.root = root;
-        req = new Requester(root);
+        req = root.createRequester();
     }
 
     public GHGistBuilder description(String desc) {

--- a/src/main/java/org/kohsuke/github/GHGistUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHGistUpdater.java
@@ -52,7 +52,7 @@ public class GHGistUpdater {
      * Updates the Gist based on the parameters specified thus far.
      */
     public GHGist update() throws IOException {
-        builder._with("files", files);
+        builder.with("files", files);
         return builder
                 .method("PATCH")
                 .to(base.getApiTailUrl(""), GHGist.class).wrap(base.owner);

--- a/src/main/java/org/kohsuke/github/GHGistUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHGistUpdater.java
@@ -16,7 +16,7 @@ public class GHGistUpdater {
 
     GHGistUpdater(GHGist base) {
         this.base = base;
-        this.builder = new Requester(base.root);
+        this.builder = base.root.createRequester();
 
         files = new LinkedHashMap<>();
     }

--- a/src/main/java/org/kohsuke/github/GHHook.java
+++ b/src/main/java/org/kohsuke/github/GHHook.java
@@ -46,14 +46,14 @@ public abstract class GHHook extends GHObject {
      * @see <a href="https://developer.github.com/v3/repos/hooks/#ping-a-hook">Ping hook</a>
      */
     public void ping() throws IOException {
-        new Requester(getRoot()).method("POST").to(getApiRoute() + "/pings");
+        getRoot().createRequester().method("POST").to(getApiRoute() + "/pings");
     }
 
     /**
      * Deletes this hook.
      */
     public void delete() throws IOException {
-        new Requester(getRoot()).method("DELETE").to(getApiRoute());
+        getRoot().createRequester().method("DELETE").to(getApiRoute());
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHHooks.java
+++ b/src/main/java/org/kohsuke/github/GHHooks.java
@@ -41,7 +41,7 @@ class GHHooks {
                 ea.add(e.symbol());
             }
 
-            GHHook hook = new Requester(root)
+            GHHook hook = root.createRequester()
                 .with("name", name)
                 .with("active", active)
                 ._with("config", config)

--- a/src/main/java/org/kohsuke/github/GHHooks.java
+++ b/src/main/java/org/kohsuke/github/GHHooks.java
@@ -44,8 +44,8 @@ class GHHooks {
             GHHook hook = root.createRequester()
                 .with("name", name)
                 .with("active", active)
-                ._with("config", config)
-                ._with("events", ea)
+                .with("config", config)
+                .with("events", ea)
                 .to(collection(), clazz());
 
             return wrap(hook);

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -175,11 +175,11 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     private void edit(String key, Object value) throws IOException {
-        root.createRequester()._with(key, value).method("PATCH").to(getApiRoute());
+        root.createRequester().with(key, value).method("PATCH").to(getApiRoute());
     }
 
     private void editIssue(String key, Object value) throws IOException {
-        root.createRequester()._with(key, value).method("PATCH").to(getIssuesApiRoute());
+        root.createRequester().with(key, value).method("PATCH").to(getIssuesApiRoute());
     }
 
     /**
@@ -319,7 +319,8 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     public void addAssignees(Collection<GHUser> assignees) throws IOException {
-        root.retrieve().method("POST").withLogins(ASSIGNEES,assignees).to(getIssuesApiRoute()+"/assignees",this);
+        List<String> logins = getLogins(assignees);
+        root.retrieve().method("POST").with(ASSIGNEES,logins).to(getIssuesApiRoute()+"/assignees",this);
     }
 
     public void setAssignees(GHUser... assignees) throws IOException {
@@ -327,7 +328,8 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     public void setAssignees(Collection<GHUser> assignees) throws IOException {
-        root.createRequester().withLogins(ASSIGNEES, assignees).method("PATCH").to(getIssuesApiRoute());
+        List<String> logins = getLogins(assignees);
+        root.createRequester().with(ASSIGNEES, logins).method("PATCH").to(getIssuesApiRoute());
     }
 
     public void removeAssignees(GHUser... assignees) throws IOException {
@@ -335,7 +337,16 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     public void removeAssignees(Collection<GHUser> assignees) throws IOException {
-        root.retrieve().method("DELETE").withLogins(ASSIGNEES,assignees).inBody().to(getIssuesApiRoute()+"/assignees",this);
+        List<String> logins = getLogins(assignees);
+        root.retrieve().method("DELETE").with(ASSIGNEES,logins).inBody().to(getIssuesApiRoute()+"/assignees",this);
+    }
+
+    protected static List<String> getLogins(Collection<GHUser> users) {
+        List<String> names = new ArrayList<String>(users.size());
+        for (GHUser a : users) {
+            names.add(a.getLogin());
+        }
+        return names;
     }
 
     protected String getApiRoute() {

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -35,10 +35,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
 
 /**
  * Represents an issue on GitHub.
@@ -157,11 +155,11 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     public void lock() throws IOException {
-        new Requester(root).method("PUT").to(getApiRoute()+"/lock");
+        root.createRequester().method("PUT").to(getApiRoute()+"/lock");
     }
 
     public void unlock() throws IOException {
-        new Requester(root).method("PUT").to(getApiRoute()+"/lock");
+        root.createRequester().method("PUT").to(getApiRoute()+"/lock");
     }
 
     /**
@@ -172,16 +170,16 @@ public class GHIssue extends GHObject implements Reactable{
      */
     @WithBridgeMethods(void.class)
     public GHIssueComment comment(String message) throws IOException {
-        GHIssueComment r = new Requester(root).with("body",message).to(getIssuesApiRoute() + "/comments", GHIssueComment.class);
+        GHIssueComment r = root.createRequester().with("body",message).to(getIssuesApiRoute() + "/comments", GHIssueComment.class);
         return r.wrapUp(this);
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(root)._with(key, value).method("PATCH").to(getApiRoute());
+        root.createRequester()._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     private void editIssue(String key, Object value) throws IOException {
-        new Requester(root)._with(key, value).method("PATCH").to(getIssuesApiRoute());
+        root.createRequester()._with(key, value).method("PATCH").to(getIssuesApiRoute());
     }
 
     /**
@@ -301,8 +299,8 @@ public class GHIssue extends GHObject implements Reactable{
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.root)
-                .withPreview(SQUIRREL_GIRL)
+        return owner.root.createRequester()
+            .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
                 .to(getApiRoute()+"/reactions", GHReaction.class).wrap(root);
     }
@@ -329,7 +327,7 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     public void setAssignees(Collection<GHUser> assignees) throws IOException {
-        new Requester(root).withLogins(ASSIGNEES, assignees).method("PATCH").to(getIssuesApiRoute());
+        root.createRequester().withLogins(ASSIGNEES, assignees).method("PATCH").to(getIssuesApiRoute());
     }
 
     public void removeAssignees(GHUser... assignees) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHIssueBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHIssueBuilder.java
@@ -15,7 +15,7 @@ public class GHIssueBuilder {
 
     GHIssueBuilder(GHRepository repo, String title) {
         this.repo = repo;
-        this.builder = new Requester(repo.root);
+        this.builder = repo.root.createRequester();
         builder.with("title",title);
     }
 

--- a/src/main/java/org/kohsuke/github/GHIssueComment.java
+++ b/src/main/java/org/kohsuke/github/GHIssueComment.java
@@ -88,7 +88,7 @@ public class GHIssueComment extends GHObject implements Reactable {
      * Updates the body of the issue comment.
      */
     public void update(String body) throws IOException {
-        new Requester(owner.root).with("body", body).method("PATCH").to(getApiRoute(), GHIssueComment.class);
+        owner.root.createRequester().with("body", body).method("PATCH").to(getApiRoute(), GHIssueComment.class);
         this.body = body;
     }
 
@@ -96,13 +96,13 @@ public class GHIssueComment extends GHObject implements Reactable {
      * Deletes this issue comment.
      */
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE").to(getApiRoute());
+        owner.root.createRequester().method("DELETE").to(getApiRoute());
     }
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.root)
-                .withPreview(SQUIRREL_GIRL)
+        return owner.root.createRequester()
+            .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
                 .to(getApiRoute()+"/reactions", GHReaction.class).wrap(owner.root);
     }

--- a/src/main/java/org/kohsuke/github/GHMilestone.java
+++ b/src/main/java/org/kohsuke/github/GHMilestone.java
@@ -93,7 +93,7 @@ public class GHMilestone extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(root)._with(key, value).method("PATCH").to(getApiRoute());
+        root.createRequester()._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     public void setTitle(String title) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHMilestone.java
+++ b/src/main/java/org/kohsuke/github/GHMilestone.java
@@ -93,7 +93,7 @@ public class GHMilestone extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        root.createRequester()._with(key, value).method("PATCH").to(getApiRoute());
+        root.createRequester().with(key, value).method("PATCH").to(getApiRoute());
     }
 
     public void setTitle(String title) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHNotificationStream.java
+++ b/src/main/java/org/kohsuke/github/GHNotificationStream.java
@@ -81,7 +81,7 @@ public class GHNotificationStream implements Iterable<GHThread> {
      */
     public Iterator<GHThread> iterator() {
         // capture the configuration setting here
-        final Requester req = new Requester(root).method("GET")
+        final Requester req = root.createRequester().method("GET")
                 .with("all", all).with("participating", participating).with("since", since);
 
         return new Iterator<GHThread>() {
@@ -198,7 +198,7 @@ public class GHNotificationStream implements Iterable<GHThread> {
      * Marks all the notifications as read.
      */
     public void markAsRead(long timestamp) throws IOException {
-        final Requester req = new Requester(root).method("PUT");
+        final Requester req = root.createRequester().method("PUT");
         if (timestamp>=0)
             req.with("last_read_at", GitHub.printDate(new Date(timestamp)));
         req.asHttpStatusCode(apiUrl);

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -236,7 +236,7 @@ public class GHOrganization extends GHPerson {
      * Creates a new team and assigns the repositories.
      */
     public GHTeam createTeam(String name, Permission p, Collection<GHRepository> repositories) throws IOException {
-        Requester post = new Requester(root).with("name", name).with("permission", p);
+        Requester post = root.createRequester().with("name", name).with("permission", p);
         List<String> repo_names = new ArrayList<String>();
         for (GHRepository r : repositories) {
             repo_names.add(login + "/" + r.getName());

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -114,7 +114,7 @@ public class GHProject extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(root).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+        root.createRequester().withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     protected String getApiRoute() {
@@ -161,7 +161,7 @@ public class GHProject extends GHObject {
     }
 
     public void delete() throws IOException {
-        new Requester(root).withPreview(INERTIA).method("DELETE").to(getApiRoute());
+        root.createRequester().withPreview(INERTIA).method("DELETE").to(getApiRoute());
     }
 
     public PagedIterable<GHProjectColumn> listColumns() throws IOException {

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -114,7 +114,7 @@ public class GHProject extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        root.createRequester().withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+        root.createRequester().withPreview(INERTIA).with(key, value).method("PATCH").to(getApiRoute());
     }
 
     protected String getApiRoute() {

--- a/src/main/java/org/kohsuke/github/GHProjectCard.java
+++ b/src/main/java/org/kohsuke/github/GHProjectCard.java
@@ -110,7 +110,7 @@ public class GHProjectCard extends GHObject {
 	}
 
 	private void edit(String key, Object value) throws IOException {
-		new Requester(root).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+		root.createRequester().withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
 	}
 
 	protected String getApiRoute() {
@@ -118,6 +118,6 @@ public class GHProjectCard extends GHObject {
 	}
 
 	public void delete() throws IOException {
-		new Requester(root).withPreview(INERTIA).method("DELETE").to(getApiRoute());
+		root.createRequester().withPreview(INERTIA).method("DELETE").to(getApiRoute());
 	}
 }

--- a/src/main/java/org/kohsuke/github/GHProjectCard.java
+++ b/src/main/java/org/kohsuke/github/GHProjectCard.java
@@ -110,7 +110,7 @@ public class GHProjectCard extends GHObject {
 	}
 
 	private void edit(String key, Object value) throws IOException {
-		root.createRequester().withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+		root.createRequester().withPreview(INERTIA).with(key, value).method("PATCH").to(getApiRoute());
 	}
 
 	protected String getApiRoute() {

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -60,7 +60,7 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	private void edit(String key, Object value) throws IOException {
-		new Requester(root).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+		root.createRequester().withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
 	}
 
 	protected String getApiRoute() {
@@ -68,7 +68,7 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	public void delete() throws IOException {
-		new Requester(root).withPreview(INERTIA).method("DELETE").to(getApiRoute());
+		root.createRequester().withPreview(INERTIA).method("DELETE").to(getApiRoute());
 	}
 
 	public PagedIterable<GHProjectCard> listCards() throws IOException {

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -60,7 +60,7 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	private void edit(String key, Object value) throws IOException {
-		root.createRequester().withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+		root.createRequester().withPreview(INERTIA).with(key, value).method("PATCH").to(getApiRoute());
 	}
 
 	protected String getApiRoute() {

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -347,7 +347,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     }
 
     public GHPullRequestReviewComment createReviewComment(String body, String sha, String path, int position) throws IOException {
-        return new Requester(root).method("POST")
+        return root.createRequester().method("POST")
                 .with("body", body)
                 .with("commit_id", sha)
                 .with("path", path)
@@ -356,7 +356,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     }
 
     public void requestReviewers(List<GHUser> reviewers) throws IOException {
-        new Requester(root).method("POST")
+        root.createRequester().method("POST")
                 .withLogins("reviewers", reviewers)
                 .to(getApiRoute() + REQUEST_REVIEWERS);
     }
@@ -366,7 +366,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
         for (GHTeam team : teams) {
           teamReviewers.add(team.getSlug());
         }
-        new Requester(root).method("POST")
+        root.createRequester().method("POST")
                 .with("team_reviewers", teamReviewers)
                 .to(getApiRoute() + REQUEST_REVIEWERS);
     }
@@ -408,7 +408,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      *      SHA that pull request head must match to allow merge.
      */
     public void merge(String msg, String sha, MergeMethod method) throws IOException {
-        new Requester(root).method("PUT")
+        root.createRequester().method("PUT")
                 .with("commit_message", msg)
                 .with("sha", sha)
                 .with("merge_method", method)
@@ -419,7 +419,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
 
     private void fetchIssue() throws IOException {
         if (!fetchedIssueDetails) {
-            new Requester(root).method("GET").to(getIssuesApiRoute(), this);
+            root.createRequester().method("GET").to(getIssuesApiRoute(), this);
             fetchedIssueDetails = true;
         }
     }

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -356,8 +356,9 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     }
 
     public void requestReviewers(List<GHUser> reviewers) throws IOException {
+        List<String> logins = getLogins(reviewers);
         root.createRequester().method("POST")
-                .withLogins("reviewers", reviewers)
+                .with("reviewers", logins)
                 .to(getApiRoute() + REQUEST_REVIEWERS);
     }
 

--- a/src/main/java/org/kohsuke/github/GHPullRequestReview.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReview.java
@@ -118,7 +118,7 @@ public class GHPullRequestReview extends GHObject {
      * Updates the comment.
      */
     public void submit(String body, GHPullRequestReviewEvent event) throws IOException {
-        new Requester(owner.root).method("POST")
+        owner.root.createRequester().method("POST")
                 .with("body", body)
                 .with("event", event.action())
                 .to(getApiRoute()+"/events",this);
@@ -130,7 +130,7 @@ public class GHPullRequestReview extends GHObject {
      * Deletes this review.
      */
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE")
+        owner.root.createRequester().method("DELETE")
                 .to(getApiRoute());
     }
 
@@ -138,7 +138,7 @@ public class GHPullRequestReview extends GHObject {
      * Dismisses this review.
      */
     public void dismiss(String message) throws IOException {
-        new Requester(owner.root).method("PUT")
+        owner.root.createRequester().method("PUT")
                 .with("message", message)
                 .to(getApiRoute()+"/dismissals");
         state = GHPullRequestReviewState.DISMISSED;

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
@@ -60,7 +60,7 @@ public class GHPullRequestReviewBuilder {
     }
 
     public GHPullRequestReview create() throws IOException {
-        return builder.method("POST")._with("comments",comments)
+        return builder.method("POST").with("comments",comments)
                 .to(pr.getApiRoute() + "/reviews", GHPullRequestReview.class)
                 .wrapUp(pr);
     }

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
@@ -17,7 +17,7 @@ public class GHPullRequestReviewBuilder {
 
     /*package*/ GHPullRequestReviewBuilder(GHPullRequest pr) {
         this.pr = pr;
-        this.builder = new Requester(pr.root);
+        this.builder = pr.root.createRequester();
     }
 
     //     public GHPullRequestReview createReview(@Nullable String commitId, String body, GHPullRequestReviewEvent event,

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
@@ -116,7 +116,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
      * Updates the comment.
      */
     public void update(String body) throws IOException {
-        new Requester(owner.root).method("PATCH").with("body", body).to(getApiRoute(),this);
+        owner.root.createRequester().method("PATCH").with("body", body).to(getApiRoute(),this);
         this.body = body;
     }
 
@@ -124,14 +124,14 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
      * Deletes this review comment.
      */
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE").to(getApiRoute());
+        owner.root.createRequester().method("DELETE").to(getApiRoute());
     }
 
     /**
      * Create a new comment that replies to this comment.
      */
     public GHPullRequestReviewComment reply(String body) throws IOException {
-        return new Requester(owner.root).method("POST")
+        return owner.root.createRequester().method("POST")
                 .with("body", body)
                 .with("in_reply_to", getId())
                 .to(getApiRoute() + "/comments", GHPullRequestReviewComment.class)
@@ -140,8 +140,8 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.root)
-                .withPreview(SQUIRREL_GIRL)
+        return owner.root.createRequester()
+            .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
                 .to(getApiRoute()+"/reactions", GHReaction.class).wrap(owner.root);
     }

--- a/src/main/java/org/kohsuke/github/GHReaction.java
+++ b/src/main/java/org/kohsuke/github/GHReaction.java
@@ -50,6 +50,6 @@ public class GHReaction extends GHObject {
      * Removes this reaction.
      */
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").withPreview(SQUIRREL_GIRL).to("/reactions/"+id);
+        root.createRequester().method("DELETE").withPreview(SQUIRREL_GIRL).to("/reactions/"+id);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHRef.java
+++ b/src/main/java/org/kohsuke/github/GHRef.java
@@ -56,7 +56,7 @@ public class GHRef {
      *      Whether or not to force this ref update.
      */
     public void updateTo(String sha, Boolean force) throws IOException {
-      new Requester(root)
+      root.createRequester()
           .with("sha", sha).with("force", force).method("PATCH").to(url, GHRef.class).wrap(root);
     }
 
@@ -64,7 +64,7 @@ public class GHRef {
      * Deletes this ref from the repository using the GitHub API.
      */
     public void delete() throws IOException {
-      new Requester(root).method("DELETE").to(url);
+      root.createRequester().method("DELETE").to(url);
     }
 
     /*package*/ GHRef wrap(GitHub root) {

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -135,7 +135,7 @@ public class GHRelease extends GHObject {
     }
     
     public GHAsset uploadAsset(String filename, InputStream stream, String contentType) throws IOException {
-        Requester builder = new Requester(owner.root);
+        Requester builder = owner.root.createRequester();
 
         String url = format("https://uploads.github.com%s/releases/%d/assets?name=%s",
                 owner.getApiTailUrl(""), getId(), filename);
@@ -145,7 +145,7 @@ public class GHRelease extends GHObject {
     }
 
     public List<GHAsset> getAssets() throws IOException {
-        Requester builder = new Requester(owner.root);
+        Requester builder = owner.root.createRequester();
 
         GHAsset[] assets = builder
                 .method("GET")
@@ -157,7 +157,7 @@ public class GHRelease extends GHObject {
      * Deletes this release.
      */
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").to(owner.getApiTailUrl("releases/"+id));
+        root.createRequester().method("DELETE").to(owner.getApiTailUrl("releases/"+id));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHReleaseBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHReleaseBuilder.java
@@ -13,7 +13,7 @@ public class GHReleaseBuilder {
 
     public GHReleaseBuilder(GHRepository ghRepository, String tag) {
         this.repo = ghRepository;
-        this.builder = new Requester(repo.root);
+        this.builder = repo.root.createRequester();
         builder.with("tag_name", tag);
     }
 

--- a/src/main/java/org/kohsuke/github/GHReleaseUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHReleaseUpdater.java
@@ -14,7 +14,7 @@ public class GHReleaseUpdater {
 
     GHReleaseUpdater(GHRelease base) {
         this.base = base;
-        this.builder = new Requester(base.root);
+        this.builder = base.root.createRequester();
     }
 
     public GHReleaseUpdater tag(String tag) {

--- a/src/main/java/org/kohsuke/github/GHSubscription.java
+++ b/src/main/java/org/kohsuke/github/GHSubscription.java
@@ -49,7 +49,7 @@ public class GHSubscription {
      * Removes this subscription.
      */
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").to(repo.getApiTailUrl("subscription"));
+        root.createRequester().method("DELETE").to(repo.getApiTailUrl("subscription"));
     }
 
     GHSubscription wrapUp(GHRepository repo) {

--- a/src/main/java/org/kohsuke/github/GHThread.java
+++ b/src/main/java/org/kohsuke/github/GHThread.java
@@ -122,14 +122,14 @@ public class GHThread extends GHObject {
      * Marks this thread as read.
      */
     public void markAsRead() throws IOException {
-        new Requester(root).method("PATCH").to(url);
+        root.createRequester().method("PATCH").to(url);
     }
 
     /**
      * Subscribes to this conversation to get notifications.
      */
     public GHSubscription subscribe(boolean subscribed, boolean ignored) throws IOException {
-        return new Requester(root)
+        return root.createRequester()
             .with("subscribed", subscribed)
             .with("ignored", ignored)
             .method("PUT").to(subscription_url, GHSubscription.class).wrapUp(root);
@@ -142,7 +142,7 @@ public class GHThread extends GHObject {
      */
     public GHSubscription getSubscription() throws IOException {
         try {
-            return new Requester(root).to(subscription_url, GHSubscription.class).wrapUp(root);
+            return root.createRequester().to(subscription_url, GHSubscription.class).wrapUp(root);
         } catch (FileNotFoundException e) {
             return null;
         }

--- a/src/main/java/org/kohsuke/github/GHTreeBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHTreeBuilder.java
@@ -84,7 +84,7 @@ public class GHTreeBuilder {
      * Creates a tree based on the parameters specified thus far.
      */
     public GHTree create() throws IOException {
-        req._with("tree", treeEntries);
+        req.with("tree", treeEntries);
         return req.method("POST").to(getApiTail(), GHTree.class).wrap(repo);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHTreeBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHTreeBuilder.java
@@ -33,7 +33,7 @@ public class GHTreeBuilder {
 
     GHTreeBuilder(GHRepository repo) {
         this.repo = repo;
-        req = new Requester(repo.root);
+        req = repo.root.createRequester();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -43,14 +43,14 @@ public class GHUser extends GHPerson {
      * Follow this user.
      */
     public void follow() throws IOException {
-        new Requester(root).method("PUT").to("/user/following/" + login);
+        root.createRequester().method("PUT").to("/user/following/" + login);
     }
 
     /**
      * Unfollow this user.
      */
     public void unfollow() throws IOException {
-        new Requester(root).method("DELETE").to("/user/following/" + login);
+        root.createRequester().method("DELETE").to("/user/following/" + login);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -259,6 +259,10 @@ public class GitHub {
         }
     }
 
+    Requester createRequester() {
+        return new RequesterImpl(this);
+    }
+
     /**
      * Is this an anonymous connection
      * @return {@code true} if operations that require authentication will fail.
@@ -308,7 +312,7 @@ public class GitHub {
     }
 
     /*package*/ Requester retrieve() {
-        return new Requester(this).method("GET");
+        return this.createRequester().method("GET");
     }
 
     /**
@@ -664,8 +668,8 @@ public class GitHub {
      * @see <a href="http://developer.github.com/v3/oauth/#create-a-new-authorization">Documentation</a>
      */
     public GHAuthorization createToken(Collection<String> scope, String note, String noteUrl) throws IOException{
-        Requester requester = new Requester(this)
-                .with("scopes", scope)
+        Requester requester = this.createRequester()
+            .with("scopes", scope)
                 .with("note", note)
                 .with("note_url", noteUrl);
 
@@ -678,8 +682,8 @@ public class GitHub {
     public GHAuthorization createOrGetAuth(String clientId, String clientSecret, List<String> scopes, String note,
                                            String note_url)
             throws IOException {
-        Requester requester = new Requester(this)
-                .with("client_secret", clientSecret)
+        Requester requester = this.createRequester()
+            .with("client_secret", clientSecret)
                 .with("scopes", scopes)
                 .with("note", note)
                 .with("note_url", note_url);
@@ -926,8 +930,8 @@ public class GitHub {
      */
     public Reader renderMarkdown(String text) throws IOException {
         return new InputStreamReader(
-            new Requester(this)
-                    .with(new ByteArrayInputStream(text.getBytes("UTF-8")))
+            this.createRequester()
+                .with(new ByteArrayInputStream(text.getBytes("UTF-8")))
                     .contentType("text/plain;charset=UTF-8")
                     .asStream("/markdown/raw"),
             "UTF-8");

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -23,222 +23,79 @@
  */
 package org.kohsuke.github;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.StringUtils;
 
-import javax.annotation.CheckForNull;
 import javax.annotation.WillClose;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Array;
-import java.lang.reflect.Field;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
-import java.net.SocketTimeoutException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.zip.GZIPInputStream;
-
-import static java.util.Arrays.asList;
-import static java.util.logging.Level.FINE;
-import static java.util.logging.Level.FINEST;
-import static java.util.logging.Level.INFO;
-import static org.apache.commons.lang3.StringUtils.defaultString;
-import static org.kohsuke.github.GitHub.MAPPER;
 
 /**
- * A builder pattern for making HTTP call and parsing its output.
+ * A builder pattern interface for making HTTP call and parsing its output.
  *
- * @author Kohsuke Kawaguchi
+ * @author Liam Newman
  */
-class Requester {
-    private final GitHub root;
-    private final List<Entry> args = new ArrayList<Entry>();
-    private final Map<String,String> headers = new LinkedHashMap<String, String>();
+public interface Requester {
 
-    /**
-     * Request method.
-     */
-    private String method = "POST";
-    private String contentType = null;
-    private InputStream body;
+    void setHeader(String name, String value);
 
-    /**
-     * Current connection.
-     */
-    private HttpURLConnection uc;
-    private boolean forceBody;
+    Requester withHeader(String name, String value);
 
-    private static class Entry {
-        String key;
-        Object value;
+    Requester withPreview(String name);
 
-        private Entry(String key, Object value) {
-            this.key = key;
-            this.value = value;
-        }
-    }
+    Requester with(String key, int value);
 
-    Requester(GitHub root) {
-        this.root = root;
-    }
+    Requester with(String key, long value);
 
-    /**
-     * Sets the request HTTP header.
-     *
-     * If a header of the same name is already set, this method overrides it.
-     */
-    public void setHeader(String name, String value) {
-        headers.put(name,value);
-    }
+    Requester with(String key, Integer value);
 
-    public Requester withHeader(String name, String value) {
-        setHeader(name,value);
-        return this;
-    }
+    Requester with(String key, boolean value);
 
-    /*package*/ Requester withPreview(String name) {
-        return withHeader("Accept",name);
-    }
+    Requester with(String key, Boolean value);
 
-    /**
-     * Makes a request with authentication credential.
-     */
-    @Deprecated
-    public Requester withCredential() {
-        // keeping it inline with retrieveWithAuth not to enforce the check
-        // root.requireCredential();
-        return this;
-    }
+    Requester with(String key, Enum e);
 
-    public Requester with(String key, int value) {
-        return _with(key, value);
-    }
+    Requester with(String key, String value);
 
-    public Requester with(String key, long value) {
-        return _with(key, value);
-    }
+    Requester with(String key, Collection<?> value);
 
-    public Requester with(String key, Integer value) {
-        if (value!=null)
-            _with(key, value);
-        return this;
-    }
+    Requester with(String key, Map<String, String> value);
 
-    public Requester with(String key, boolean value) {
-        return _with(key, value);
-    }
-    public Requester with(String key, Boolean value) {
-        return _with(key, value);
-    }
+    Requester withPermissions(String key, Map<String, GHPermissionType> value);
 
-    public Requester with(String key, Enum e) {
-        if (e==null)    return _with(key, null);
-        return with(key, transformEnum(e));
-    }
+    Requester with(@WillClose InputStream body);
 
-    public Requester with(String key, String value) {
-        return _with(key, value);
-    }
+    Requester withNullable(String key, Object value);
 
-    public Requester with(String key, Collection<?> value) {
-        return _with(key, value);
-    }
 
-    public Requester withLogins(String key, Collection<GHUser> users) {
-        List<String> names = new ArrayList<String>(users.size());
-        for (GHUser a : users) {
-            names.add(a.getLogin());
-        }
-        return with(key,names);
-    }
+    Requester withLogins(String key, Collection<GHUser> users);
 
-    public Requester with(String key, Map<String, String> value) {
-        return _with(key, value);
-    }
 
-    public Requester withPermissions(String key, Map<String, GHPermissionType> value) {
-        Map<String,String> retMap = new HashMap<String, String>();
-        for (Map.Entry<String, GHPermissionType> entry : value.entrySet()) {
-            retMap.put(entry.getKey(), transformEnum(entry.getValue()));
-        }
-        return _with(key, retMap);
-    }
-
-    public Requester with(@WillClose/*later*/ InputStream body) {
-        this.body = body;
-        return this;
-    }
-
-	public Requester withNullable(String key, Object value) {
-		args.add(new Entry(key, value));
-		return this;
-	}
-
-    public Requester _with(String key, Object value) {
-        if (value!=null) {
-            args.add(new Entry(key,value));
-        }
-        return this;
-    }
+    Requester _with(String key, Object value);
 
     /**
      * Unlike {@link #with(String, String)}, overrides the existing value
      */
-    public Requester set(String key, Object value) {
-        for (Entry e : args) {
-            if (e.key.equals(key)) {
-                e.value = value;
-                return this;
-            }
-        }
-        return _with(key,value);
-    }
+    Requester set(String key, Object value);
 
-    public Requester method(String method) {
-        this.method = method;
-        return this;
-    }
+    //Requester setNullable(String key, Object value);
 
-    public Requester contentType(String contentType) {
-        this.contentType = contentType;
-        return this;
-    }
+    Requester method(String method);
+
+    Requester contentType(String contentType);
 
     /**
      * Small number of GitHub APIs use HTTP methods somewhat inconsistently, and use a body where it's not expected.
      * Normally whether parameters go as query parameters or a body depends on the HTTP verb in use,
      * but this method forces the parameters to be sent as a body.
      */
-    /*package*/ Requester inBody() {
-        forceBody = true;
-        return this;
-    }
+    Requester inBody();
 
-    public void to(String tailApiUrl) throws IOException {
-        to(tailApiUrl,null);
-    }
+    void to(String tailApiUrl) throws IOException;
 
     /**
      * Sends a request to the specified URL, and parses the response into the given type via databinding.
@@ -248,546 +105,24 @@ class Requester {
      * @return
      *      {@link Reader} that reads the response.
      */
-    public <T> T to(String tailApiUrl, Class<T> type) throws IOException {
-        return _to(tailApiUrl, type, null);
-    }
+    <T> T to(String tailApiUrl, Class<T> type) throws IOException;
 
     /**
      * Like {@link #to(String, Class)} but updates an existing object instead of creating a new instance.
      */
-    public <T> T to(String tailApiUrl, T existingInstance) throws IOException {
-        return _to(tailApiUrl, null, existingInstance);
-    }
-
-    /**
-     * Short for {@code method(method).to(tailApiUrl,type)}
-     */
-    @Deprecated
-    public <T> T to(String tailApiUrl, Class<T> type, String method) throws IOException {
-        return method(method).to(tailApiUrl, type);
-    }
-
-    @SuppressFBWarnings("SBSC_USE_STRINGBUFFER_CONCATENATION")
-    private <T> T _to(String tailApiUrl, Class<T> type, T instance) throws IOException {
-        if (!isMethodWithBody() && !args.isEmpty()) {
-            boolean questionMarkFound = tailApiUrl.indexOf('?') != -1;
-            tailApiUrl += questionMarkFound ? '&' : '?';
-            for (Iterator<Entry> it = args.listIterator(); it.hasNext();) {
-                Entry arg = it.next();
-                tailApiUrl += arg.key + '=' + URLEncoder.encode(arg.value.toString(),"UTF-8");
-                if (it.hasNext()) {
-                    tailApiUrl += '&';
-                }
-            }
-        }
-
-        while (true) {// loop while API rate limit is hit
-            setupConnection(root.getApiURL(tailApiUrl));
-
-            buildRequest();
-
-            try {
-                T result = parse(type, instance);
-                if (type != null && type.isArray()) { // we might have to loop for pagination - done through recursion
-                    final String links = uc.getHeaderField("link");
-                    if (links != null && links.contains("rel=\"next\"")) {
-                        Pattern nextLinkPattern = Pattern.compile(".*<(.*)>; rel=\"next\"");
-                        Matcher nextLinkMatcher = nextLinkPattern.matcher(links);
-                        if (nextLinkMatcher.find()) {
-                            final String link = nextLinkMatcher.group(1);
-                            T nextResult = _to(link, type, instance);
-                            setResponseHeaders(nextResult);
-                            final int resultLength = Array.getLength(result);
-                            final int nextResultLength = Array.getLength(nextResult);
-                            T concatResult = (T) Array.newInstance(type.getComponentType(), resultLength + nextResultLength);
-                            System.arraycopy(result, 0, concatResult, 0, resultLength);
-                            System.arraycopy(nextResult, 0, concatResult, resultLength, nextResultLength);
-                            result = concatResult;
-                        }
-                    }
-                }
-                return setResponseHeaders(result);
-            } catch (IOException e) {
-                handleApiError(e);
-            } finally {
-                noteRateLimit(tailApiUrl);
-            }
-        }
-    }
+    <T> T to(String tailApiUrl, T existingInstance) throws IOException;
 
     /**
      * Makes a request and just obtains the HTTP status code.
+     * @return a status code
      */
-    public int asHttpStatusCode(String tailApiUrl) throws IOException {
-        while (true) {// loop while API rate limit is hit
-            method("GET");
-            setupConnection(root.getApiURL(tailApiUrl));
+    int asHttpStatusCode(String tailApiUrl) throws IOException;
 
-            buildRequest();
+    InputStream asStream(String tailApiUrl) throws IOException;
 
-            try {
-                return uc.getResponseCode();
-            } catch (IOException e) {
-                handleApiError(e);
-            } finally {
-                noteRateLimit(tailApiUrl);
-            }
-        }
-    }
+    <T> PagedIterable<T> asPagedIterable(String tailApiUrl, Class<T[]> type, Consumer<T> consumer);
 
-    public InputStream asStream(String tailApiUrl) throws IOException {
-        while (true) {// loop while API rate limit is hit
-            setupConnection(root.getApiURL(tailApiUrl));
+    <T> Iterator<T> asIterator(String tailApiUrl, Class<T> type, int pageSize);
 
-            buildRequest();
-
-            try {
-                return wrapStream(uc.getInputStream());
-            } catch (IOException e) {
-                handleApiError(e);
-            } finally {
-                noteRateLimit(tailApiUrl);
-            }
-        }
-    }
-
-    private void noteRateLimit(String tailApiUrl) {
-        if ("/rate_limit".equals(tailApiUrl)) {
-            // the rate_limit API is "free"
-            return;
-        }
-        if (tailApiUrl.startsWith("/search")) {
-            // the search API uses a different rate limit
-            return;
-        }
-        String limit = uc.getHeaderField("X-RateLimit-Limit");
-        if (StringUtils.isBlank(limit)) {
-            // if we are missing a header, return fast
-            return;
-        }
-        String remaining = uc.getHeaderField("X-RateLimit-Remaining");
-        if (StringUtils.isBlank(remaining)) {
-            // if we are missing a header, return fast
-            return;
-        }
-        String reset = uc.getHeaderField("X-RateLimit-Reset");
-        if (StringUtils.isBlank(reset)) {
-            // if we are missing a header, return fast
-            return;
-        }
-        GHRateLimit observed = new GHRateLimit();
-        try {
-            observed.limit = Integer.parseInt(limit);
-        } catch (NumberFormatException e) {
-            if (LOGGER.isLoggable(FINEST)) {
-                LOGGER.log(FINEST, "Malformed X-RateLimit-Limit header value " + limit, e);
-            }
-            return;
-        }
-        try {
-            observed.remaining = Integer.parseInt(remaining);
-        } catch (NumberFormatException e) {
-            if (LOGGER.isLoggable(FINEST)) {
-                LOGGER.log(FINEST, "Malformed X-RateLimit-Remaining header value " + remaining, e);
-            }
-            return;
-        }
-        try {
-            observed.reset = new Date(Long.parseLong(reset)); // this is madness, storing the date as seconds
-            root.updateRateLimit(observed);
-        } catch (NumberFormatException e) {
-            if (LOGGER.isLoggable(FINEST)) {
-                LOGGER.log(FINEST, "Malformed X-RateLimit-Reset header value " + reset, e);
-            }
-        }
-    }
-
-    public String getResponseHeader(String header) {
-        return uc.getHeaderField(header);
-    }
-
-
-    /**
-     * Set up the request parameters or POST payload.
-     */
-    private void buildRequest() throws IOException {
-        if (isMethodWithBody()) {
-            uc.setDoOutput(true);
-
-            if (body == null) {
-                uc.setRequestProperty("Content-type", defaultString(contentType,"application/json"));
-                Map json = new HashMap();
-                for (Entry e : args) {
-                    json.put(e.key, e.value);
-                }
-                MAPPER.writeValue(uc.getOutputStream(), json);
-            } else {
-                uc.setRequestProperty("Content-type", defaultString(contentType,"application/x-www-form-urlencoded"));
-                try {
-                    byte[] bytes = new byte[32768];
-                    int read;
-                    while ((read = body.read(bytes)) != -1) {
-                        uc.getOutputStream().write(bytes, 0, read);
-                    }
-                } finally {
-                    body.close();
-                }
-            }
-        }
-    }
-
-    private boolean isMethodWithBody() {
-        return forceBody || !METHODS_WITHOUT_BODY.contains(method);
-    }
-
-    /*package*/  <T> PagedIterable<T> asPagedIterable(String tailApiUrl, Class<T[]> type, Consumer<T> consumer) {
-        return new PagedIterableWithConsumer(type, this, tailApiUrl, consumer);
-    }
-
-    private static class PagedIterableWithConsumer<S> extends PagedIterable<S> {
-
-        private final Class<S[]> clazz;
-        private final Requester requester;
-        private final String tailApiUrl;
-        private final Consumer<S> consumer;
-
-        public PagedIterableWithConsumer(Class<S[]> clazz, Requester requester, String tailApiUrl, Consumer<S> consumer) {
-            this.clazz = clazz;
-            this.tailApiUrl = tailApiUrl;
-            this.requester = requester;
-            this.consumer = consumer;
-        }
-
-        @Override
-        public PagedIterator<S> _iterator(int pageSize) {
-            final Iterator<S[]> iterator = requester.asIterator(tailApiUrl, clazz, pageSize);
-            return new PagedIterator<S>(iterator) {
-                @Override
-                protected void wrapUp(S[] page) {
-                    if (consumer != null) {
-                        for (S item : page) {
-                            consumer.accept(item);
-                        }
-                    }
-                }
-            };
-        }
-    }
-
-    /**
-     * Loads paginated resources.
-     *
-     * Every iterator call reports a new batch.
-     */
-    /*package*/ <T> Iterator<T> asIterator(String tailApiUrl, Class<T> type, int pageSize) {
-        method("GET");
-
-        if (pageSize!=0)
-            args.add(new Entry("per_page",pageSize));
-
-        StringBuilder s = new StringBuilder(tailApiUrl);
-        if (!args.isEmpty()) {
-            boolean first = true;
-            try {
-                for (Entry a : args) {
-                    s.append(first ? '?' : '&');
-                    first = false;
-                    s.append(URLEncoder.encode(a.key, "UTF-8"));
-                    s.append('=');
-                    s.append(URLEncoder.encode(a.value.toString(), "UTF-8"));
-                }
-            } catch (UnsupportedEncodingException e) {
-                throw new AssertionError(e);    // UTF-8 is mandatory
-            }
-        }
-
-        try {
-            return new PagingIterator<T>(type, tailApiUrl, root.getApiURL(s.toString()));
-        } catch (IOException e) {
-            throw new GHException("Unable to build github Api URL",e);
-        }
-    }
-
-    class PagingIterator<T> implements Iterator<T> {
-
-        private final Class<T> type;
-        private final String tailApiUrl;
-
-        /**
-         * The next batch to be returned from {@link #next()}.
-         */
-        private T next;
-
-        /**
-         * URL of the next resource to be retrieved, or null if no more data is available.
-         */
-        private URL url;
-
-        PagingIterator(Class<T> type, String tailApiUrl, URL url) {
-            this.type = type;
-            this.tailApiUrl = tailApiUrl;
-            this.url = url;
-        }
-
-        public boolean hasNext() {
-            fetch();
-            return next!=null;
-        }
-
-        public T next() {
-            fetch();
-            T r = next;
-            if (r==null)    throw new NoSuchElementException();
-            next = null;
-            return r;
-        }
-
-        public void remove() {
-            throw new UnsupportedOperationException();
-        }
-
-        private void fetch() {
-            if (next!=null) return; // already fetched
-            if (url==null)  return; // no more data to fetch
-
-            try {
-                while (true) {// loop while API rate limit is hit
-                    setupConnection(url);
-                    try {
-                        next = parse(type,null);
-                        assert next!=null;
-                        findNextURL();
-                        return;
-                    } catch (IOException e) {
-                        handleApiError(e);
-                    } finally {
-                        noteRateLimit(tailApiUrl);
-                    }
-                }
-            } catch (IOException e) {
-                throw new GHException("Failed to retrieve " + url, e);
-            }
-        }
-
-        /**
-         * Locate the next page from the pagination "Link" tag.
-         */
-        private void findNextURL() throws MalformedURLException {
-            url = null; // start defensively
-            String link = uc.getHeaderField("Link");
-            if (link==null) return;
-
-            for (String token : link.split(", ")) {
-                if (token.endsWith("rel=\"next\"")) {
-                    // found the next page. This should look something like
-                    // <https://api.github.com/repos?page=3&per_page=100>; rel="next"
-                    int idx = token.indexOf('>');
-                    url = new URL(token.substring(1,idx));
-                    return;
-                }
-            }
-
-            // no more "next" link. we are done.
-        }
-    }
-
-
-    private void setupConnection(URL url) throws IOException {
-        if (LOGGER.isLoggable(FINE)) {
-            LOGGER.log(FINE, "GitHub API request [" + (root.login == null ? "anonymous" : root.login) + "]: " + method + " " + url.toString());
-        }
-        uc = root.getConnector().connect(url);
-
-        // if the authentication is needed but no credential is given, try it anyway (so that some calls
-        // that do work with anonymous access in the reduced form should still work.)
-        if (root.encodedAuthorization!=null)
-            uc.setRequestProperty("Authorization", root.encodedAuthorization);
-
-        for (Map.Entry<String, String> e : headers.entrySet()) {
-            String v = e.getValue();
-            if (v!=null)
-                uc.setRequestProperty(e.getKey(), v);
-        }
-
-        setRequestMethod(uc);
-        uc.setRequestProperty("Accept-Encoding", "gzip");
-    }
-
-    private void setRequestMethod(HttpURLConnection uc) throws IOException {
-        try {
-            uc.setRequestMethod(method);
-        } catch (ProtocolException e) {
-            // JDK only allows one of the fixed set of verbs. Try to override that
-            try {
-                Field $method = HttpURLConnection.class.getDeclaredField("method");
-                $method.setAccessible(true);
-                $method.set(uc,method);
-            } catch (Exception x) {
-                throw (IOException)new IOException("Failed to set the custom verb").initCause(x);
-            }
-            // sun.net.www.protocol.https.DelegatingHttpsURLConnection delegates to another HttpURLConnection
-            try {
-                Field $delegate = uc.getClass().getDeclaredField("delegate");
-                $delegate.setAccessible(true);
-                Object delegate = $delegate.get(uc);
-                if (delegate instanceof HttpURLConnection) {
-                    HttpURLConnection nested = (HttpURLConnection) delegate;
-                    setRequestMethod(nested);
-                }
-            } catch (NoSuchFieldException x) {
-                // no problem
-            } catch (IllegalAccessException x) {
-                throw (IOException)new IOException("Failed to set the custom verb").initCause(x);
-            }
-        }
-        if (!uc.getRequestMethod().equals(method))
-            throw new IllegalStateException("Failed to set the request method to "+method);
-    }
-
-    @CheckForNull
-    private <T> T parse(Class<T> type, T instance) throws IOException {
-        return parse(type, instance, 2);
-    }
-
-    private <T> T parse(Class<T> type, T instance, int timeouts) throws IOException {
-        InputStreamReader r = null;
-        int responseCode = -1;
-        String responseMessage = null;
-        try {
-            responseCode = uc.getResponseCode();
-            responseMessage = uc.getResponseMessage();
-            if (responseCode == 304) {
-                return null;    // special case handling for 304 unmodified, as the content will be ""
-            }
-            if (responseCode == 204 && type!=null && type.isArray()) {
-                // no content
-                return type.cast(Array.newInstance(type.getComponentType(),0));
-            }
-
-            // Response code 202 means the statistics are still being cached.
-            // See https://developer.github.com/v3/repos/statistics/#a-word-about-caching
-            if (responseCode == 202) {
-                LOGGER.log(INFO, "The statistics are still being generated. Please try again in 5 seconds.");
-                // Maybe throw an exception instead?
-                return null;
-            }
-
-            r = new InputStreamReader(wrapStream(uc.getInputStream()), "UTF-8");
-            String data = IOUtils.toString(r);
-            if (type!=null)
-                try {
-                    return setResponseHeaders(MAPPER.readValue(data, type));
-                } catch (JsonMappingException e) {
-                    throw (IOException)new IOException("Failed to deserialize " +data).initCause(e);
-                }
-            if (instance!=null) {
-                return setResponseHeaders(MAPPER.readerForUpdating(instance).<T>readValue(data));
-            }
-            return null;
-        } catch (FileNotFoundException e) {
-            // java.net.URLConnection handles 404 exception has FileNotFoundException, don't wrap exception in HttpException
-            // to preserve backward compatibility
-            throw e;
-        } catch (IOException e) {
-            if (e instanceof SocketTimeoutException && timeouts > 0) {
-                LOGGER.log(INFO, "timed out accessing " + uc.getURL() + "; will try " + timeouts + " more time(s)", e);
-                return parse(type, instance, timeouts - 1);
-            }
-            throw new HttpException(responseCode, responseMessage, uc.getURL(), e);
-        } finally {
-            IOUtils.closeQuietly(r);
-        }
-    }
-
-    private <T> T setResponseHeaders(T readValue) {
-        if (readValue instanceof GHObject[]) {
-            for (GHObject ghObject : (GHObject[]) readValue) {
-                setResponseHeaders(ghObject);
-            }
-        } else if (readValue instanceof GHObject) {
-            setResponseHeaders((GHObject) readValue);
-        }
-        return readValue;
-    }
-
-    private void setResponseHeaders(GHObject readValue) {
-        readValue.responseHeaderFields = uc.getHeaderFields();
-    }
-
-    /**
-     * Handles the "Content-Encoding" header.
-     */
-    private InputStream wrapStream(InputStream in) throws IOException {
-        String encoding = uc.getContentEncoding();
-        if (encoding==null || in==null) return in;
-        if (encoding.equals("gzip"))    return new GZIPInputStream(in);
-
-        throw new UnsupportedOperationException("Unexpected Content-Encoding: "+encoding);
-    }
-
-    /**
-     * Handle API error by either throwing it or by returning normally to retry.
-     */
-    /*package*/ void handleApiError(IOException e) throws IOException {
-        int responseCode;
-        try {
-            responseCode = uc.getResponseCode();
-        } catch (IOException e2) {
-            // likely to be a network exception (e.g. SSLHandshakeException),
-            // uc.getResponseCode() and any other getter on the response will cause an exception
-            if (LOGGER.isLoggable(FINE))
-                LOGGER.log(FINE, "Silently ignore exception retrieving response code for '" + uc.getURL() + "'" +
-                        " handling exception " + e, e);
-            throw e;
-        }
-        InputStream es = wrapStream(uc.getErrorStream());
-        if (es != null) {
-            try {
-                String error = IOUtils.toString(es, "UTF-8");
-                if (e instanceof FileNotFoundException) {
-                    // pass through 404 Not Found to allow the caller to handle it intelligently
-                    e = (IOException) new GHFileNotFoundException(error).withResponseHeaderFields(uc).initCause(e);
-                } else if (e instanceof HttpException) {
-                    HttpException http = (HttpException) e;
-                    e = new HttpException(error, http.getResponseCode(), http.getResponseMessage(),
-                            http.getUrl(), e);
-                } else {
-                    e = (IOException) new GHIOException(error).withResponseHeaderFields(uc).initCause(e);
-                }
-            } finally {
-                IOUtils.closeQuietly(es);
-            }
-        }
-        if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) // 401 / Unauthorized == bad creds
-            throw e;
-
-        if ("0".equals(uc.getHeaderField("X-RateLimit-Remaining"))) {
-            root.rateLimitHandler.onError(e,uc);
-            return;
-        }
-
-        // Retry-After is not documented but apparently that field exists
-        if (responseCode == HttpURLConnection.HTTP_FORBIDDEN &&
-            uc.getHeaderField("Retry-After") != null) {
-            this.root.abuseLimitHandler.onError(e,uc);
-            return;
-        }
-
-        throw e;
-    }
-
-    /**
-     * Transform Java Enum into Github constants given its conventions
-     * @param en - Enum to be transformed
-     * @return a String containing the value of a Github constant
-     */
-    private String transformEnum(Enum en){
-        // by convention Java constant names are upper cases, but github uses
-        // lower-case constants. GitHub also uses '-', which in Java we always
-        // replace by '_'
-        return en.toString().toLowerCase(Locale.ENGLISH).replace('_', '-');
-    }
-
-    private static final List<String> METHODS_WITHOUT_BODY = asList("GET", "DELETE");
-    private static final Logger LOGGER = Logger.getLogger(Requester.class.getName());
+    String getResponseHeader(String header);
 }

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -31,6 +31,7 @@ import java.io.Reader;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -51,11 +52,7 @@ public interface Requester {
 
     Requester with(String key, long value);
 
-    Requester with(String key, Integer value);
-
     Requester with(String key, boolean value);
-
-    Requester with(String key, Boolean value);
 
     Requester with(String key, Enum e);
 
@@ -65,17 +62,11 @@ public interface Requester {
 
     Requester with(String key, Map<String, String> value);
 
-    Requester withPermissions(String key, Map<String, GHPermissionType> value);
-
     Requester with(@WillClose InputStream body);
 
+    Requester with(String key, Object value);
+
     Requester withNullable(String key, Object value);
-
-
-    Requester withLogins(String key, Collection<GHUser> users);
-
-
-    Requester _with(String key, Object value);
 
     /**
      * Unlike {@link #with(String, String)}, overrides the existing value
@@ -95,6 +86,11 @@ public interface Requester {
      */
     Requester inBody();
 
+    /**
+     *
+     * @param tailApiUrl
+     * @throws IOException
+     */
     void to(String tailApiUrl) throws IOException;
 
     /**
@@ -125,4 +121,17 @@ public interface Requester {
     <T> Iterator<T> asIterator(String tailApiUrl, Class<T> type, int pageSize);
 
     String getResponseHeader(String header);
+
+    /**
+     * Transform Java Enum into Github constants given its conventions
+     * @param en - Enum to be transformed
+     * @return a String containing the value of a Github constant
+     */
+    static String transformEnum(Enum en){
+        // by convention Java constant names are upper cases, but github uses
+        // lower-case constants. GitHub also uses '-', which in Java we always
+        // replace by '_'
+        return en.toString().toLowerCase(Locale.ENGLISH).replace('_', '-');
+    }
+
 }

--- a/src/main/java/org/kohsuke/github/RequesterImpl.java
+++ b/src/main/java/org/kohsuke/github/RequesterImpl.java
@@ -121,57 +121,38 @@ class RequesterImpl implements Requester {
     }
 
     public Requester with(String key, int value) {
-        return _with(key, value);
+        return with(key, (Object)value);
     }
 
     public Requester with(String key, long value) {
-        return _with(key, value);
+        return with(key, (Object)value);
     }
 
     public Requester with(String key, Integer value) {
         if (value!=null)
-            _with(key, value);
+            with(key, (Object)value);
         return this;
     }
 
     public Requester with(String key, boolean value) {
-        return _with(key, value);
-    }
-    public Requester with(String key, Boolean value) {
-        return _with(key, value);
+        return with(key, (Object)value);
     }
 
     public Requester with(String key, Enum e) {
-        if (e==null)    return _with(key, null);
-        return with(key, transformEnum(e));
+        if (e==null)    return with(key, (Object)null);
+        return with(key, Requester.transformEnum(e));
     }
 
     public Requester with(String key, String value) {
-        return _with(key, value);
+        return with(key, (Object)value);
     }
 
     public Requester with(String key, Collection<?> value) {
-        return _with(key, value);
-    }
-
-    public Requester withLogins(String key, Collection<GHUser> users) {
-        List<String> names = new ArrayList<String>(users.size());
-        for (GHUser a : users) {
-            names.add(a.getLogin());
-        }
-        return with(key,names);
+        return with(key, (Object)value);
     }
 
     public Requester with(String key, Map<String, String> value) {
-        return _with(key, value);
-    }
-
-    public Requester withPermissions(String key, Map<String, GHPermissionType> value) {
-        Map<String,String> retMap = new HashMap<String, String>();
-        for (Map.Entry<String, GHPermissionType> entry : value.entrySet()) {
-            retMap.put(entry.getKey(), transformEnum(entry.getValue()));
-        }
-        return _with(key, retMap);
+        return with(key, (Object)value);
     }
 
     public Requester with(@WillClose/*later*/ InputStream body) {
@@ -184,7 +165,7 @@ class RequesterImpl implements Requester {
 		return this;
 	}
 
-    public Requester _with(String key, Object value) {
+    public Requester with(String key, Object value) {
         if (value!=null) {
             args.add(new Entry(key,value));
         }
@@ -201,7 +182,7 @@ class RequesterImpl implements Requester {
                 return this;
             }
         }
-        return _with(key,value);
+        return with(key,value);
     }
 
     public Requester method(String method) {
@@ -754,18 +735,6 @@ class RequesterImpl implements Requester {
         }
 
         throw e;
-    }
-
-    /**
-     * Transform Java Enum into Github constants given its conventions
-     * @param en - Enum to be transformed
-     * @return a String containing the value of a Github constant
-     */
-    private String transformEnum(Enum en){
-        // by convention Java constant names are upper cases, but github uses
-        // lower-case constants. GitHub also uses '-', which in Java we always
-        // replace by '_'
-        return en.toString().toLowerCase(Locale.ENGLISH).replace('_', '-');
     }
 
     private static final List<String> METHODS_WITHOUT_BODY = asList("GET", "DELETE");

--- a/src/main/java/org/kohsuke/github/RequesterImpl.java
+++ b/src/main/java/org/kohsuke/github/RequesterImpl.java
@@ -1,0 +1,773 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010, Kohsuke Kawaguchi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.kohsuke.github;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.WillClose;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ProtocolException;
+import java.net.SocketTimeoutException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.GZIPInputStream;
+
+import static java.util.Arrays.asList;
+import static java.util.logging.Level.*;
+import static org.apache.commons.lang3.StringUtils.defaultString;
+import static org.kohsuke.github.GitHub.MAPPER;
+
+/**
+ * A builder pattern for making HTTP call and parsing its output.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+class RequesterImpl implements Requester {
+    private final GitHub root;
+    private final List<Entry> args = new ArrayList<Entry>();
+    private final Map<String,String> headers = new LinkedHashMap<String, String>();
+
+    /**
+     * Request method.
+     */
+    private String method = "POST";
+    private String contentType = null;
+    private InputStream body;
+
+    /**
+     * Current connection.
+     */
+    private HttpURLConnection uc;
+    private boolean forceBody;
+
+    private static class Entry {
+        String key;
+        Object value;
+
+        private Entry(String key, Object value) {
+            this.key = key;
+            this.value = value;
+        }
+    }
+
+    RequesterImpl(GitHub root) {
+        this.root = root;
+    }
+
+    /**
+     * Sets the request HTTP header.
+     *
+     * If a header of the same name is already set, this method overrides it.
+     */
+    public void setHeader(String name, String value) {
+        headers.put(name,value);
+    }
+
+    public Requester withHeader(String name, String value) {
+        setHeader(name,value);
+        return this;
+    }
+
+    public Requester withPreview(String name) {
+        return withHeader("Accept",name);
+    }
+
+    public Requester with(String key, int value) {
+        return _with(key, value);
+    }
+
+    public Requester with(String key, long value) {
+        return _with(key, value);
+    }
+
+    public Requester with(String key, Integer value) {
+        if (value!=null)
+            _with(key, value);
+        return this;
+    }
+
+    public Requester with(String key, boolean value) {
+        return _with(key, value);
+    }
+    public Requester with(String key, Boolean value) {
+        return _with(key, value);
+    }
+
+    public Requester with(String key, Enum e) {
+        if (e==null)    return _with(key, null);
+        return with(key, transformEnum(e));
+    }
+
+    public Requester with(String key, String value) {
+        return _with(key, value);
+    }
+
+    public Requester with(String key, Collection<?> value) {
+        return _with(key, value);
+    }
+
+    public Requester withLogins(String key, Collection<GHUser> users) {
+        List<String> names = new ArrayList<String>(users.size());
+        for (GHUser a : users) {
+            names.add(a.getLogin());
+        }
+        return with(key,names);
+    }
+
+    public Requester with(String key, Map<String, String> value) {
+        return _with(key, value);
+    }
+
+    public Requester withPermissions(String key, Map<String, GHPermissionType> value) {
+        Map<String,String> retMap = new HashMap<String, String>();
+        for (Map.Entry<String, GHPermissionType> entry : value.entrySet()) {
+            retMap.put(entry.getKey(), transformEnum(entry.getValue()));
+        }
+        return _with(key, retMap);
+    }
+
+    public Requester with(@WillClose/*later*/ InputStream body) {
+        this.body = body;
+        return this;
+    }
+
+	public Requester withNullable(String key, Object value) {
+		args.add(new Entry(key, value));
+		return this;
+	}
+
+    public Requester _with(String key, Object value) {
+        if (value!=null) {
+            args.add(new Entry(key,value));
+        }
+        return this;
+    }
+
+    /**
+     * Unlike {@link #with(String, String)}, overrides the existing value
+     */
+    public Requester set(String key, Object value) {
+        for (Entry e : args) {
+            if (e.key.equals(key)) {
+                e.value = value;
+                return this;
+            }
+        }
+        return _with(key,value);
+    }
+
+    public Requester method(String method) {
+        this.method = method;
+        return this;
+    }
+
+    public Requester contentType(String contentType) {
+        this.contentType = contentType;
+        return this;
+    }
+
+    /**
+     * Small number of GitHub APIs use HTTP methods somewhat inconsistently, and use a body where it's not expected.
+     * Normally whether parameters go as query parameters or a body depends on the HTTP verb in use,
+     * but this method forces the parameters to be sent as a body.
+     */
+    public Requester inBody() {
+        forceBody = true;
+        return this;
+    }
+
+    public void to(String tailApiUrl) throws IOException {
+        _to(tailApiUrl,null, null);
+    }
+
+    /**
+     * Sends a request to the specified URL, and parses the response into the given type via databinding.
+     *
+     * @throws IOException
+     *      if the server returns 4xx/5xx responses.
+     * @return
+     *      {@link Reader} that reads the response.
+     */
+    public <T> T to(String tailApiUrl, Class<T> type) throws IOException {
+        return _to(tailApiUrl, type, null);
+    }
+
+    /**
+     * Like {@link #to(String, Class)} but updates an existing object instead of creating a new instance.
+     */
+    public <T> T to(String tailApiUrl, T existingInstance) throws IOException {
+        return _to(tailApiUrl, null, existingInstance);
+    }
+
+    @SuppressFBWarnings("SBSC_USE_STRINGBUFFER_CONCATENATION")
+    private <T> T _to(String tailApiUrl, Class<T> type, T instance) throws IOException {
+        if (!isMethodWithBody() && !args.isEmpty()) {
+            boolean questionMarkFound = tailApiUrl.indexOf('?') != -1;
+            tailApiUrl += questionMarkFound ? '&' : '?';
+            for (Iterator<Entry> it = args.listIterator(); it.hasNext();) {
+                Entry arg = it.next();
+                tailApiUrl += arg.key + '=' + URLEncoder.encode(arg.value.toString(),"UTF-8");
+                if (it.hasNext()) {
+                    tailApiUrl += '&';
+                }
+            }
+        }
+
+        while (true) {// loop while API rate limit is hit
+            setupConnection(root.getApiURL(tailApiUrl));
+
+            buildRequest();
+
+            try {
+                T result = parse(type, instance);
+                if (type != null && type.isArray()) { // we might have to loop for pagination - done through recursion
+                    final String links = uc.getHeaderField("link");
+                    if (links != null && links.contains("rel=\"next\"")) {
+                        Pattern nextLinkPattern = Pattern.compile(".*<(.*)>; rel=\"next\"");
+                        Matcher nextLinkMatcher = nextLinkPattern.matcher(links);
+                        if (nextLinkMatcher.find()) {
+                            final String link = nextLinkMatcher.group(1);
+                            T nextResult = _to(link, type, instance);
+                            setResponseHeaders(nextResult);
+                            final int resultLength = Array.getLength(result);
+                            final int nextResultLength = Array.getLength(nextResult);
+                            T concatResult = (T) Array.newInstance(type.getComponentType(), resultLength + nextResultLength);
+                            System.arraycopy(result, 0, concatResult, 0, resultLength);
+                            System.arraycopy(nextResult, 0, concatResult, resultLength, nextResultLength);
+                            result = concatResult;
+                        }
+                    }
+                }
+                return setResponseHeaders(result);
+            } catch (IOException e) {
+                handleApiError(e);
+            } finally {
+                noteRateLimit(tailApiUrl);
+            }
+        }
+    }
+
+    /**
+     * Makes a request and just obtains the HTTP status code.
+     */
+    public int asHttpStatusCode(String tailApiUrl) throws IOException {
+        while (true) {// loop while API rate limit is hit
+            method("GET");
+            setupConnection(root.getApiURL(tailApiUrl));
+
+            buildRequest();
+
+            try {
+                return uc.getResponseCode();
+            } catch (IOException e) {
+                handleApiError(e);
+            } finally {
+                noteRateLimit(tailApiUrl);
+            }
+        }
+    }
+
+    public InputStream asStream(String tailApiUrl) throws IOException {
+        while (true) {// loop while API rate limit is hit
+            setupConnection(root.getApiURL(tailApiUrl));
+
+            buildRequest();
+
+            try {
+                return wrapStream(uc.getInputStream());
+            } catch (IOException e) {
+                handleApiError(e);
+            } finally {
+                noteRateLimit(tailApiUrl);
+            }
+        }
+    }
+
+    private void noteRateLimit(String tailApiUrl) {
+        if ("/rate_limit".equals(tailApiUrl)) {
+            // the rate_limit API is "free"
+            return;
+        }
+        if (tailApiUrl.startsWith("/search")) {
+            // the search API uses a different rate limit
+            return;
+        }
+        String limit = uc.getHeaderField("X-RateLimit-Limit");
+        if (StringUtils.isBlank(limit)) {
+            // if we are missing a header, return fast
+            return;
+        }
+        String remaining = uc.getHeaderField("X-RateLimit-Remaining");
+        if (StringUtils.isBlank(remaining)) {
+            // if we are missing a header, return fast
+            return;
+        }
+        String reset = uc.getHeaderField("X-RateLimit-Reset");
+        if (StringUtils.isBlank(reset)) {
+            // if we are missing a header, return fast
+            return;
+        }
+        GHRateLimit observed = new GHRateLimit();
+        try {
+            observed.limit = Integer.parseInt(limit);
+        } catch (NumberFormatException e) {
+            if (LOGGER.isLoggable(FINEST)) {
+                LOGGER.log(FINEST, "Malformed X-RateLimit-Limit header value " + limit, e);
+            }
+            return;
+        }
+        try {
+            observed.remaining = Integer.parseInt(remaining);
+        } catch (NumberFormatException e) {
+            if (LOGGER.isLoggable(FINEST)) {
+                LOGGER.log(FINEST, "Malformed X-RateLimit-Remaining header value " + remaining, e);
+            }
+            return;
+        }
+        try {
+            observed.reset = new Date(Long.parseLong(reset)); // this is madness, storing the date as seconds
+            root.updateRateLimit(observed);
+        } catch (NumberFormatException e) {
+            if (LOGGER.isLoggable(FINEST)) {
+                LOGGER.log(FINEST, "Malformed X-RateLimit-Reset header value " + reset, e);
+            }
+        }
+    }
+
+    public String getResponseHeader(String header) {
+        return uc.getHeaderField(header);
+    }
+
+
+    /**
+     * Set up the request parameters or POST payload.
+     */
+    private void buildRequest() throws IOException {
+        if (isMethodWithBody()) {
+            uc.setDoOutput(true);
+
+            if (body == null) {
+                uc.setRequestProperty("Content-type", defaultString(contentType,"application/json"));
+                Map json = new HashMap();
+                for (Entry e : args) {
+                    json.put(e.key, e.value);
+                }
+                MAPPER.writeValue(uc.getOutputStream(), json);
+            } else {
+                uc.setRequestProperty("Content-type", defaultString(contentType,"application/x-www-form-urlencoded"));
+                try {
+                    byte[] bytes = new byte[32768];
+                    int read;
+                    while ((read = body.read(bytes)) != -1) {
+                        uc.getOutputStream().write(bytes, 0, read);
+                    }
+                } finally {
+                    body.close();
+                }
+            }
+        }
+    }
+
+    private boolean isMethodWithBody() {
+        return forceBody || !METHODS_WITHOUT_BODY.contains(method);
+    }
+
+    public <T> PagedIterable<T> asPagedIterable(String tailApiUrl, Class<T[]> type, Consumer<T> consumer) {
+        return new PagedIterableWithConsumer(type, this, tailApiUrl, consumer);
+    }
+
+    private static class PagedIterableWithConsumer<S> extends PagedIterable<S> {
+
+        private final Class<S[]> clazz;
+        private final RequesterImpl requester;
+        private final String tailApiUrl;
+        private final Consumer<S> consumer;
+
+        public PagedIterableWithConsumer(Class<S[]> clazz, RequesterImpl requester, String tailApiUrl, Consumer<S> consumer) {
+            this.clazz = clazz;
+            this.tailApiUrl = tailApiUrl;
+            this.requester = requester;
+            this.consumer = consumer;
+        }
+
+        @Override
+        public PagedIterator<S> _iterator(int pageSize) {
+            final Iterator<S[]> iterator = requester.asIterator(tailApiUrl, clazz, pageSize);
+            return new PagedIterator<S>(iterator) {
+                @Override
+                protected void wrapUp(S[] page) {
+                    if (consumer != null) {
+                        for (S item : page) {
+                            consumer.accept(item);
+                        }
+                    }
+                }
+            };
+        }
+    }
+
+    /**
+     * Loads paginated resources.
+     *
+     * Every iterator call reports a new batch.
+     */
+    public <T> Iterator<T> asIterator(String tailApiUrl, Class<T> type, int pageSize) {
+        method("GET");
+
+        if (pageSize!=0)
+            args.add(new Entry("per_page",pageSize));
+
+        StringBuilder s = new StringBuilder(tailApiUrl);
+        if (!args.isEmpty()) {
+            boolean first = true;
+            try {
+                for (Entry a : args) {
+                    s.append(first ? '?' : '&');
+                    first = false;
+                    s.append(URLEncoder.encode(a.key, "UTF-8"));
+                    s.append('=');
+                    s.append(URLEncoder.encode(a.value.toString(), "UTF-8"));
+                }
+            } catch (UnsupportedEncodingException e) {
+                throw new AssertionError(e);    // UTF-8 is mandatory
+            }
+        }
+
+        try {
+            return new PagingIterator<T>(type, tailApiUrl, root.getApiURL(s.toString()));
+        } catch (IOException e) {
+            throw new GHException("Unable to build github Api URL",e);
+        }
+    }
+
+    private class PagingIterator<T> implements Iterator<T> {
+
+        private final Class<T> type;
+        private final String tailApiUrl;
+
+        /**
+         * The next batch to be returned from {@link #next()}.
+         */
+        private T next;
+
+        /**
+         * URL of the next resource to be retrieved, or null if no more data is available.
+         */
+        private URL url;
+
+        PagingIterator(Class<T> type, String tailApiUrl, URL url) {
+            this.type = type;
+            this.tailApiUrl = tailApiUrl;
+            this.url = url;
+        }
+
+        public boolean hasNext() {
+            fetch();
+            return next!=null;
+        }
+
+        public T next() {
+            fetch();
+            T r = next;
+            if (r==null)    throw new NoSuchElementException();
+            next = null;
+            return r;
+        }
+
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        private void fetch() {
+            if (next!=null) return; // already fetched
+            if (url==null)  return; // no more data to fetch
+
+            try {
+                while (true) {// loop while API rate limit is hit
+                    setupConnection(url);
+                    try {
+                        next = parse(type,null);
+                        assert next!=null;
+                        findNextURL();
+                        return;
+                    } catch (IOException e) {
+                        handleApiError(e);
+                    } finally {
+                        noteRateLimit(tailApiUrl);
+                    }
+                }
+            } catch (IOException e) {
+                throw new GHException("Failed to retrieve " + url, e);
+            }
+        }
+
+        /**
+         * Locate the next page from the pagination "Link" tag.
+         */
+        private void findNextURL() throws MalformedURLException {
+            url = null; // start defensively
+            String link = uc.getHeaderField("Link");
+            if (link==null) return;
+
+            for (String token : link.split(", ")) {
+                if (token.endsWith("rel=\"next\"")) {
+                    // found the next page. This should look something like
+                    // <https://api.github.com/repos?page=3&per_page=100>; rel="next"
+                    int idx = token.indexOf('>');
+                    url = new URL(token.substring(1,idx));
+                    return;
+                }
+            }
+
+            // no more "next" link. we are done.
+        }
+    }
+
+
+    private void setupConnection(URL url) throws IOException {
+        if (LOGGER.isLoggable(FINE)) {
+            LOGGER.log(FINE, "GitHub API request [" + (root.login == null ? "anonymous" : root.login) + "]: " + method + " " + url.toString());
+        }
+        uc = root.getConnector().connect(url);
+
+        // if the authentication is needed but no credential is given, try it anyway (so that some calls
+        // that do work with anonymous access in the reduced form should still work.)
+        if (root.encodedAuthorization!=null)
+            uc.setRequestProperty("Authorization", root.encodedAuthorization);
+
+        for (Map.Entry<String, String> e : headers.entrySet()) {
+            String v = e.getValue();
+            if (v!=null)
+                uc.setRequestProperty(e.getKey(), v);
+        }
+
+        setRequestMethod(uc);
+        uc.setRequestProperty("Accept-Encoding", "gzip");
+    }
+
+    private void setRequestMethod(HttpURLConnection uc) throws IOException {
+        try {
+            uc.setRequestMethod(method);
+        } catch (ProtocolException e) {
+            // JDK only allows one of the fixed set of verbs. Try to override that
+            try {
+                Field $method = HttpURLConnection.class.getDeclaredField("method");
+                $method.setAccessible(true);
+                $method.set(uc,method);
+            } catch (Exception x) {
+                throw (IOException)new IOException("Failed to set the custom verb").initCause(x);
+            }
+            // sun.net.www.protocol.https.DelegatingHttpsURLConnection delegates to another HttpURLConnection
+            try {
+                Field $delegate = uc.getClass().getDeclaredField("delegate");
+                $delegate.setAccessible(true);
+                Object delegate = $delegate.get(uc);
+                if (delegate instanceof HttpURLConnection) {
+                    HttpURLConnection nested = (HttpURLConnection) delegate;
+                    setRequestMethod(nested);
+                }
+            } catch (NoSuchFieldException x) {
+                // no problem
+            } catch (IllegalAccessException x) {
+                throw (IOException)new IOException("Failed to set the custom verb").initCause(x);
+            }
+        }
+        if (!uc.getRequestMethod().equals(method))
+            throw new IllegalStateException("Failed to set the request method to "+method);
+    }
+
+    @CheckForNull
+    private <T> T parse(Class<T> type, T instance) throws IOException {
+        return parse(type, instance, 2);
+    }
+
+    private <T> T parse(Class<T> type, T instance, int timeouts) throws IOException {
+        InputStreamReader r = null;
+        int responseCode = -1;
+        String responseMessage = null;
+        try {
+            responseCode = uc.getResponseCode();
+            responseMessage = uc.getResponseMessage();
+            if (responseCode == 304) {
+                return null;    // special case handling for 304 unmodified, as the content will be ""
+            }
+            if (responseCode == 204 && type!=null && type.isArray()) {
+                // no content
+                return type.cast(Array.newInstance(type.getComponentType(),0));
+            }
+
+            // Response code 202 means the statistics are still being cached.
+            // See https://developer.github.com/v3/repos/statistics/#a-word-about-caching
+            if (responseCode == 202) {
+                LOGGER.log(INFO, "The statistics are still being generated. Please try again in 5 seconds.");
+                // Maybe throw an exception instead?
+                return null;
+            }
+
+            r = new InputStreamReader(wrapStream(uc.getInputStream()), "UTF-8");
+            String data = IOUtils.toString(r);
+            if (type!=null)
+                try {
+                    return setResponseHeaders(MAPPER.readValue(data, type));
+                } catch (JsonMappingException e) {
+                    throw (IOException)new IOException("Failed to deserialize " +data).initCause(e);
+                }
+            if (instance!=null) {
+                return setResponseHeaders(MAPPER.readerForUpdating(instance).<T>readValue(data));
+            }
+            return null;
+        } catch (FileNotFoundException e) {
+            // java.net.URLConnection handles 404 exception has FileNotFoundException, don't wrap exception in HttpException
+            // to preserve backward compatibility
+            throw e;
+        } catch (IOException e) {
+            if (e instanceof SocketTimeoutException && timeouts > 0) {
+                LOGGER.log(INFO, "timed out accessing " + uc.getURL() + "; will try " + timeouts + " more time(s)", e);
+                return parse(type, instance, timeouts - 1);
+            }
+            throw new HttpException(responseCode, responseMessage, uc.getURL(), e);
+        } finally {
+            IOUtils.closeQuietly(r);
+        }
+    }
+
+    private <T> T setResponseHeaders(T readValue) {
+        if (readValue instanceof GHObject[]) {
+            for (GHObject ghObject : (GHObject[]) readValue) {
+                setResponseHeaders(ghObject);
+            }
+        } else if (readValue instanceof GHObject) {
+            setResponseHeaders((GHObject) readValue);
+        }
+        return readValue;
+    }
+
+    private void setResponseHeaders(GHObject readValue) {
+        readValue.responseHeaderFields = uc.getHeaderFields();
+    }
+
+    /**
+     * Handles the "Content-Encoding" header.
+     */
+    private InputStream wrapStream(InputStream in) throws IOException {
+        String encoding = uc.getContentEncoding();
+        if (encoding==null || in==null) return in;
+        if (encoding.equals("gzip"))    return new GZIPInputStream(in);
+
+        throw new UnsupportedOperationException("Unexpected Content-Encoding: "+encoding);
+    }
+
+    /**
+     * Handle API error by either throwing it or by returning normally to retry.
+     */
+    /*package*/ void handleApiError(IOException e) throws IOException {
+        int responseCode;
+        try {
+            responseCode = uc.getResponseCode();
+        } catch (IOException e2) {
+            // likely to be a network exception (e.g. SSLHandshakeException),
+            // uc.getResponseCode() and any other getter on the response will cause an exception
+            if (LOGGER.isLoggable(FINE))
+                LOGGER.log(FINE, "Silently ignore exception retrieving response code for '" + uc.getURL() + "'" +
+                        " handling exception " + e, e);
+            throw e;
+        }
+        InputStream es = wrapStream(uc.getErrorStream());
+        if (es != null) {
+            try {
+                String error = IOUtils.toString(es, "UTF-8");
+                if (e instanceof FileNotFoundException) {
+                    // pass through 404 Not Found to allow the caller to handle it intelligently
+                    e = (IOException) new GHFileNotFoundException(error).withResponseHeaderFields(uc).initCause(e);
+                } else if (e instanceof HttpException) {
+                    HttpException http = (HttpException) e;
+                    e = new HttpException(error, http.getResponseCode(), http.getResponseMessage(),
+                            http.getUrl(), e);
+                } else {
+                    e = (IOException) new GHIOException(error).withResponseHeaderFields(uc).initCause(e);
+                }
+            } finally {
+                IOUtils.closeQuietly(es);
+            }
+        }
+        if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) // 401 / Unauthorized == bad creds
+            throw e;
+
+        if ("0".equals(uc.getHeaderField("X-RateLimit-Remaining"))) {
+            root.rateLimitHandler.onError(e,uc);
+            return;
+        }
+
+        // Retry-After is not documented but apparently that field exists
+        if (responseCode == HttpURLConnection.HTTP_FORBIDDEN &&
+            uc.getHeaderField("Retry-After") != null) {
+            this.root.abuseLimitHandler.onError(e,uc);
+            return;
+        }
+
+        throw e;
+    }
+
+    /**
+     * Transform Java Enum into Github constants given its conventions
+     * @param en - Enum to be transformed
+     * @return a String containing the value of a Github constant
+     */
+    private String transformEnum(Enum en){
+        // by convention Java constant names are upper cases, but github uses
+        // lower-case constants. GitHub also uses '-', which in Java we always
+        // replace by '_'
+        return en.toString().toLowerCase(Locale.ENGLISH).replace('_', '-');
+    }
+
+    private static final List<String> METHODS_WITHOUT_BODY = asList("GET", "DELETE");
+    private static final Logger LOGGER = Logger.getLogger(RequesterImpl.class.getName());
+}

--- a/src/main/java/org/kohsuke/github/extras/okhttp3/ObsoleteUrlFactory.java
+++ b/src/main/java/org/kohsuke/github/extras/okhttp3/ObsoleteUrlFactory.java
@@ -201,12 +201,8 @@ public final class ObsoleteUrlFactory implements URLStreamHandlerFactory, Clonea
 
     // If the Content-Length or Transfer-Encoding headers disagree with the response code, the
     // response is malformed. For best compatibility, we honor the headers.
-    if (contentLength(response.headers()) != -1
-        || "chunked".equalsIgnoreCase(response.header("Transfer-Encoding"))) {
-      return true;
-    }
-
-    return false;
+    return contentLength(response.headers()) != -1
+        || "chunked".equalsIgnoreCase(response.header("Transfer-Encoding"));
   }
 
   static long contentLength(Headers headers) {


### PR DESCRIPTION
Initial proof of concept for #513. 

Doing this did help me clean up some odd rough edges in Requester, so I can see some advantages to making this part of the library more user facing and productized.  

At the same time, I think I'd probably still want to mark the `createRequester()` in such a way as to make it clear that anything that comes out of that method may change at any time.

- [ ] Tests.  Lots of tests.
- [ ] Change name of `Requester` to `GitHubRequest`? 
- [ ] Move `Requester` to `internals` package?  - again to make it clear this is available but not supported.

 