### PR TITLE
JacksonInject POC

### DIFF
--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -102,7 +102,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public PagedIterable<GHAppInstallation> listInstallations() {
-        return getRoot().retrieve().withPreview(MACHINE_MAN)
+        return getRoot().createRequest().method("GET").withPreview(MACHINE_MAN)
             .asPagedIterable(
                 "/app/installations",
                 GHAppInstallation[].class);
@@ -118,7 +118,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationById(long id) throws IOException {
-        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/app/installations/%d", id), GHAppInstallation.class);
+        return getRoot().createRequest().method("GET").withPreview(MACHINE_MAN).to(String.format("/app/installations/%d", id), GHAppInstallation.class);
     }
 
     /**
@@ -131,7 +131,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationByOrganization(String name) throws IOException {
-        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/orgs/%s/installation", name), GHAppInstallation.class);
+        return getRoot().createRequest().method("GET").withPreview(MACHINE_MAN).to(String.format("/orgs/%s/installation", name), GHAppInstallation.class);
     }
 
     /**
@@ -145,7 +145,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationByRepository(String ownerName, String repositoryName) throws IOException {
-        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/repos/%s/%s/installation", ownerName, repositoryName), GHAppInstallation.class);
+        return getRoot().createRequest().method("GET").withPreview(MACHINE_MAN).to(String.format("/repos/%s/%s/installation", ownerName, repositoryName), GHAppInstallation.class);
     }
 
     /**
@@ -158,7 +158,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationByUser(String name) throws IOException {
-        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/users/%s/installation", name), GHAppInstallation.class);
+        return getRoot().createRequest().method("GET").withPreview(MACHINE_MAN).to(String.format("/users/%s/installation", name), GHAppInstallation.class);
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -109,8 +109,7 @@ public class GHApp extends GHObject {
         return getRoot().retrieve().withPreview(MACHINE_MAN)
             .asPagedIterable(
                 "/app/installations",
-                GHAppInstallation[].class,
-                item -> item.wrapUp(getRoot()) );
+                GHAppInstallation[].class);
     }
 
     /**
@@ -123,7 +122,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationById(long id) throws IOException {
-        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/app/installations/%d", id), GHAppInstallation.class).wrapUp(getRoot());
+        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/app/installations/%d", id), GHAppInstallation.class);
     }
 
     /**
@@ -136,7 +135,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationByOrganization(String name) throws IOException {
-        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/orgs/%s/installation", name), GHAppInstallation.class).wrapUp(getRoot());
+        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/orgs/%s/installation", name), GHAppInstallation.class);
     }
 
     /**
@@ -150,7 +149,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationByRepository(String ownerName, String repositoryName) throws IOException {
-        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/repos/%s/%s/installation", ownerName, repositoryName), GHAppInstallation.class).wrapUp(getRoot());
+        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/repos/%s/%s/installation", ownerName, repositoryName), GHAppInstallation.class);
     }
 
     /**
@@ -163,7 +162,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationByUser(String name) throws IOException {
-        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/users/%s/installation", name), GHAppInstallation.class).wrapUp(getRoot());
+        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/users/%s/installation", name), GHAppInstallation.class);
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -93,7 +93,6 @@ public class GHApp extends GHObject {
     }
 
     /*package*/ GHApp wrapUp(GitHub root) {
-        this.root = root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -19,7 +19,6 @@ import static org.kohsuke.github.Previews.MACHINE_MAN;
 
 public class GHApp extends GHObject {
 
-    private GitHub root;
     private GHUser owner;
     private String name;
     private String description;

--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -92,10 +92,6 @@ public class GHApp extends GHObject {
         this.permissions = permissions;
     }
 
-    /*package*/ GHApp wrapUp(GitHub root) {
-        return this;
-    }
-
     /**
      * Obtains all the installations associated with this app.
      *

--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -106,11 +106,11 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public PagedIterable<GHAppInstallation> listInstallations() {
-        return root.retrieve().withPreview(MACHINE_MAN)
+        return getRoot().retrieve().withPreview(MACHINE_MAN)
             .asPagedIterable(
                 "/app/installations",
                 GHAppInstallation[].class,
-                item -> item.wrapUp(root) );
+                item -> item.wrapUp(getRoot()) );
     }
 
     /**
@@ -123,7 +123,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationById(long id) throws IOException {
-        return root.retrieve().withPreview(MACHINE_MAN).to(String.format("/app/installations/%d", id), GHAppInstallation.class).wrapUp(root);
+        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/app/installations/%d", id), GHAppInstallation.class).wrapUp(getRoot());
     }
 
     /**
@@ -136,7 +136,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationByOrganization(String name) throws IOException {
-        return root.retrieve().withPreview(MACHINE_MAN).to(String.format("/orgs/%s/installation", name), GHAppInstallation.class).wrapUp(root);
+        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/orgs/%s/installation", name), GHAppInstallation.class).wrapUp(getRoot());
     }
 
     /**
@@ -150,7 +150,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationByRepository(String ownerName, String repositoryName) throws IOException {
-        return root.retrieve().withPreview(MACHINE_MAN).to(String.format("/repos/%s/%s/installation", ownerName, repositoryName), GHAppInstallation.class).wrapUp(root);
+        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/repos/%s/%s/installation", ownerName, repositoryName), GHAppInstallation.class).wrapUp(getRoot());
     }
 
     /**
@@ -163,7 +163,7 @@ public class GHApp extends GHObject {
      */
     @Preview @Deprecated
     public GHAppInstallation getInstallationByUser(String name) throws IOException {
-        return root.retrieve().withPreview(MACHINE_MAN).to(String.format("/users/%s/installation", name), GHAppInstallation.class).wrapUp(root);
+        return getRoot().retrieve().withPreview(MACHINE_MAN).to(String.format("/users/%s/installation", name), GHAppInstallation.class).wrapUp(getRoot());
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
@@ -46,7 +46,7 @@ public class GHAppCreateTokenBuilder extends GHObjectBase {
      */
     @Preview @Deprecated
     public GHAppInstallationToken create() throws IOException {
-        return builder.method("POST").withPreview(MACHINE_MAN).to(apiUrlTail, GHAppInstallationToken.class).wrapUp(getRoot());
+        return builder.method("POST").withPreview(MACHINE_MAN).to(apiUrlTail, GHAppInstallationToken.class);
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
@@ -13,8 +13,7 @@ import static org.kohsuke.github.Previews.MACHINE_MAN;
  *
  * @see GHAppInstallation#createToken(Map)
  */
-public class GHAppCreateTokenBuilder {
-    private final GitHub root;
+public class GHAppCreateTokenBuilder extends GHObjectBase {
     protected final Requester builder;
     private final String apiUrlTail;
 

--- a/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
@@ -46,7 +46,7 @@ public class GHAppCreateTokenBuilder extends GHObjectBase {
      */
     @Preview @Deprecated
     public GHAppInstallationToken create() throws IOException {
-        return builder.method("POST").withPreview(MACHINE_MAN).to(apiUrlTail, GHAppInstallationToken.class).wrapUp(root);
+        return builder.method("POST").withPreview(MACHINE_MAN).to(apiUrlTail, GHAppInstallationToken.class).wrapUp(getRoot());
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
@@ -19,7 +19,7 @@ public class GHAppCreateTokenBuilder extends GHObjectBase {
 
     @Preview @Deprecated
     /*package*/ GHAppCreateTokenBuilder(GitHub root, String apiUrlTail, Map<String, GHPermissionType> permissions) {
-        this.root = root;
+        super(root);
         this.apiUrlTail = apiUrlTail;
         this.builder = new Requester(root);
         this.builder.withPermissions("permissions",permissions);

--- a/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHAppCreateTokenBuilder.java
@@ -21,7 +21,7 @@ public class GHAppCreateTokenBuilder extends GHObjectBase {
     /*package*/ GHAppCreateTokenBuilder(GitHub root, String apiUrlTail, Map<String, GHPermissionType> permissions) {
         super(root);
         this.apiUrlTail = apiUrlTail;
-        this.builder = new Requester(root);
+        this.builder = root.createRequest();
         this.builder.withPermissions("permissions",permissions);
     }
 

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -22,7 +22,6 @@ import static org.kohsuke.github.Previews.GAMBIT;
  */
 
 public class GHAppInstallation extends GHObject {
-    private GitHub root;
     private GHUser account;
 
     @JsonProperty("access_tokens_url")

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -51,7 +51,13 @@ public class GHAppInstallation extends GHObject {
         return super.getRoot();
     }
 
+    /**
+     * Sets the root {@link GitHub} instance.
+     * @param root a {@link GitHub} instance
+     * @deprecated No one should be setting the root from outside.
+     */
     @Override
+    @Deprecated
     public void setRoot(GitHub root) {
         //TODO: needs fixing
         //this.root = root;

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -153,7 +153,7 @@ public class GHAppInstallation extends GHObject {
      */
     @Preview @Deprecated
     public void deleteInstallation() throws IOException {
-        getRoot().retrieve().method("DELETE").withPreview(GAMBIT).to(String.format("/app/installations/%d", id));
+        getRoot().createRequest().method("GET").method("DELETE").withPreview(GAMBIT).to(String.format("/app/installations/%d", id));
     }
 
 

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -153,7 +153,7 @@ public class GHAppInstallation extends GHObject {
      */
     @Preview @Deprecated
     public void deleteInstallation() throws IOException {
-        getRoot().createRequest().method("GET").method("DELETE").withPreview(GAMBIT).to(String.format("/app/installations/%d", id));
+        getRoot().createRequest().method("DELETE").withPreview(GAMBIT).to(String.format("/app/installations/%d", id));
     }
 
 

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -51,7 +51,8 @@ public class GHAppInstallation extends GHObject {
     }
 
     public void setRoot(GitHub root) {
-        this.root = root;
+        //TODO: needs fixing
+        //this.root = root;
     }
 
     public GHUser getAccount() {
@@ -135,7 +136,6 @@ public class GHAppInstallation extends GHObject {
     }
 
     /*package*/ GHAppInstallation wrapUp(GitHub root) {
-        this.root = root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -138,10 +138,6 @@ public class GHAppInstallation extends GHObject {
         this.repositorySelection = repositorySelection;
     }
 
-    /*package*/ GHAppInstallation wrapUp(GitHub root) {
-        return this;
-    }
-
     /**
      * Delete a Github App installation
      *

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -46,13 +46,16 @@ public class GHAppInstallation extends GHObject {
         return GitHub.parseURL(htmlUrl);
     }
 
+    @Override
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
+    @Override
     public void setRoot(GitHub root) {
         //TODO: needs fixing
         //this.root = root;
+        super.setRoot(root);
     }
 
     public GHUser getAccount() {
@@ -148,7 +151,7 @@ public class GHAppInstallation extends GHObject {
      */
     @Preview @Deprecated
     public void deleteInstallation() throws IOException {
-        root.retrieve().method("DELETE").withPreview(GAMBIT).to(String.format("/app/installations/%d", id));
+        getRoot().retrieve().method("DELETE").withPreview(GAMBIT).to(String.format("/app/installations/%d", id));
     }
 
 
@@ -161,6 +164,6 @@ public class GHAppInstallation extends GHObject {
      */
     @Preview @Deprecated
     public GHAppCreateTokenBuilder createToken(Map<String,GHPermissionType> permissions){
-        return new GHAppCreateTokenBuilder(root,String.format("/app/installations/%d/access_tokens", id), permissions);
+        return new GHAppCreateTokenBuilder(getRoot(),String.format("/app/installations/%d/access_tokens", id), permissions);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
@@ -82,8 +82,4 @@ public class GHAppInstallationToken extends GHObjectBase{
     private Object expiresAtStr(Date id, Class type) {
         return expires_at;
     }
-
-    /*package*/ GHAppInstallationToken wrapUp(GitHub root) {
-        return this;
-    }
 }

--- a/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
@@ -17,8 +17,7 @@ import java.util.Map;
  * @see GHAppInstallation#createToken(Map)
  */
 
-public class GHAppInstallationToken {
-    private GitHub root;
+public class GHAppInstallationToken extends GHObjectBase{
 
     private String token;
     protected String expires_at;

--- a/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
@@ -26,12 +26,15 @@ public class GHAppInstallationToken extends GHObjectBase{
     @JsonProperty("repository_selection")
     private GHRepositorySelection repositorySelection;
 
+
+
     public GitHub getRoot() {
         return root;
     }
 
     public void setRoot(GitHub root) {
-        this.root = root;
+        //TODO: needs fixing
+        //this.root = root;
     }
 
     public Map<String, String> getPermissions() {
@@ -80,7 +83,6 @@ public class GHAppInstallationToken extends GHObjectBase{
     }
 
     /*package*/ GHAppInstallationToken wrapUp(GitHub root) {
-        this.root = root;
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
@@ -26,15 +26,16 @@ public class GHAppInstallationToken extends GHObjectBase{
     @JsonProperty("repository_selection")
     private GHRepositorySelection repositorySelection;
 
-
-
+    @Override
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
+    @Override
     public void setRoot(GitHub root) {
         //TODO: needs fixing
         //this.root = root;
+        super.setRoot(root);
     }
 
     public Map<String, String> getPermissions() {

--- a/src/main/java/org/kohsuke/github/GHAsset.java
+++ b/src/main/java/org/kohsuke/github/GHAsset.java
@@ -73,11 +73,11 @@ public class GHAsset extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(getRoot())._with(key, value).method("PATCH").to(getApiRoute());
+        createRequest()._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     public void delete() throws IOException {
-        new Requester(getRoot()).method("DELETE").to(getApiRoute());
+        createRequest().method("DELETE").to(getApiRoute());
     }
 
 

--- a/src/main/java/org/kohsuke/github/GHAsset.java
+++ b/src/main/java/org/kohsuke/github/GHAsset.java
@@ -49,7 +49,7 @@ public class GHAsset extends GHObject {
     }
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
     public long getSize() {
@@ -73,11 +73,11 @@ public class GHAsset extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(root)._with(key, value).method("PATCH").to(getApiRoute());
+        new Requester(getRoot())._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").to(getApiRoute());
+        new Requester(getRoot()).method("DELETE").to(getApiRoute());
     }
 
 

--- a/src/main/java/org/kohsuke/github/GHAsset.java
+++ b/src/main/java/org/kohsuke/github/GHAsset.java
@@ -9,7 +9,6 @@ import java.net.URL;
  * @see GHRelease#getAssets()
  */
 public class GHAsset extends GHObject {
-    GitHub root;
     GHRepository owner;
     private String name;
     private String label;

--- a/src/main/java/org/kohsuke/github/GHAsset.java
+++ b/src/main/java/org/kohsuke/github/GHAsset.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+
 import java.io.IOException;
 import java.net.URL;
 
@@ -9,6 +11,8 @@ import java.net.URL;
  * @see GHRelease#getAssets()
  */
 public class GHAsset extends GHObject {
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     GHRepository owner;
     private String name;
     private String label;

--- a/src/main/java/org/kohsuke/github/GHAsset.java
+++ b/src/main/java/org/kohsuke/github/GHAsset.java
@@ -87,7 +87,6 @@ public class GHAsset extends GHObject {
 
     GHAsset wrap(GHRelease release) {
         this.owner = release.getOwner();
-        this.root = owner.root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHAuthorization.java
+++ b/src/main/java/org/kohsuke/github/GHAuthorization.java
@@ -99,7 +99,6 @@ public class GHAuthorization extends GHObject {
     }
 
     /*package*/ GHAuthorization wrap(GitHub root) {
-        this.root = root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHAuthorization.java
+++ b/src/main/java/org/kohsuke/github/GHAuthorization.java
@@ -33,7 +33,6 @@ public class GHAuthorization extends GHObject {
     public static final String WRITE_KEY = "write:public_key";
     public static final String ADMIN_KEY = "admin:public_key";
 
-    private GitHub root;
     private List<String> scopes;
     private String token;
     private String token_last_eight;

--- a/src/main/java/org/kohsuke/github/GHAuthorization.java
+++ b/src/main/java/org/kohsuke/github/GHAuthorization.java
@@ -45,7 +45,7 @@ public class GHAuthorization extends GHObject {
     //private GHUser user;
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
     public List<String> getScopes() {

--- a/src/main/java/org/kohsuke/github/GHAuthorization.java
+++ b/src/main/java/org/kohsuke/github/GHAuthorization.java
@@ -98,10 +98,6 @@ public class GHAuthorization extends GHObject {
         return fingerprint;
     }
 
-    /*package*/ GHAuthorization wrap(GitHub root) {
-        return this;
-    }
-
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD"}, 
         justification = "JSON API")
     private static class App {

--- a/src/main/java/org/kohsuke/github/GHBlobBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHBlobBuilder.java
@@ -14,7 +14,7 @@ public class GHBlobBuilder {
 
     GHBlobBuilder(GHRepository repo) {
         this.repo = repo;
-        req = new Requester(repo.root);
+        req = new Requester(repo.getRoot());
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHBlobBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHBlobBuilder.java
@@ -14,7 +14,7 @@ public class GHBlobBuilder {
 
     GHBlobBuilder(GHRepository repo) {
         this.repo = repo;
-        req = new Requester(repo.getRoot());
+        req = repo.createRequest();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHBranch.java
+++ b/src/main/java/org/kohsuke/github/GHBranch.java
@@ -16,8 +16,7 @@ import static org.kohsuke.github.Previews.*;
  */
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
     "NP_UNWRITTEN_FIELD", "URF_UNREAD_FIELD"}, justification = "JSON API")
-public class GHBranch {
-    private GitHub root;
+public class GHBranch extends GHObjectBase {
     private GHRepository owner;
 
     private String name;

--- a/src/main/java/org/kohsuke/github/GHBranch.java
+++ b/src/main/java/org/kohsuke/github/GHBranch.java
@@ -77,7 +77,7 @@ public class GHBranch extends GHObjectBase {
      * Disables branch protection and allows anyone with push access to push changes.
      */
     public void disableProtection() throws IOException {
-        new Requester(super.getRoot()).method("DELETE").to(protection_url);
+        createRequest().method("DELETE").to(protection_url);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHBranch.java
+++ b/src/main/java/org/kohsuke/github/GHBranch.java
@@ -7,8 +7,6 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Collection;
 
-import static org.kohsuke.github.Previews.*;
-
 /**
  * A branch in a repository.
  *
@@ -34,7 +32,7 @@ public class GHBranch extends GHObjectBase {
     }
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
     /**
@@ -65,7 +63,7 @@ public class GHBranch extends GHObjectBase {
     }
 
     public GHBranchProtection getProtection() throws IOException {
-        return root.retrieve().to(protection_url, GHBranchProtection.class).wrap(this);
+        return super.getRoot().retrieve().to(protection_url, GHBranchProtection.class).wrap(this);
     }
 
     /**
@@ -79,7 +77,7 @@ public class GHBranch extends GHObjectBase {
      * Disables branch protection and allows anyone with push access to push changes.
      */
     public void disableProtection() throws IOException {
-        new Requester(root).method("DELETE").to(protection_url);
+        new Requester(super.getRoot()).method("DELETE").to(protection_url);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHBranch.java
+++ b/src/main/java/org/kohsuke/github/GHBranch.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -15,6 +16,8 @@ import java.util.Collection;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
     "NP_UNWRITTEN_FIELD", "URF_UNREAD_FIELD"}, justification = "JSON API")
 public class GHBranch extends GHObjectBase {
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     private GHRepository owner;
 
     private String name;
@@ -63,7 +66,7 @@ public class GHBranch extends GHObjectBase {
     }
 
     public GHBranchProtection getProtection() throws IOException {
-        return super.getRoot().retrieve().to(protection_url, GHBranchProtection.class).wrap(this);
+        return super.getRoot().createRequest().method("GET").to(protection_url, GHBranchProtection.class).wrap(this);
     }
 
     /**
@@ -115,10 +118,5 @@ public class GHBranch extends GHObjectBase {
     public String toString() {
         final String url = owner != null ? owner.getUrl().toString() : "unknown";
         return "Branch:" + name + " in " + url;
-    }
-
-    /*package*/ GHBranch wrap(GHRepository repo) {
-        this.owner = repo;
-        return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHBranch.java
+++ b/src/main/java/org/kohsuke/github/GHBranch.java
@@ -121,7 +121,6 @@ public class GHBranch extends GHObjectBase {
 
     /*package*/ GHBranch wrap(GHRepository repo) {
         this.owner = repo;
-        this.root = repo.root;
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHBranchProtection.java
+++ b/src/main/java/org/kohsuke/github/GHBranchProtection.java
@@ -68,7 +68,6 @@ public class GHBranchProtection extends GHObjectBase {
     }
 
     GHBranchProtection wrap(GHBranch branch) {
-        this.root = branch.getRoot();
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHBranchProtection.java
+++ b/src/main/java/org/kohsuke/github/GHBranchProtection.java
@@ -72,7 +72,7 @@ public class GHBranchProtection extends GHObjectBase {
     }
 
     private Requester requester() {
-        return new Requester(getRoot()).withPreview(ZZZAX);
+        return createRequest().withPreview(ZZZAX);
     }
 
     public static class EnforceAdmins {

--- a/src/main/java/org/kohsuke/github/GHBranchProtection.java
+++ b/src/main/java/org/kohsuke/github/GHBranchProtection.java
@@ -72,7 +72,7 @@ public class GHBranchProtection extends GHObjectBase {
     }
 
     private Requester requester() {
-        return new Requester(root).withPreview(ZZZAX);
+        return new Requester(getRoot()).withPreview(ZZZAX);
     }
 
     public static class EnforceAdmins {

--- a/src/main/java/org/kohsuke/github/GHBranchProtection.java
+++ b/src/main/java/org/kohsuke/github/GHBranchProtection.java
@@ -10,13 +10,12 @@ import java.util.Collection;
 
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", "NP_UNWRITTEN_FIELD",
         "URF_UNREAD_FIELD"}, justification = "JSON API")
-public class GHBranchProtection {
+public class GHBranchProtection extends GHObjectBase {
     private static final String REQUIRE_SIGNATURES_URI = "/required_signatures";
 
     @JsonProperty("enforce_admins")
     private EnforceAdmins enforceAdmins;
 
-    private GitHub root;
 
     @JsonProperty("required_pull_request_reviews")
     private RequiredReviews requiredReviews;

--- a/src/main/java/org/kohsuke/github/GHBranchProtectionBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHBranchProtectionBuilder.java
@@ -203,7 +203,7 @@ public class GHBranchProtectionBuilder {
     }
 
     private Requester requester() {
-        return new Requester(branch.getRoot()).withPreview(LUKE_CAGE);
+        return branch.createRequest().withPreview(LUKE_CAGE);
     }
 
     private static class Restrictions {

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -320,14 +320,14 @@ public class GHCommit {
 
     private GHUser resolveUser(User author) throws IOException {
         if (author==null || author.login==null) return null;
-        return owner.root.getUser(author.login);
+        return owner.getRoot().getUser(author.login);
     }
 
     /**
      * Lists up all the commit comments in this repository.
      */
     public PagedIterable<GHCommitComment> listComments() {
-        return owner.root.retrieve()
+        return owner.getRoot().retrieve()
             .asPagedIterable(
                 String.format("/repos/%s/%s/commits/%s/comments", owner.getOwnerName(), owner.getName(), sha),
                 GHCommitComment[].class,
@@ -340,7 +340,7 @@ public class GHCommit {
      * I'm not sure how path/line/position parameters interact with each other.
      */
     public GHCommitComment createComment(String body, String path, Integer line, Integer position) throws IOException {
-        GHCommitComment r = new Requester(owner.root)
+        GHCommitComment r = new Requester(owner.getRoot())
                 .with("body",body)
                 .with("path",path)
                 .with("line",line)
@@ -372,7 +372,7 @@ public class GHCommit {
      */
     void populate() throws IOException {
         if (files==null && stats==null)
-            owner.root.retrieve().to(owner.getApiTailUrl("commits/" + sha), this);
+            owner.getRoot().retrieve().to(owner.getApiTailUrl("commits/" + sha), this);
     }
 
     GHCommit wrapUp(GHRepository owner) {

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -21,6 +22,8 @@ import java.util.List;
 @SuppressFBWarnings(value = {"NP_UNWRITTEN_FIELD", "UWF_UNWRITTEN_FIELD"}, 
         justification = "JSON API")
 public class GHCommit {
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     private GHRepository owner;
     
     private ShortInfo commit;
@@ -327,11 +330,10 @@ public class GHCommit {
      * Lists up all the commit comments in this repository.
      */
     public PagedIterable<GHCommitComment> listComments() {
-        return owner.getRoot().retrieve()
+        return owner.createRequest().method("GET")
             .asPagedIterable(
                 String.format("/repos/%s/%s/commits/%s/comments", owner.getOwnerName(), owner.getName(), sha),
-                GHCommitComment[].class,
-                item -> item.wrap(owner) );
+                GHCommitComment[].class);
     }
 
     /**
@@ -346,7 +348,7 @@ public class GHCommit {
                 .with("line",line)
                 .with("position",position)
                 .to(String.format("/repos/%s/%s/commits/%s/comments",owner.getOwnerName(),owner.getName(),sha),GHCommitComment.class);
-        return r.wrap(owner);
+        return r;
     }
 
     public GHCommitComment createComment(String body) throws IOException {
@@ -372,11 +374,6 @@ public class GHCommit {
      */
     void populate() throws IOException {
         if (files==null && stats==null)
-            owner.getRoot().retrieve().to(owner.getApiTailUrl("commits/" + sha), this);
-    }
-
-    GHCommit wrapUp(GHRepository owner) {
-        this.owner = owner;
-        return this;
+            owner.createRequest().method("GET").to(owner.getApiTailUrl("commits/" + sha), this);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHCommit.java
+++ b/src/main/java/org/kohsuke/github/GHCommit.java
@@ -340,7 +340,7 @@ public class GHCommit {
      * I'm not sure how path/line/position parameters interact with each other.
      */
     public GHCommitComment createComment(String body, String path, Integer line, Integer position) throws IOException {
-        GHCommitComment r = new Requester(owner.getRoot())
+        GHCommitComment r = owner.createRequest()
                 .with("body",body)
                 .with("path",path)
                 .with("line",line)

--- a/src/main/java/org/kohsuke/github/GHCommitBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitBuilder.java
@@ -35,7 +35,7 @@ public class GHCommitBuilder {
 
     GHCommitBuilder(GHRepository repo) {
         this.repo = repo;
-        req = new Requester(repo.root);
+        req = new Requester(repo.getRoot());
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCommitBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitBuilder.java
@@ -87,6 +87,6 @@ public class GHCommitBuilder {
      */
     public GHCommit create() throws IOException {
         req._with("parents", parents);
-        return req.method("POST").to(getApiTail(), GHCommit.class).wrapUp(repo);
+        return req.method("POST").to(getApiTail(), GHCommit.class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHCommitBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitBuilder.java
@@ -35,7 +35,7 @@ public class GHCommitBuilder {
 
     GHCommitBuilder(GHRepository repo) {
         this.repo = repo;
-        req = new Requester(repo.getRoot());
+        req = repo.createRequest();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCommitComment.java
+++ b/src/main/java/org/kohsuke/github/GHCommitComment.java
@@ -68,7 +68,7 @@ public class GHCommitComment extends GHObject implements Reactable {
      * Gets the user who put this comment.
      */
     public GHUser getUser() throws IOException {
-        return owner == null || owner.root.isOffline() ? user : owner.root.getUser(user.login);
+        return owner == null || owner.getRoot().isOffline() ? user : owner.getRoot().getUser(user.login);
     }
 
     /**
@@ -82,7 +82,7 @@ public class GHCommitComment extends GHObject implements Reactable {
      * Updates the body of the commit message.
      */
     public void update(String body) throws IOException {
-        new Requester(owner.root)
+        new Requester(owner.getRoot())
                 .with("body", body)
                 .method("PATCH").to(getApiTail(), GHCommitComment.class);
         this.body = body;
@@ -90,26 +90,26 @@ public class GHCommitComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.root)
+        return new Requester(owner.getRoot())
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
-                .to(getApiTail()+"/reactions", GHReaction.class).wrap(owner.root);
+                .to(getApiTail()+"/reactions", GHReaction.class).wrap(owner.getRoot());
     }
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return owner.root.retrieve().withPreview(SQUIRREL_GIRL)
+        return owner.getRoot().retrieve().withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiTail()+"/reactions",
                 GHReaction[].class,
-                item -> item.wrap(owner.root) );
+                item -> item.wrap(owner.getRoot()) );
     }
 
     /**
      * Deletes this comment.
      */
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE").to(getApiTail());
+        new Requester(owner.getRoot()).method("DELETE").to(getApiTail());
     }
 
     private String getApiTail() {
@@ -119,8 +119,8 @@ public class GHCommitComment extends GHObject implements Reactable {
 
     GHCommitComment wrap(GHRepository owner) {
         this.owner = owner;
-        if (owner.root.isOffline()) {
-            user.wrapUp(owner.root);
+        if (owner.getRoot().isOffline()) {
+            user.wrapUp(owner.getRoot());
         }
         return this;
     }

--- a/src/main/java/org/kohsuke/github/GHCommitComment.java
+++ b/src/main/java/org/kohsuke/github/GHCommitComment.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.IOException;
@@ -18,7 +19,9 @@ import static org.kohsuke.github.Previews.*;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
 public class GHCommitComment extends GHObject implements Reactable {
-    private GHRepository owner;
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
+    GHRepository owner;
 
     String body, html_url, commit_id;
     Integer line;
@@ -98,7 +101,7 @@ public class GHCommitComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return owner.getRoot().retrieve().withPreview(SQUIRREL_GIRL)
+        return createRequest().method("GET").withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiTail()+"/reactions",
                 GHReaction[].class);
@@ -113,10 +116,5 @@ public class GHCommitComment extends GHObject implements Reactable {
 
     private String getApiTail() {
         return String.format("/repos/%s/%s/comments/%s",owner.getOwnerName(),owner.getName(),id);
-    }
-
-    GHCommitComment wrap(GHRepository owner) {
-        this.owner = owner;
-        return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHCommitComment.java
+++ b/src/main/java/org/kohsuke/github/GHCommitComment.java
@@ -93,7 +93,7 @@ public class GHCommitComment extends GHObject implements Reactable {
         return new Requester(owner.getRoot())
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
-                .to(getApiTail()+"/reactions", GHReaction.class).wrap(owner.getRoot());
+                .to(getApiTail()+"/reactions", GHReaction.class);
     }
 
     @Preview @Deprecated
@@ -101,8 +101,7 @@ public class GHCommitComment extends GHObject implements Reactable {
         return owner.getRoot().retrieve().withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiTail()+"/reactions",
-                GHReaction[].class,
-                item -> item.wrap(owner.getRoot()) );
+                GHReaction[].class);
     }
 
     /**
@@ -116,12 +115,8 @@ public class GHCommitComment extends GHObject implements Reactable {
         return String.format("/repos/%s/%s/comments/%s",owner.getOwnerName(),owner.getName(),id);
     }
 
-
     GHCommitComment wrap(GHRepository owner) {
         this.owner = owner;
-        if (owner.getRoot().isOffline()) {
-            user.wrapUp(owner.getRoot());
-        }
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHCommitComment.java
+++ b/src/main/java/org/kohsuke/github/GHCommitComment.java
@@ -82,7 +82,7 @@ public class GHCommitComment extends GHObject implements Reactable {
      * Updates the body of the commit message.
      */
     public void update(String body) throws IOException {
-        new Requester(owner.getRoot())
+        owner.createRequest()
                 .with("body", body)
                 .method("PATCH").to(getApiTail(), GHCommitComment.class);
         this.body = body;
@@ -90,7 +90,7 @@ public class GHCommitComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.getRoot())
+        return owner.createRequest()
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
                 .to(getApiTail()+"/reactions", GHReaction.class);
@@ -108,7 +108,7 @@ public class GHCommitComment extends GHObject implements Reactable {
      * Deletes this comment.
      */
     public void delete() throws IOException {
-        new Requester(owner.getRoot()).method("DELETE").to(getApiTail());
+        owner.createRequest().method("DELETE").to(getApiTail());
     }
 
     private String getApiTail() {

--- a/src/main/java/org/kohsuke/github/GHCommitPointer.java
+++ b/src/main/java/org/kohsuke/github/GHCommitPointer.java
@@ -80,7 +80,6 @@ public class GHCommitPointer {
     }
 
     void wrapUp(GitHub root) {
-        if (user!=null) user.root = root;
         if (repo!=null) repo.wrap(root);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHCommitPointer.java
+++ b/src/main/java/org/kohsuke/github/GHCommitPointer.java
@@ -40,7 +40,7 @@ public class GHCommitPointer {
      * the {@link #getRepository()}.
      */
     public GHUser getUser() throws IOException {
-        if (user != null) return user.root.intern(user);
+        if (user != null) return user.getRoot().intern(user);
         return user;
     }
 

--- a/src/main/java/org/kohsuke/github/GHCommitPointer.java
+++ b/src/main/java/org/kohsuke/github/GHCommitPointer.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  *
  * @author Kohsuke Kawaguchi
  */
-public class GHCommitPointer {
+public class GHCommitPointer extends GHObjectBase {
     private String ref, sha, label;
     private GHUser user;
     private GHRepository repo;
@@ -77,9 +77,5 @@ public class GHCommitPointer {
      */
     public GHCommit getCommit() throws IOException {
         return getRepository().getCommit(getSha());
-    }
-
-    void wrapUp(GitHub root) {
-        if (repo!=null) repo.wrap(root);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
@@ -24,7 +24,7 @@ public class GHCommitQueryBuilder {
 
     /*package*/ GHCommitQueryBuilder(GHRepository repo) {
         this.repo = repo;
-        this.req = repo.getRoot().retrieve();    // requester to build up
+        this.req = repo.createRequest().method("GET");    // requester to build up
     }
 
     /**
@@ -94,7 +94,6 @@ public class GHCommitQueryBuilder {
         return req
             .asPagedIterable(
                 repo.getApiTailUrl("commits"),
-                GHCommit[].class,
-                item -> item.wrapUp(repo) );
+                GHCommit[].class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitQueryBuilder.java
@@ -24,7 +24,7 @@ public class GHCommitQueryBuilder {
 
     /*package*/ GHCommitQueryBuilder(GHRepository repo) {
         this.repo = repo;
-        this.req = repo.root.retrieve();    // requester to build up
+        this.req = repo.getRoot().retrieve();    // requester to build up
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHCommitSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCommitSearchBuilder.java
@@ -110,7 +110,8 @@ public class GHCommitSearchBuilder extends GHSearchBuilder<GHCommit> {
                 String repoName = getRepoName(commit.url);
                 try {
                     GHRepository repo = root.getRepository(repoName);
-                    commit.wrapUp(repo);
+                    // BUGBUG - late binding garbage
+                    // commit.wrapUp(repo);
                 } catch (IOException ioe) {}
             }
             return items;

--- a/src/main/java/org/kohsuke/github/GHCommitStatus.java
+++ b/src/main/java/org/kohsuke/github/GHCommitStatus.java
@@ -44,7 +44,7 @@ public class GHCommitStatus extends GHObject {
     }
 
     public GHUser getCreator() throws IOException {
-        return root.intern(creator);
+        return getRoot().intern(creator);
     }
 
     public String getContext() {

--- a/src/main/java/org/kohsuke/github/GHCommitStatus.java
+++ b/src/main/java/org/kohsuke/github/GHCommitStatus.java
@@ -17,8 +17,6 @@ public class GHCommitStatus extends GHObject {
     String context;
     GHUser creator;
 
-    private GitHub root;
-
     /*package*/ GHCommitStatus wrapUp(GitHub root) {
         if (creator!=null)  creator.wrapUp(root);
         this.root = root;

--- a/src/main/java/org/kohsuke/github/GHCommitStatus.java
+++ b/src/main/java/org/kohsuke/github/GHCommitStatus.java
@@ -19,7 +19,6 @@ public class GHCommitStatus extends GHObject {
 
     /*package*/ GHCommitStatus wrapUp(GitHub root) {
         if (creator!=null)  creator.wrapUp(root);
-        this.root = root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHCommitStatus.java
+++ b/src/main/java/org/kohsuke/github/GHCommitStatus.java
@@ -17,11 +17,6 @@ public class GHCommitStatus extends GHObject {
     String context;
     GHUser creator;
 
-    /*package*/ GHCommitStatus wrapUp(GitHub root) {
-        if (creator!=null)  creator.wrapUp(root);
-        return this;
-    }
-
     public GHCommitState getState() {
         for (GHCommitState s : GHCommitState.values()) {
             if (s.name().equalsIgnoreCase(state))

--- a/src/main/java/org/kohsuke/github/GHCompare.java
+++ b/src/main/java/org/kohsuke/github/GHCompare.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -19,6 +20,7 @@ public class GHCompare {
     private Commit[] commits;
     private GHCommit.File[] files;
 
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     private GHRepository owner;
 
     public URL getUrl() {
@@ -83,16 +85,6 @@ public class GHCompare {
         GHCommit.File[] newValue = new GHCommit.File[files.length];
         System.arraycopy(files, 0, newValue, 0, files.length);
         return newValue;
-    }
-
-    public GHCompare wrap(GHRepository owner) {
-        this.owner = owner;
-        for (Commit commit : commits) {
-            commit.wrapUp(owner);
-        }
-        merge_base_commit.wrapUp(owner);
-        base_commit.wrapUp(owner);
-        return this;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -16,14 +16,12 @@ import java.io.UnsupportedEncodingException;
  * @see GHRepository#getFileContent(String)
  */
 @SuppressWarnings({"UnusedDeclaration"})
-public class GHContent implements Refreshable {
+public class GHContent extends GHObjectBase implements Refreshable {
     /*
         In normal use of this class, repository field is set via wrap(),
         but in the code search API, there's a nested 'repository' field that gets populated from JSON.
      */
     private GHRepository repository;
-
-    private GitHub root;
 
     private String type;
     private String encoding;

--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -229,11 +229,9 @@ public class GHContent extends GHObjectBase implements Refreshable {
 
     GHContent wrap(GHRepository owner) {
         this.repository = owner;
-        this.root = owner.root;
         return this;
     }
     GHContent wrap(GitHub root) {
-        this.root = root;
         if (repository!=null)
             repository.wrap(root);
         return this;

--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -182,7 +182,7 @@ public class GHContent extends GHObjectBase implements Refreshable {
     public GHContentUpdateResponse update(byte[] newContentBytes, String commitMessage, String branch) throws IOException {
         String encodedContent = Base64.encodeBase64String(newContentBytes);
 
-        Requester requester = new Requester(getRoot())
+        Requester requester = createRequest()
             .with("path", path)
             .with("message", commitMessage)
             .with("sha", sha)
@@ -207,7 +207,7 @@ public class GHContent extends GHObjectBase implements Refreshable {
     }
 
     public GHContentUpdateResponse delete(String commitMessage, String branch) throws IOException {
-        Requester requester = new Requester(getRoot())
+        Requester requester = createRequest()
             .with("path", path)
             .with("message", commitMessage)
             .with("sha", sha)

--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -148,7 +148,7 @@ public class GHContent extends GHObjectBase implements Refreshable {
      * Depending on the original API call where this object is created, it may not contain everything.
      */
     protected synchronized void populate() throws IOException {
-        root.retrieve().to(url, this);
+        getRoot().retrieve().to(url, this);
     }
 
     /**
@@ -158,7 +158,7 @@ public class GHContent extends GHObjectBase implements Refreshable {
         if (!isDirectory())
             throw new IllegalStateException(path+" is not a directory");
 
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 url,
                 GHContent[].class,
@@ -182,7 +182,7 @@ public class GHContent extends GHObjectBase implements Refreshable {
     public GHContentUpdateResponse update(byte[] newContentBytes, String commitMessage, String branch) throws IOException {
         String encodedContent = Base64.encodeBase64String(newContentBytes);
 
-        Requester requester = new Requester(root)
+        Requester requester = new Requester(getRoot())
             .with("path", path)
             .with("message", commitMessage)
             .with("sha", sha)
@@ -207,7 +207,7 @@ public class GHContent extends GHObjectBase implements Refreshable {
     }
 
     public GHContentUpdateResponse delete(String commitMessage, String branch) throws IOException {
-        Requester requester = new Requester(root)
+        Requester requester = new Requester(getRoot())
             .with("path", path)
             .with("message", commitMessage)
             .with("sha", sha)
@@ -252,6 +252,6 @@ public class GHContent extends GHObjectBase implements Refreshable {
      */
     @Override
     public synchronized void refresh() throws IOException {
-        root.retrieve().to(url, this);
+        getRoot().retrieve().to(url, this);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -231,12 +231,6 @@ public class GHContent extends GHObjectBase implements Refreshable {
         this.repository = owner;
         return this;
     }
-    GHContent wrap(GitHub root) {
-        if (repository!=null)
-            repository.wrap(root);
-        return this;
-    }
-
 
     public static GHContent[] wrap(GHContent[] contents, GHRepository repository) {
         for (GHContent unwrappedContent : contents) {

--- a/src/main/java/org/kohsuke/github/GHContentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHContentBuilder.java
@@ -21,7 +21,7 @@ public final class GHContentBuilder {
 
     GHContentBuilder(GHRepository repo) {
         this.repo = repo;
-        this.req = new Requester(repo.root).method("PUT");
+        this.req = new Requester(repo.getRoot()).method("PUT");
     }
 
     public GHContentBuilder path(String path) {

--- a/src/main/java/org/kohsuke/github/GHContentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHContentBuilder.java
@@ -68,9 +68,6 @@ public final class GHContentBuilder {
     public GHContentUpdateResponse commit() throws IOException {
         GHContentUpdateResponse response = req.to(repo.getApiTailUrl("contents/" + path), GHContentUpdateResponse.class);
 
-        response.getContent().wrap(repo);
-        response.getCommit().wrapUp(repo);
-
         return response;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHContentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHContentBuilder.java
@@ -21,7 +21,7 @@ public final class GHContentBuilder {
 
     GHContentBuilder(GHRepository repo) {
         this.repo = repo;
-        this.req = new Requester(repo.getRoot()).method("PUT");
+        this.req = repo.createRequest().method("PUT");
     }
 
     public GHContentBuilder path(String path) {

--- a/src/main/java/org/kohsuke/github/GHContentSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHContentSearchBuilder.java
@@ -61,8 +61,6 @@ public class GHContentSearchBuilder extends GHSearchBuilder<GHContent> {
 
         @Override
         /*package*/ GHContent[] getItems(GitHub root) {
-            for (GHContent item : items)
-                item.wrap(root);
             return items;
         }
     }

--- a/src/main/java/org/kohsuke/github/GHContentWithLicense.java
+++ b/src/main/java/org/kohsuke/github/GHContentWithLicense.java
@@ -13,8 +13,6 @@ class GHContentWithLicense extends GHContent {
     @Override
     GHContentWithLicense wrap(GHRepository owner) {
         super.wrap(owner);
-        if (license!=null)
-            license.wrap(owner.getRoot());
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHContentWithLicense.java
+++ b/src/main/java/org/kohsuke/github/GHContentWithLicense.java
@@ -10,9 +10,4 @@ package org.kohsuke.github;
 class GHContentWithLicense extends GHContent {
     GHLicense license;
 
-    @Override
-    GHContentWithLicense wrap(GHRepository owner) {
-        super.wrap(owner);
-        return this;
-    }
 }

--- a/src/main/java/org/kohsuke/github/GHContentWithLicense.java
+++ b/src/main/java/org/kohsuke/github/GHContentWithLicense.java
@@ -14,7 +14,7 @@ class GHContentWithLicense extends GHContent {
     GHContentWithLicense wrap(GHRepository owner) {
         super.wrap(owner);
         if (license!=null)
-            license.wrap(owner.root);
+            license.wrap(owner.getRoot());
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
@@ -8,8 +8,7 @@ import java.net.URL;
  *
  * @author Kohsuke Kawaguchi
  */
-public class GHCreateRepositoryBuilder {
-    private final GitHub root;
+public class GHCreateRepositoryBuilder extends GHObjectBase{
     protected final Requester builder;
     private final String apiUrlTail;
 

--- a/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
@@ -131,7 +131,7 @@ public class GHCreateRepositoryBuilder extends GHObjectBase{
      * Creates a repository with all the parameters.
      */
     public GHRepository create() throws IOException {
-        return builder.method("POST").to(apiUrlTail, GHRepository.class).wrap(root);
+        return builder.method("POST").to(apiUrlTail, GHRepository.class).wrap(getRoot());
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
@@ -131,7 +131,7 @@ public class GHCreateRepositoryBuilder extends GHObjectBase{
      * Creates a repository with all the parameters.
      */
     public GHRepository create() throws IOException {
-        return builder.method("POST").to(apiUrlTail, GHRepository.class).wrap(getRoot());
+        return builder.method("POST").to(apiUrlTail, GHRepository.class);
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
@@ -15,7 +15,7 @@ public class GHCreateRepositoryBuilder extends GHObjectBase{
     /*package*/ GHCreateRepositoryBuilder(GitHub root, String apiUrlTail, String name) {
         super(root);
         this.apiUrlTail = apiUrlTail;
-        this.builder = new Requester(root);
+        this.builder = createRequest();
         this.builder.with("name",name);
     }
 

--- a/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHCreateRepositoryBuilder.java
@@ -13,7 +13,7 @@ public class GHCreateRepositoryBuilder extends GHObjectBase{
     private final String apiUrlTail;
 
     /*package*/ GHCreateRepositoryBuilder(GitHub root, String apiUrlTail, String name) {
-        this.root = root;
+        super(root);
         this.apiUrlTail = apiUrlTail;
         this.builder = new Requester(root);
         this.builder.with("name",name);

--- a/src/main/java/org/kohsuke/github/GHDeployKey.java
+++ b/src/main/java/org/kohsuke/github/GHDeployKey.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import java.io.IOException;
@@ -9,6 +10,8 @@ public class GHDeployKey {
     protected String url, key, title;
     protected boolean verified;
     protected long id;
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     private GHRepository owner;
 
     public long getId() {
@@ -29,11 +32,6 @@ public class GHDeployKey {
 
     public boolean isVerified() {
         return verified;
-    }
-
-    public GHDeployKey wrap(GHRepository repo) {
-        this.owner = repo;
-        return this;
     }
 
     public String toString() {

--- a/src/main/java/org/kohsuke/github/GHDeployKey.java
+++ b/src/main/java/org/kohsuke/github/GHDeployKey.java
@@ -41,6 +41,6 @@ public class GHDeployKey {
     }
     
     public void delete() throws IOException {
-        new Requester(owner.getRoot()).method("DELETE").to(String.format("/repos/%s/%s/keys/%d", owner.getOwnerName(), owner.getName(), id));
+        owner.createRequest().method("DELETE").to(String.format("/repos/%s/%s/keys/%d", owner.getOwnerName(), owner.getName(), id));
     }
 }

--- a/src/main/java/org/kohsuke/github/GHDeployKey.java
+++ b/src/main/java/org/kohsuke/github/GHDeployKey.java
@@ -41,6 +41,6 @@ public class GHDeployKey {
     }
     
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE").to(String.format("/repos/%s/%s/keys/%d", owner.getOwnerName(), owner.getName(), id));
+        new Requester(owner.getRoot()).method("DELETE").to(String.format("/repos/%s/%s/keys/%d", owner.getOwnerName(), owner.getName(), id));
     }
 }

--- a/src/main/java/org/kohsuke/github/GHDeployment.java
+++ b/src/main/java/org/kohsuke/github/GHDeployment.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+
 import java.io.IOException;
 import java.net.URL;
 
@@ -11,7 +13,10 @@ import java.net.URL;
  * @see GHRepository#getDeployment(long)
  */
 public class GHDeployment extends GHObject {
-    private GHRepository owner;
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
+    GHRepository owner;
+
     protected String sha;
     protected String ref;
     protected String task;
@@ -21,12 +26,6 @@ public class GHDeployment extends GHObject {
     protected String statuses_url;
     protected String repository_url;
     protected GHUser creator;
-
-
-    GHDeployment wrap(GHRepository owner) {
-        this.owner = owner;
-        return this;
-    }
 
     public URL getStatusesUrl() {
         return GitHub.parseURL(statuses_url);
@@ -68,7 +67,7 @@ public class GHDeployment extends GHObject {
     }
 
     public PagedIterable<GHDeploymentStatus> listStatuses() {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .asPagedIterable(
                 statuses_url,
                 GHDeploymentStatus[].class,

--- a/src/main/java/org/kohsuke/github/GHDeployment.java
+++ b/src/main/java/org/kohsuke/github/GHDeployment.java
@@ -12,7 +12,6 @@ import java.net.URL;
  */
 public class GHDeployment extends GHObject {
     private GHRepository owner;
-    private GitHub root;
     protected String sha;
     protected String ref;
     protected String task;

--- a/src/main/java/org/kohsuke/github/GHDeployment.java
+++ b/src/main/java/org/kohsuke/github/GHDeployment.java
@@ -25,7 +25,6 @@ public class GHDeployment extends GHObject {
 
     GHDeployment wrap(GHRepository owner) {
         this.owner = owner;
-        if(creator != null) creator.wrapUp(getRoot());
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHDeployment.java
+++ b/src/main/java/org/kohsuke/github/GHDeployment.java
@@ -25,7 +25,7 @@ public class GHDeployment extends GHObject {
 
     GHDeployment wrap(GHRepository owner) {
         this.owner = owner;
-        if(creator != null) creator.wrapUp(root);
+        if(creator != null) creator.wrapUp(getRoot());
         return this;
     }
 
@@ -47,7 +47,7 @@ public class GHDeployment extends GHObject {
         return environment;
     }
     public GHUser getCreator() throws IOException {
-        return root.intern(creator);
+        return getRoot().intern(creator);
     }
     public String getRef() {
         return ref;
@@ -69,7 +69,7 @@ public class GHDeployment extends GHObject {
     }
 
     public PagedIterable<GHDeploymentStatus> listStatuses() {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 statuses_url,
                 GHDeploymentStatus[].class,

--- a/src/main/java/org/kohsuke/github/GHDeployment.java
+++ b/src/main/java/org/kohsuke/github/GHDeployment.java
@@ -25,7 +25,6 @@ public class GHDeployment extends GHObject {
 
     GHDeployment wrap(GHRepository owner) {
         this.owner = owner;
-        this.root = owner.root;
         if(creator != null) creator.wrapUp(root);
         return this;
     }

--- a/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
@@ -10,7 +10,7 @@ public class GHDeploymentBuilder {
 
     public GHDeploymentBuilder(GHRepository repo) {
         this.repo = repo;
-        this.builder = new Requester(repo.root);
+        this.builder = new Requester(repo.getRoot());
     }
 
     public GHDeploymentBuilder(GHRepository repo, String ref) {

--- a/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
@@ -10,7 +10,7 @@ public class GHDeploymentBuilder {
 
     public GHDeploymentBuilder(GHRepository repo) {
         this.repo = repo;
-        this.builder = new Requester(repo.getRoot());
+        this.builder = repo.createRequest();
     }
 
     public GHDeploymentBuilder(GHRepository repo, String ref) {

--- a/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
@@ -50,6 +50,6 @@ public class GHDeploymentBuilder {
     }
 
     public GHDeployment create() throws IOException {
-        return builder.to(repo.getApiTailUrl("deployments"),GHDeployment.class).wrap(repo);
+        return builder.to(repo.getApiTailUrl("deployments"),GHDeployment.class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
@@ -5,7 +5,6 @@ import java.util.Locale;
 
 public class GHDeploymentStatus extends GHObject {
     private GHRepository owner;
-    private GitHub root;
     protected GHUser creator;
     protected String state;
     protected String description;

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
@@ -4,7 +4,7 @@ import java.net.URL;
 import java.util.Locale;
 
 public class GHDeploymentStatus extends GHObject {
-    private GHRepository owner;
+    GHRepository owner;
     protected GHUser creator;
     protected String state;
     protected String description;

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
@@ -13,7 +13,6 @@ public class GHDeploymentStatus extends GHObject {
     protected String repository_url;
     public GHDeploymentStatus wrap(GHRepository owner) {
         this.owner = owner;
-        this.root = owner.root;
         if(creator != null) creator.wrapUp(root);
         return this;
     }

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
@@ -11,9 +11,9 @@ public class GHDeploymentStatus extends GHObject {
     protected String target_url;
     protected String deployment_url;
     protected String repository_url;
+
     public GHDeploymentStatus wrap(GHRepository owner) {
         this.owner = owner;
-        if(creator != null) creator.wrapUp(getRoot());
         return this;
     }
     public URL getTargetUrl() {

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
@@ -13,7 +13,7 @@ public class GHDeploymentStatus extends GHObject {
     protected String repository_url;
     public GHDeploymentStatus wrap(GHRepository owner) {
         this.owner = owner;
-        if(creator != null) creator.wrapUp(root);
+        if(creator != null) creator.wrapUp(getRoot());
         return this;
     }
     public URL getTargetUrl() {

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
@@ -24,7 +24,7 @@ public class GHDeploymentStatusBuilder {
     /*package*/ GHDeploymentStatusBuilder(GHRepository repo, long deploymentId, GHDeploymentState state) {
         this.repo = repo;
         this.deploymentId = deploymentId;
-        this.builder = new Requester(repo.root);
+        this.builder = new Requester(repo.getRoot());
         this.builder.with("state",state);
     }
 

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
@@ -24,7 +24,7 @@ public class GHDeploymentStatusBuilder {
     /*package*/ GHDeploymentStatusBuilder(GHRepository repo, long deploymentId, GHDeploymentState state) {
         this.repo = repo;
         this.deploymentId = deploymentId;
-        this.builder = new Requester(repo.getRoot());
+        this.builder = repo.createRequest();
         this.builder.with("state",state);
     }
 

--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -101,7 +101,6 @@ public class GHEventInfo extends GHObjectBase {
         InjectableValues.Std inject = new InjectableValues.Std();
         inject.addValue(GitHub.class.getName(), this.getRoot());
         T v = GitHub.MAPPER.reader(inject).forType(type).readValue(payload.traverse());
-        v.wrapUp(getRoot());
         return v;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -68,13 +68,13 @@ public class GHEventInfo extends GHObjectBase {
     @SuppressFBWarnings(value = {"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" }, 
             justification = "The field comes from JSON deserialization")
     public GHRepository getRepository() throws IOException {
-        return root.getRepository(repo.name);
+        return getRoot().getRepository(repo.name);
     }
     
     @SuppressFBWarnings(value = {"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" }, 
             justification = "The field comes from JSON deserialization")
     public GHUser getActor() throws IOException {
-        return root.getUser(actor.getLogin());
+        return getRoot().getUser(actor.getLogin());
     }
 
     /**
@@ -87,7 +87,7 @@ public class GHEventInfo extends GHObjectBase {
     @SuppressFBWarnings(value = {"UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" }, 
             justification = "The field comes from JSON deserialization")
     public GHOrganization getOrganization() throws IOException {
-        return (org==null || org.getLogin()==null) ? null : root.getOrganization(org.getLogin());
+        return (org==null || org.getLogin()==null) ? null : getRoot().getOrganization(org.getLogin());
     }
 
     /**
@@ -99,9 +99,9 @@ public class GHEventInfo extends GHObjectBase {
      */
     public <T extends GHEventPayload> T getPayload(Class<T> type) throws IOException {
         InjectableValues.Std inject = new InjectableValues.Std();
-        inject.addValue(GitHub.class.getName(), this.root);
+        inject.addValue(GitHub.class.getName(), this.getRoot());
         T v = GitHub.MAPPER.reader(inject).forType(type).readValue(payload.traverse());
-        v.wrapUp(root);
+        v.wrapUp(getRoot());
         return v;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -51,7 +51,6 @@ public class GHEventInfo extends GHObjectBase {
     }
 
     /*package*/ GHEventInfo wrapUp(GitHub root) {
-        this.root = root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -12,8 +13,7 @@ import java.util.Date;
  * @author Kohsuke Kawaguchi
  */
 @SuppressFBWarnings(value = "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", justification = "JSON API")
-public class GHEventInfo {
-    private GitHub root;
+public class GHEventInfo extends GHObjectBase {
 
     // we don't want to expose Jackson dependency to the user. This needs databinding
     private ObjectNode payload;
@@ -99,7 +99,9 @@ public class GHEventInfo {
      *      This must match the {@linkplain #getType() event type}.
      */
     public <T extends GHEventPayload> T getPayload(Class<T> type) throws IOException {
-        T v = GitHub.MAPPER.readValue(payload.traverse(), type);
+        InjectableValues.Std inject = new InjectableValues.Std();
+        inject.addValue(GitHub.class.getName(), this.root);
+        T v = GitHub.MAPPER.reader(inject).forType(type).readValue(payload.traverse());
         v.wrapUp(root);
         return v;
     }

--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -50,10 +50,6 @@ public class GHEventInfo extends GHObjectBase {
         return null;    // unknown event type
     }
 
-    /*package*/ GHEventInfo wrapUp(GitHub root) {
-        return this;
-    }
-
     public long getId() {
         return id;
     }

--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -94,8 +94,8 @@ public class GHEventInfo extends GHObjectBase {
      *      This must match the {@linkplain #getType() event type}.
      */
     public <T extends GHEventPayload> T getPayload(Class<T> type) throws IOException {
-        InjectableValues.Std inject = new InjectableValues.Std();
-        inject.addValue(GitHub.class.getName(), this.getRoot());
+        final InjectableValues.Std inject = new InjectableValues.Std();
+        Requester.lateBinding(inject, this.getRoot());
         T v = GitHub.MAPPER.reader(inject).forType(type).readValue(payload.traverse());
         return v;
     }

--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -57,7 +57,8 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public GHPullRequest getPullRequest() {
             if (repository!=null) {
-                pull_request.wrapUp(repository);
+                // BUGBUG
+                pull_request.owner = repository;
             }
 
             return pull_request;
@@ -93,13 +94,13 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
         
         public GHPullRequestReview getReview() {
-            review.wrapUp(pull_request);
+            review.owner = pull_request;
             return review;
         }
 
         public GHPullRequest getPullRequest() {
             if (repository!=null) {
-                pull_request.wrapUp(repository);
+                pull_request.owner = repository;
             }
 
             return pull_request;
@@ -133,13 +134,13 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
         
         public GHPullRequestReviewComment getComment() {
-            comment.wrapUp(pull_request);
+            comment.owner = pull_request;
             return comment;
         }
 
         public GHPullRequest getPullRequest() {
             if (repository!=null) {
-                pull_request.wrapUp(repository);
+                pull_request.owner = repository;
             }
 
             return pull_request;
@@ -176,7 +177,7 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public GHIssue getIssue() {
             if (repository != null) {
-                issue.wrap(repository);
+                issue.owner = repository;
             }
 
             return issue;
@@ -214,7 +215,7 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
 
         public GHIssueComment getComment() {
-            comment.wrapUp(issue);
+            comment.owner = issue;
             return comment;
         }
 
@@ -224,7 +225,7 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public GHIssue getIssue() {
             if (repository != null) {
-                issue.wrap(repository);
+                issue.owner = repository;
             }
 
             return issue;
@@ -262,7 +263,7 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public GHCommitComment getComment() {
             if (repository != null) {
-                comment.wrap(repository);
+                comment.owner = repository;
             }
 
             return comment;
@@ -371,7 +372,7 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public GHDeployment getDeployment() {
             if (repository != null) {
-                deployment.wrap(repository);
+                deployment.owner = repository;
             }
             return deployment;
         }
@@ -404,8 +405,8 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public GHDeploymentStatus getDeploymentStatus() {
             if (repository != null) {
-                deployment.wrap(repository);
-                deploymentStatus.wrap(repository);
+                deployment.owner = repository;
+                deploymentStatus.owner = repository;
             }
 
             return deploymentStatus;
@@ -417,8 +418,8 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public GHDeployment getDeployment() {
             if (repository != null) {
-                deployment.wrap(repository);
-                deploymentStatus.wrap(repository);
+                deployment.owner = repository;
+                deploymentStatus.owner = repository;
             }
 
             return deployment;

--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -14,8 +14,7 @@ import java.util.List;
  * @see GHEventInfo#getPayload(Class)
  */
 @SuppressWarnings("UnusedDeclaration")
-public abstract class GHEventPayload {
-    protected GitHub root;
+public abstract class GHEventPayload extends GHObjectBase {
 
     private GHUser sender;
 
@@ -705,7 +704,7 @@ public abstract class GHEventPayload {
         /**
          * Commit in a push
          */
-        public static class PushCommit {
+        public static class PushCommit extends GHObjectBase {
             private GitUser author;
             private GitUser committer;
             private String url, sha, message;

--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -33,12 +34,6 @@ public abstract class GHEventPayload extends GHObjectBase {
         this.sender = sender;
     }
 
-    /*package*/ void wrapUp(GitHub root) {
-        if (sender != null) {
-            sender.wrapUp(root);
-        }
-    }
-
     /**
      * A pull request status has changed.
      *
@@ -61,6 +56,10 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
 
         public GHPullRequest getPullRequest() {
+            if (repository!=null) {
+                pull_request.wrapUp(repository);
+            }
+
             return pull_request;
         }
 
@@ -68,18 +67,13 @@ public abstract class GHEventPayload extends GHObjectBase {
             return repository;
         }
 
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
+        @JsonCreator
+        public PullRequest(@JsonProperty("pull_request")  GHPullRequest pull_request) {
+            this.pull_request = pull_request;
             if (pull_request==null)
                 throw new IllegalStateException("Expected pull_request payload, but got something else. Maybe we've got another type of event?");
-            if (repository!=null) {
-                repository.wrap(root);
-                pull_request.wrapUp(repository);
-            } else {
-                pull_request.wrapUp(root);
-            }
         }
+
     }
 
 
@@ -99,10 +93,15 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
         
         public GHPullRequestReview getReview() {
+            review.wrapUp(pull_request);
             return review;
         }
 
         public GHPullRequest getPullRequest() {
+            if (repository!=null) {
+                pull_request.wrapUp(repository);
+            }
+
             return pull_request;
         }
 
@@ -110,20 +109,11 @@ public abstract class GHEventPayload extends GHObjectBase {
             return repository;
         }
 
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
+        @JsonCreator
+        public PullRequestReview(@JsonProperty("review") GHPullRequestReview review) {
+            this.review = review;
             if (review==null)
                 throw new IllegalStateException("Expected pull_request_review payload, but got something else. Maybe we've got another type of event?");
-            
-            review.wrapUp(pull_request);
-            
-            if (repository!=null) {
-                repository.wrap(root);
-                pull_request.wrapUp(repository);
-            } else {
-                pull_request.wrapUp(root);
-            }
         }
     }
     
@@ -143,10 +133,15 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
         
         public GHPullRequestReviewComment getComment() {
+            comment.wrapUp(pull_request);
             return comment;
         }
 
         public GHPullRequest getPullRequest() {
+            if (repository!=null) {
+                pull_request.wrapUp(repository);
+            }
+
             return pull_request;
         }
 
@@ -154,20 +149,11 @@ public abstract class GHEventPayload extends GHObjectBase {
             return repository;
         }
 
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
+        @JsonCreator
+        public PullRequestReviewComment(@JsonProperty("comment") GHPullRequestReviewComment comment) {
+            this.comment = comment;
             if (comment==null)
                 throw new IllegalStateException("Expected pull_request_review_comment payload, but got something else. Maybe we've got another type of event?");
-            
-            comment.wrapUp(pull_request);
-            
-            if (repository!=null) {
-                repository.wrap(root);
-                pull_request.wrapUp(repository);
-            } else {
-                pull_request.wrapUp(root);
-            }
         }
     }
 
@@ -189,6 +175,10 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
 
         public GHIssue getIssue() {
+            if (repository != null) {
+                issue.wrap(repository);
+            }
+
             return issue;
         }
 
@@ -202,17 +192,6 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public void setRepository(GHRepository repository) {
             this.repository = repository;
-        }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository != null) {
-                repository.wrap(root);
-                issue.wrap(repository);
-            } else {
-                issue.wrap(root);
-            }
         }
     }
 
@@ -235,6 +214,7 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
 
         public GHIssueComment getComment() {
+            comment.wrapUp(issue);
             return comment;
         }
 
@@ -243,6 +223,10 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
 
         public GHIssue getIssue() {
+            if (repository != null) {
+                issue.wrap(repository);
+            }
+
             return issue;
         }
 
@@ -256,18 +240,6 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public void setRepository(GHRepository repository) {
             this.repository = repository;
-        }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository != null) {
-                repository.wrap(root);
-                issue.wrap(repository);
-            } else {
-                issue.wrap(root);
-            }
-            comment.wrapUp(issue);
         }
     }
 
@@ -289,6 +261,10 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
 
         public GHCommitComment getComment() {
+            if (repository != null) {
+                comment.wrap(repository);
+            }
+
             return comment;
         }
 
@@ -302,15 +278,6 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public void setRepository(GHRepository repository) {
             this.repository = repository;
-        }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository != null) {
-                repository.wrap(root);
-                comment.wrap(repository);
-            }
         }
     }
 
@@ -357,14 +324,6 @@ public abstract class GHEventPayload extends GHObjectBase {
         public void setRepository(GHRepository repository) {
             this.repository = repository;
         }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository != null) {
-                repository.wrap(root);
-            }
-        }
     }
 
     /**
@@ -397,14 +356,6 @@ public abstract class GHEventPayload extends GHObjectBase {
         public void setRepository(GHRepository repository) {
             this.repository = repository;
         }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository != null) {
-                repository.wrap(root);
-            }
-        }
     }
 
     /**
@@ -419,6 +370,9 @@ public abstract class GHEventPayload extends GHObjectBase {
         private GHRepository repository;
 
         public GHDeployment getDeployment() {
+            if (repository != null) {
+                deployment.wrap(repository);
+            }
             return deployment;
         }
 
@@ -432,15 +386,6 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public void setRepository(GHRepository repository) {
             this.repository = repository;
-        }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository != null) {
-                repository.wrap(root);
-                deployment.wrap(repository);
-            }
         }
     }
 
@@ -458,6 +403,11 @@ public abstract class GHEventPayload extends GHObjectBase {
         private GHRepository repository;
 
         public GHDeploymentStatus getDeploymentStatus() {
+            if (repository != null) {
+                deployment.wrap(repository);
+                deploymentStatus.wrap(repository);
+            }
+
             return deploymentStatus;
         }
 
@@ -466,6 +416,11 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
 
         public GHDeployment getDeployment() {
+            if (repository != null) {
+                deployment.wrap(repository);
+                deploymentStatus.wrap(repository);
+            }
+
             return deployment;
         }
 
@@ -479,16 +434,6 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public void setRepository(GHRepository repository) {
             this.repository = repository;
-        }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository != null) {
-                repository.wrap(root);
-                deployment.wrap(repository);
-                deploymentStatus.wrap(repository);
-            }
         }
     }
 
@@ -519,15 +464,6 @@ public abstract class GHEventPayload extends GHObjectBase {
         public void setRepository(GHRepository repository) {
             this.repository = repository;
         }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            forkee.wrap(root);
-            if (repository != null) {
-                repository.wrap(root);
-            }
-        }
     }
 
     /**
@@ -552,17 +488,6 @@ public abstract class GHEventPayload extends GHObjectBase {
         public void setOrganization(GHOrganization organization) {
             this.organization = organization;
         }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository!=null)
-                repository.wrap(root);
-            if (organization != null) {
-                organization.wrapUp(root);
-            }
-        }
-
     }
 
     /**
@@ -580,14 +505,6 @@ public abstract class GHEventPayload extends GHObjectBase {
         public GHRepository getRepository() {
             return repository;
         }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository!=null)
-                repository.wrap(root);
-        }
-
     }
 
     /**
@@ -670,13 +587,6 @@ public abstract class GHEventPayload extends GHObjectBase {
 
         public void setPusher(Pusher pusher) {
             this.pusher = pusher;
-        }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository!=null)
-                repository.wrap(root);
         }
 
         public static class Pusher {
@@ -790,14 +700,6 @@ public abstract class GHEventPayload extends GHObjectBase {
         public void setRepository(GHRepository repository) {
             this.repository = repository;
         }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            if (repository != null) {
-                repository.wrap(root);
-            }
-        }
     }
 
     /**
@@ -831,15 +733,5 @@ public abstract class GHEventPayload extends GHObjectBase {
         public void setOrganization(GHOrganization organization) {
             this.organization = organization;
         }
-
-        @Override
-        void wrapUp(GitHub root) {
-            super.wrapUp(root);
-            repository.wrap(root);
-            if (organization != null) {
-                organization.wrapUp(root);
-            }
-        }
-
     }
 }

--- a/src/main/java/org/kohsuke/github/GHEventPayload.java
+++ b/src/main/java/org/kohsuke/github/GHEventPayload.java
@@ -34,7 +34,6 @@ public abstract class GHEventPayload extends GHObjectBase {
     }
 
     /*package*/ void wrapUp(GitHub root) {
-        this.root = root;
         if (sender != null) {
             sender.wrapUp(root);
         }
@@ -62,7 +61,6 @@ public abstract class GHEventPayload extends GHObjectBase {
         }
 
         public GHPullRequest getPullRequest() {
-            pull_request.root = root;
             return pull_request;
         }
 

--- a/src/main/java/org/kohsuke/github/GHGist.java
+++ b/src/main/java/org/kohsuke/github/GHGist.java
@@ -122,11 +122,11 @@ public class GHGist extends GHObject {
     }
 
     public void star() throws IOException {
-        new Requester(getRoot()).method("PUT").to(getApiTailUrl("star"));
+        createRequest().method("PUT").to(getApiTailUrl("star"));
     }
 
     public void unstar() throws IOException {
-        new Requester(getRoot()).method("DELETE").to(getApiTailUrl("star"));
+        createRequest().method("DELETE").to(getApiTailUrl("star"));
     }
 
     public boolean isStarred() throws IOException {
@@ -137,7 +137,7 @@ public class GHGist extends GHObject {
      * Forks this gist into your own.
      */
     public GHGist fork() throws IOException {
-        return new Requester(getRoot()).to(getApiTailUrl("forks"),GHGist.class);
+        return createRequest().to(getApiTailUrl("forks"),GHGist.class);
     }
 
     public PagedIterable<GHGist> listForks() {
@@ -152,7 +152,7 @@ public class GHGist extends GHObject {
      * Deletes this gist.
      */
     public void delete() throws IOException {
-        new Requester(getRoot()).method("DELETE").to("/gists/" + id);
+        createRequest().method("DELETE").to("/gists/" + id);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHGist.java
+++ b/src/main/java/org/kohsuke/github/GHGist.java
@@ -130,7 +130,7 @@ public class GHGist extends GHObject {
     }
 
     public boolean isStarred() throws IOException {
-        return getRoot().retrieve().asHttpStatusCode(getApiTailUrl("star"))/100==2;
+        return getRoot().createRequest().method("GET").asHttpStatusCode(getApiTailUrl("star"))/100==2;
     }
 
     /**
@@ -141,7 +141,7 @@ public class GHGist extends GHObject {
     }
 
     public PagedIterable<GHGist> listForks() {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .asPagedIterable(
                 getApiTailUrl("forks"),
                 GHGist[].class,

--- a/src/main/java/org/kohsuke/github/GHGist.java
+++ b/src/main/java/org/kohsuke/github/GHGist.java
@@ -1,10 +1,8 @@
 package org.kohsuke.github;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.OptBoolean;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
@@ -46,10 +44,10 @@ public class GHGist extends GHObject {
     @JacksonInject(value = "owner")
     @JsonProperty
     public GHUser getOwner() throws IOException {
-        return root.intern(owner);
+        return getRoot().intern(owner);
     }
     public void setOwner(GHUser owner) {
-        this.owner = root.getUser(owner);
+        this.owner = getRoot().getUser(owner);
     }
 
 
@@ -124,26 +122,26 @@ public class GHGist extends GHObject {
     }
 
     public void star() throws IOException {
-        new Requester(root).method("PUT").to(getApiTailUrl("star"));
+        new Requester(getRoot()).method("PUT").to(getApiTailUrl("star"));
     }
 
     public void unstar() throws IOException {
-        new Requester(root).method("DELETE").to(getApiTailUrl("star"));
+        new Requester(getRoot()).method("DELETE").to(getApiTailUrl("star"));
     }
 
     public boolean isStarred() throws IOException {
-        return root.retrieve().asHttpStatusCode(getApiTailUrl("star"))/100==2;
+        return getRoot().retrieve().asHttpStatusCode(getApiTailUrl("star"))/100==2;
     }
 
     /**
      * Forks this gist into your own.
      */
     public GHGist fork() throws IOException {
-        return new Requester(root).to(getApiTailUrl("forks"),GHGist.class);
+        return new Requester(getRoot()).to(getApiTailUrl("forks"),GHGist.class);
     }
 
     public PagedIterable<GHGist> listForks() {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl("forks"),
                 GHGist[].class,
@@ -154,7 +152,7 @@ public class GHGist extends GHObject {
      * Deletes this gist.
      */
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").to("/gists/" + id);
+        new Requester(getRoot()).method("DELETE").to("/gists/" + id);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHGist.java
+++ b/src/main/java/org/kohsuke/github/GHGist.java
@@ -41,7 +41,7 @@ public class GHGist extends GHObject {
     /**
      * User that owns this Gist.
      */
-    @JacksonInject(value = "owner")
+    @JacksonInject(value = "org.kohsuke.github.GHUser")
     @JsonProperty
     public GHUser getOwner() throws IOException {
         return getRoot().intern(owner);

--- a/src/main/java/org/kohsuke/github/GHGist.java
+++ b/src/main/java/org/kohsuke/github/GHGist.java
@@ -27,9 +27,6 @@ public class GHGist extends GHObject {
 
     GHUser owner;
 
-    @JacksonInject
-    GitHub root;
-
     private String forks_url, commits_url, id, git_pull_url, git_push_url, html_url;
 
     @JsonProperty("public")

--- a/src/main/java/org/kohsuke/github/GHGistBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHGistBuilder.java
@@ -43,6 +43,6 @@ public class GHGistBuilder {
      */
     public GHGist create() throws IOException {
         req._with("files",files);
-        return req.to("/gists",GHGist.class).wrapUp(root);
+        return req.to("/gists",GHGist.class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHGistBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHGistBuilder.java
@@ -15,7 +15,7 @@ public class GHGistBuilder extends GHObjectBase {
     private final LinkedHashMap<String,Object> files = new LinkedHashMap<String, Object>();
 
     public GHGistBuilder(GitHub root) {
-        this.root = root;
+        super(root);
         req = new Requester(root);
     }
 

--- a/src/main/java/org/kohsuke/github/GHGistBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHGistBuilder.java
@@ -10,8 +10,7 @@ import java.util.LinkedHashMap;
  * @author Kohsuke Kawaguchi
  * @see GitHub#createGist()
  */
-public class GHGistBuilder {
-    private final GitHub root;
+public class GHGistBuilder extends GHObjectBase {
     private final Requester req;
     private final LinkedHashMap<String,Object> files = new LinkedHashMap<String, Object>();
 

--- a/src/main/java/org/kohsuke/github/GHGistBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHGistBuilder.java
@@ -16,7 +16,7 @@ public class GHGistBuilder extends GHObjectBase {
 
     public GHGistBuilder(GitHub root) {
         super(root);
-        req = new Requester(root);
+        req = createRequest();
     }
 
     public GHGistBuilder description(String desc) {

--- a/src/main/java/org/kohsuke/github/GHGistUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHGistUpdater.java
@@ -55,6 +55,7 @@ public class GHGistUpdater {
         builder._with("files", files);
         return builder
                 .method("PATCH")
-                .to(base.getApiTailUrl(""), GHGist.class).wrap(base.owner);
+                .inject("owner", base.owner)
+                .to(base.getApiTailUrl(""), GHGist.class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHGistUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHGistUpdater.java
@@ -16,7 +16,7 @@ public class GHGistUpdater {
 
     GHGistUpdater(GHGist base) {
         this.base = base;
-        this.builder = new Requester(base.getRoot());
+        this.builder = base.createRequest();
 
         files = new LinkedHashMap<>();
     }

--- a/src/main/java/org/kohsuke/github/GHGistUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHGistUpdater.java
@@ -16,7 +16,7 @@ public class GHGistUpdater {
 
     GHGistUpdater(GHGist base) {
         this.base = base;
-        this.builder = new Requester(base.root);
+        this.builder = new Requester(base.getRoot());
 
         files = new LinkedHashMap<>();
     }

--- a/src/main/java/org/kohsuke/github/GHHook.java
+++ b/src/main/java/org/kohsuke/github/GHHook.java
@@ -46,14 +46,14 @@ public abstract class GHHook extends GHObject {
      * @see <a href="https://developer.github.com/v3/repos/hooks/#ping-a-hook">Ping hook</a>
      */
     public void ping() throws IOException {
-        new Requester(getRoot()).method("POST").to(getApiRoute() + "/pings");
+        createRequest().method("POST").to(getApiRoute() + "/pings");
     }
 
     /**
      * Deletes this hook.
      */
     public void delete() throws IOException {
-        new Requester(getRoot()).method("DELETE").to(getApiRoute());
+        createRequest().method("DELETE").to(getApiRoute());
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHHooks.java
+++ b/src/main/java/org/kohsuke/github/GHHooks.java
@@ -15,7 +15,7 @@ class GHHooks {
     static abstract class Context extends GHObjectBase  {
 
         private Context(GitHub root) {
-          this.root = root;
+            super(root);
         }
 
         public List<GHHook> getHooks() throws IOException {

--- a/src/main/java/org/kohsuke/github/GHHooks.java
+++ b/src/main/java/org/kohsuke/github/GHHooks.java
@@ -40,7 +40,7 @@ class GHHooks {
                 ea.add(e.symbol());
             }
 
-            GHHook hook = new Requester(getRoot())
+            GHHook hook = createRequest()
                 .with("name", name)
                 .with("active", active)
                 ._with("config", config)

--- a/src/main/java/org/kohsuke/github/GHHooks.java
+++ b/src/main/java/org/kohsuke/github/GHHooks.java
@@ -12,8 +12,7 @@ import java.util.Map;
  * functionality
  */
 class GHHooks {
-    static abstract class Context {
-        private final GitHub root;
+    static abstract class Context extends GHObjectBase  {
 
         private Context(GitHub root) {
           this.root = root;

--- a/src/main/java/org/kohsuke/github/GHHooks.java
+++ b/src/main/java/org/kohsuke/github/GHHooks.java
@@ -20,7 +20,7 @@ class GHHooks {
 
         public List<GHHook> getHooks() throws IOException {
         	
-            GHHook [] hookArray = root.retrieve().to(collection(),collectionClass());  // jdk/eclipse bug requires this to be on separate line
+            GHHook [] hookArray = getRoot().retrieve().to(collection(),collectionClass());  // jdk/eclipse bug requires this to be on separate line
             List<GHHook> list = new ArrayList<GHHook>(Arrays.asList(hookArray));
             for (GHHook h : list)
               wrap(h);
@@ -28,7 +28,7 @@ class GHHooks {
         }
 
         public GHHook getHook(int id) throws IOException {
-            GHHook hook = root.retrieve().to(collection() + "/" + id, clazz());
+            GHHook hook = getRoot().retrieve().to(collection() + "/" + id, clazz());
             return wrap(hook);
         }
 
@@ -40,7 +40,7 @@ class GHHooks {
                 ea.add(e.symbol());
             }
 
-            GHHook hook = new Requester(root)
+            GHHook hook = new Requester(getRoot())
                 .with("name", name)
                 .with("active", active)
                 ._with("config", config)
@@ -64,7 +64,7 @@ class GHHooks {
         private final GHUser owner;
 
         private RepoContext(GHRepository repository, GHUser owner) {
-            super(repository.root);
+            super(repository.getRoot());
             this.repository = repository;
             this.owner = owner;
         }
@@ -94,7 +94,7 @@ class GHHooks {
         private final GHOrganization organization;
 
         private OrgContext(GHOrganization organization) {
-            super(organization.root);
+            super(organization.getRoot());
             this.organization = organization;
         }
 

--- a/src/main/java/org/kohsuke/github/GHHooks.java
+++ b/src/main/java/org/kohsuke/github/GHHooks.java
@@ -20,7 +20,7 @@ class GHHooks {
 
         public List<GHHook> getHooks() throws IOException {
         	
-            GHHook [] hookArray = getRoot().retrieve().to(collection(),collectionClass());  // jdk/eclipse bug requires this to be on separate line
+            GHHook [] hookArray = getRoot().createRequest().method("GET").to(collection(),collectionClass());  // jdk/eclipse bug requires this to be on separate line
             List<GHHook> list = new ArrayList<GHHook>(Arrays.asList(hookArray));
             for (GHHook h : list)
               wrap(h);
@@ -28,7 +28,7 @@ class GHHooks {
         }
 
         public GHHook getHook(int id) throws IOException {
-            GHHook hook = getRoot().retrieve().to(collection() + "/" + id, clazz());
+            GHHook hook = getRoot().createRequest().method("GET").to(collection() + "/" + id, clazz());
             return wrap(hook);
         }
 

--- a/src/main/java/org/kohsuke/github/GHInvitation.java
+++ b/src/main/java/org/kohsuke/github/GHInvitation.java
@@ -23,14 +23,14 @@ public class GHInvitation extends GHObject {
      * Accept a repository invitation.
      */
     public void accept() throws IOException {
-        getRoot().retrieve().method("PATCH").to("/user/repository_invitations/" + id);
+        getRoot().createRequest().method("GET").method("PATCH").to("/user/repository_invitations/" + id);
     }
 
     /**
      * Decline a repository invitation.
      */
     public void decline() throws IOException {
-        getRoot().retrieve().method("DELETE").to("/user/repository_invitations/" + id);
+        getRoot().createRequest().method("GET").method("DELETE").to("/user/repository_invitations/" + id);
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHInvitation.java
+++ b/src/main/java/org/kohsuke/github/GHInvitation.java
@@ -20,7 +20,6 @@ public class GHInvitation extends GHObject {
     private String html_url;
 
     /*package*/ GHInvitation wrapUp(GitHub root) {
-        this.root = root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHInvitation.java
+++ b/src/main/java/org/kohsuke/github/GHInvitation.java
@@ -27,14 +27,14 @@ public class GHInvitation extends GHObject {
      * Accept a repository invitation.
      */
     public void accept() throws IOException {
-        root.retrieve().method("PATCH").to("/user/repository_invitations/" + id);
+        getRoot().retrieve().method("PATCH").to("/user/repository_invitations/" + id);
     }
 
     /**
      * Decline a repository invitation.
      */
     public void decline() throws IOException {
-        root.retrieve().method("DELETE").to("/user/repository_invitations/" + id);
+        getRoot().retrieve().method("DELETE").to("/user/repository_invitations/" + id);
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHInvitation.java
+++ b/src/main/java/org/kohsuke/github/GHInvitation.java
@@ -12,7 +12,6 @@ import java.net.URL;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
     "NP_UNWRITTEN_FIELD", "UUF_UNUSED_FIELD"}, justification = "JSON API")
 public class GHInvitation extends GHObject {
-    /*package almost final*/ GitHub root;
 
     private int id;
     private GHRepository repository;

--- a/src/main/java/org/kohsuke/github/GHInvitation.java
+++ b/src/main/java/org/kohsuke/github/GHInvitation.java
@@ -19,10 +19,6 @@ public class GHInvitation extends GHObject {
     private String permissions;
     private String html_url;
 
-    /*package*/ GHInvitation wrapUp(GitHub root) {
-        return this;
-    }
-
     /**
      * Accept a repository invitation.
      */

--- a/src/main/java/org/kohsuke/github/GHInvitation.java
+++ b/src/main/java/org/kohsuke/github/GHInvitation.java
@@ -23,14 +23,14 @@ public class GHInvitation extends GHObject {
      * Accept a repository invitation.
      */
     public void accept() throws IOException {
-        getRoot().createRequest().method("GET").method("PATCH").to("/user/repository_invitations/" + id);
+        getRoot().createRequest().method("PATCH").to("/user/repository_invitations/" + id);
     }
 
     /**
      * Decline a repository invitation.
      */
     public void decline() throws IOException {
-        getRoot().createRequest().method("GET").method("DELETE").to("/user/repository_invitations/" + id);
+        getRoot().createRequest().method("DELETE").to("/user/repository_invitations/" + id);
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -305,7 +305,7 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     public void addAssignees(Collection<GHUser> assignees) throws IOException {
-        getRoot().createRequest().method("GET").method("POST").withLogins(ASSIGNEES,assignees).to(getIssuesApiRoute()+"/assignees",this);
+        getRoot().createRequest().method("POST").withLogins(ASSIGNEES,assignees).to(getIssuesApiRoute()+"/assignees",this);
     }
 
     public void setAssignees(GHUser... assignees) throws IOException {
@@ -321,7 +321,7 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     public void removeAssignees(Collection<GHUser> assignees) throws IOException {
-        getRoot().createRequest().method("GET").method("DELETE").withLogins(ASSIGNEES,assignees).inBody().to(getIssuesApiRoute()+"/assignees",this);
+        getRoot().createRequest().method("DELETE").withLogins(ASSIGNEES,assignees).inBody().to(getIssuesApiRoute()+"/assignees",this);
     }
 
     protected String getApiRoute() {

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -145,11 +145,11 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     public void lock() throws IOException {
-        new Requester(getRoot()).method("PUT").to(getApiRoute()+"/lock");
+        createRequest().method("PUT").to(getApiRoute()+"/lock");
     }
 
     public void unlock() throws IOException {
-        new Requester(getRoot()).method("PUT").to(getApiRoute()+"/lock");
+        createRequest().method("PUT").to(getApiRoute()+"/lock");
     }
 
     /**
@@ -160,16 +160,16 @@ public class GHIssue extends GHObject implements Reactable{
      */
     @WithBridgeMethods(void.class)
     public GHIssueComment comment(String message) throws IOException {
-        GHIssueComment r = new Requester(getRoot()).with("body",message).to(getIssuesApiRoute() + "/comments", GHIssueComment.class);
+        GHIssueComment r = createRequest().with("body",message).to(getIssuesApiRoute() + "/comments", GHIssueComment.class);
         return r.wrapUp(this);
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(getRoot())._with(key, value).method("PATCH").to(getApiRoute());
+        createRequest()._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     private void editIssue(String key, Object value) throws IOException {
-        new Requester(getRoot())._with(key, value).method("PATCH").to(getIssuesApiRoute());
+        createRequest()._with(key, value).method("PATCH").to(getIssuesApiRoute());
     }
 
     /**
@@ -289,7 +289,7 @@ public class GHIssue extends GHObject implements Reactable{
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.getRoot())
+        return owner.createRequest()
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
                 .to(getApiRoute()+"/reactions", GHReaction.class);
@@ -316,7 +316,7 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     public void setAssignees(Collection<GHUser> assignees) throws IOException {
-        new Requester(getRoot()).withLogins(ASSIGNEES, assignees).method("PATCH").to(getIssuesApiRoute());
+        createRequest().withLogins(ASSIGNEES, assignees).method("PATCH").to(getIssuesApiRoute());
     }
 
     public void removeAssignees(GHUser... assignees) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -52,7 +52,6 @@ import java.util.Set;
 public class GHIssue extends GHObject implements Reactable{
     private static final String ASSIGNEES = "assignees";
 
-    GitHub root;
     GHRepository owner;
     
     // API v3

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -85,7 +85,6 @@ public class GHIssue extends GHObject implements Reactable{
     }
 
     /*package*/ GHIssue wrap(GitHub root) {
-        this.root = root;
         if(assignee != null) assignee.wrapUp(root);
         if(assignees!=null)    GHUser.wrap(assignees,root);
         if(user != null) user.wrapUp(root);

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -79,14 +79,6 @@ public class GHIssue extends GHObject implements Reactable{
     /*package*/ GHIssue wrap(GHRepository owner) {
         this.owner = owner;
         if(milestone != null) milestone.wrap(owner);
-        return wrap(owner.getRoot());
-    }
-
-    /*package*/ GHIssue wrap(GitHub root) {
-        if(assignee != null) assignee.wrapUp(root);
-        if(assignees!=null)    GHUser.wrap(assignees,root);
-        if(user != null) user.wrapUp(root);
-        if(closed_by != null) closed_by.wrapUp(root);
         return this;
     }
 
@@ -300,7 +292,7 @@ public class GHIssue extends GHObject implements Reactable{
         return new Requester(owner.getRoot())
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
-                .to(getApiRoute()+"/reactions", GHReaction.class).wrap(getRoot());
+                .to(getApiRoute()+"/reactions", GHReaction.class);
     }
 
     @Preview @Deprecated
@@ -308,8 +300,7 @@ public class GHIssue extends GHObject implements Reactable{
         return owner.getRoot().retrieve().withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiRoute()+"/reactions",
-                GHReaction[].class,
-                item -> item.wrap(owner.getRoot()) );
+                GHReaction[].class);
     }
 
     public void addAssignees(GHUser... assignees) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHIssueBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHIssueBuilder.java
@@ -15,7 +15,7 @@ public class GHIssueBuilder {
 
     GHIssueBuilder(GHRepository repo, String title) {
         this.repo = repo;
-        this.builder = new Requester(repo.root);
+        this.builder = new Requester(repo.getRoot());
         builder.with("title",title);
     }
 

--- a/src/main/java/org/kohsuke/github/GHIssueBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHIssueBuilder.java
@@ -55,6 +55,6 @@ public class GHIssueBuilder {
      * Creates a new issue.
      */
     public GHIssue create() throws IOException {
-        return builder.with("labels",labels).with("assignees",assignees).to(repo.getApiTailUrl("issues"),GHIssue.class).wrap(repo);
+        return builder.with("labels",labels).with("assignees",assignees).to(repo.getApiTailUrl("issues"),GHIssue.class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHIssueBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHIssueBuilder.java
@@ -15,7 +15,7 @@ public class GHIssueBuilder {
 
     GHIssueBuilder(GHRepository repo, String title) {
         this.repo = repo;
-        this.builder = new Requester(repo.getRoot());
+        this.builder = repo.createRequest();
         builder.with("title",title);
     }
 

--- a/src/main/java/org/kohsuke/github/GHIssueComment.java
+++ b/src/main/java/org/kohsuke/github/GHIssueComment.java
@@ -88,7 +88,7 @@ public class GHIssueComment extends GHObject implements Reactable {
      * Updates the body of the issue comment.
      */
     public void update(String body) throws IOException {
-        new Requester(owner.getRoot()).with("body", body).method("PATCH").to(getApiRoute(), GHIssueComment.class);
+        owner.createRequest().with("body", body).method("PATCH").to(getApiRoute(), GHIssueComment.class);
         this.body = body;
     }
 
@@ -96,12 +96,12 @@ public class GHIssueComment extends GHObject implements Reactable {
      * Deletes this issue comment.
      */
     public void delete() throws IOException {
-        new Requester(owner.getRoot()).method("DELETE").to(getApiRoute());
+        owner.createRequest().method("DELETE").to(getApiRoute());
     }
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.getRoot())
+        return owner.createRequest()
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
                 .to(getApiRoute()+"/reactions", GHReaction.class);

--- a/src/main/java/org/kohsuke/github/GHIssueComment.java
+++ b/src/main/java/org/kohsuke/github/GHIssueComment.java
@@ -23,6 +23,8 @@
  */
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+
 import java.io.IOException;
 import java.net.URL;
 
@@ -36,15 +38,12 @@ import static org.kohsuke.github.Previews.*;
  * @see GHIssue#listComments()
  */
 public class GHIssueComment extends GHObject implements Reactable {
+
+    @JacksonInject("org.kohsuke.github.GHIssue")
     GHIssue owner;
 
     private String body, gravatar_id, html_url, author_association;
     private GHUser user; // not fully populated. beware.
-
-    /*package*/ GHIssueComment wrapUp(GHIssue owner) {
-        this.owner = owner;
-        return this;
-    }
 
     /**
      * Gets the issue to which this comment is associated.
@@ -109,7 +108,7 @@ public class GHIssueComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return owner.getRoot().retrieve()
+        return createRequest().method("GET")
             .withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiRoute()+"/reactions",

--- a/src/main/java/org/kohsuke/github/GHIssueComment.java
+++ b/src/main/java/org/kohsuke/github/GHIssueComment.java
@@ -72,7 +72,7 @@ public class GHIssueComment extends GHObject implements Reactable {
      * Gets the user who posted this comment.
      */
     public GHUser getUser() throws IOException {
-        return owner == null || owner.root.isOffline() ? user : owner.root.getUser(user.getLogin());
+        return owner == null || owner.getRoot().isOffline() ? user : owner.getRoot().getUser(user.getLogin());
     }
     
     @Override
@@ -88,7 +88,7 @@ public class GHIssueComment extends GHObject implements Reactable {
      * Updates the body of the issue comment.
      */
     public void update(String body) throws IOException {
-        new Requester(owner.root).with("body", body).method("PATCH").to(getApiRoute(), GHIssueComment.class);
+        new Requester(owner.getRoot()).with("body", body).method("PATCH").to(getApiRoute(), GHIssueComment.class);
         this.body = body;
     }
 
@@ -96,25 +96,25 @@ public class GHIssueComment extends GHObject implements Reactable {
      * Deletes this issue comment.
      */
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE").to(getApiRoute());
+        new Requester(owner.getRoot()).method("DELETE").to(getApiRoute());
     }
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.root)
+        return new Requester(owner.getRoot())
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
-                .to(getApiRoute()+"/reactions", GHReaction.class).wrap(owner.root);
+                .to(getApiRoute()+"/reactions", GHReaction.class).wrap(owner.getRoot());
     }
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return owner.root.retrieve()
+        return owner.getRoot().retrieve()
             .withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiRoute()+"/reactions",
                 GHReaction[].class,
-                item -> item.wrap(owner.root) );
+                item -> item.wrap(owner.getRoot()) );
     }
 
     private String getApiRoute() {

--- a/src/main/java/org/kohsuke/github/GHIssueComment.java
+++ b/src/main/java/org/kohsuke/github/GHIssueComment.java
@@ -104,7 +104,7 @@ public class GHIssueComment extends GHObject implements Reactable {
         return new Requester(owner.getRoot())
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
-                .to(getApiRoute()+"/reactions", GHReaction.class).wrap(owner.getRoot());
+                .to(getApiRoute()+"/reactions", GHReaction.class);
     }
 
     @Preview @Deprecated
@@ -113,8 +113,7 @@ public class GHIssueComment extends GHObject implements Reactable {
             .withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiRoute()+"/reactions",
-                GHReaction[].class,
-                item -> item.wrap(owner.getRoot()) );
+                GHReaction[].class);
     }
 
     private String getApiRoute() {

--- a/src/main/java/org/kohsuke/github/GHIssueEvent.java
+++ b/src/main/java/org/kohsuke/github/GHIssueEvent.java
@@ -57,10 +57,6 @@ public class GHIssueEvent extends GHObjectBase {
         return issue;
     }
 
-    GHIssueEvent wrapUp(GitHub root) {
-        return this;
-    }
-
     GHIssueEvent wrapUp(GHIssue parent) {
         this.issue = parent;
         return this;

--- a/src/main/java/org/kohsuke/github/GHIssueEvent.java
+++ b/src/main/java/org/kohsuke/github/GHIssueEvent.java
@@ -5,9 +5,7 @@ import java.util.Date;
 /**
  * @author Martin van Zijl
  */
-public class GHIssueEvent {
-    private GitHub root;
-
+public class GHIssueEvent extends GHObjectBase {
     private long id;
     private String node_id;
     private String url;

--- a/src/main/java/org/kohsuke/github/GHIssueEvent.java
+++ b/src/main/java/org/kohsuke/github/GHIssueEvent.java
@@ -58,13 +58,11 @@ public class GHIssueEvent extends GHObjectBase {
     }
 
     GHIssueEvent wrapUp(GitHub root) {
-        this.root = root;
         return this;
     }
 
     GHIssueEvent wrapUp(GHIssue parent) {
         this.issue = parent;
-        this.root = parent.root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHIssueEvent.java
+++ b/src/main/java/org/kohsuke/github/GHIssueEvent.java
@@ -50,7 +50,7 @@ public class GHIssueEvent extends GHObjectBase {
     }
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
     public GHIssue getIssue() {

--- a/src/main/java/org/kohsuke/github/GHIssueSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHIssueSearchBuilder.java
@@ -56,8 +56,6 @@ public class GHIssueSearchBuilder extends GHSearchBuilder<GHIssue> {
 
         @Override
         /*package*/ GHIssue[] getItems(GitHub root) {
-            for (GHIssue i : items)
-                i.wrap(root);
             return items;
         }
     }

--- a/src/main/java/org/kohsuke/github/GHKey.java
+++ b/src/main/java/org/kohsuke/github/GHKey.java
@@ -42,10 +42,6 @@ public class GHKey extends GHObjectBase {
         return verified;
     }
 
-    /*package*/ GHKey wrap(GitHub root) {
-        return this;
-    }
-
     public String toString() {
         return new ToStringBuilder(this).append("title",title).append("id",id).append("key",key).toString();
     }

--- a/src/main/java/org/kohsuke/github/GHKey.java
+++ b/src/main/java/org/kohsuke/github/GHKey.java
@@ -43,7 +43,6 @@ public class GHKey extends GHObjectBase {
     }
 
     /*package*/ GHKey wrap(GitHub root) {
-        this.root = root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHKey.java
+++ b/src/main/java/org/kohsuke/github/GHKey.java
@@ -9,8 +9,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * @author Kohsuke Kawaguchi
  */
 @SuppressFBWarnings(value = "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", justification = "JSON API")
-public class GHKey {
-    /*package almost final*/ GitHub root;
+public class GHKey extends GHObjectBase {
 
     protected String url, key, title;
     protected boolean verified;

--- a/src/main/java/org/kohsuke/github/GHKey.java
+++ b/src/main/java/org/kohsuke/github/GHKey.java
@@ -35,7 +35,7 @@ public class GHKey extends GHObjectBase {
     }
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
     
     public boolean isVerified() {

--- a/src/main/java/org/kohsuke/github/GHLabel.java
+++ b/src/main/java/org/kohsuke/github/GHLabel.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -14,6 +16,8 @@ import static org.kohsuke.github.Previews.SYMMETRA;
  */
 public class GHLabel {
     private String url, name, color, description;
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     private GHRepository repo;
 
     public String getUrl() {
@@ -39,13 +43,8 @@ public class GHLabel {
         return description;
     }
 
-    /*package*/ GHLabel wrapUp(GHRepository repo) {
-        this.repo = repo;
-        return this;
-    }
-
     public void delete() throws IOException {
-        repo.getRoot().retrieve().method("DELETE").to(url);
+        repo.getRoot().createRequest().method("GET").method("DELETE").to(url);
     }
 
     /**
@@ -53,7 +52,7 @@ public class GHLabel {
      *      6-letter hex color code, like "f29513"
      */
     public void setColor(String newColor) throws IOException {
-        repo.getRoot().retrieve().method("PATCH")
+        repo.createRequest().method("GET").method("PATCH")
                 .withPreview(SYMMETRA)
                 .with("name", name)
                 .with("color", newColor)
@@ -67,7 +66,7 @@ public class GHLabel {
      */
     @Preview @Deprecated
     public void setDescription(String newDescription) throws IOException {
-        repo.getRoot().retrieve().method("PATCH")
+        repo.createRequest().method("GET").method("PATCH")
                 .withPreview(SYMMETRA)
                 .with("name", name)
                 .with("color", color)

--- a/src/main/java/org/kohsuke/github/GHLabel.java
+++ b/src/main/java/org/kohsuke/github/GHLabel.java
@@ -45,7 +45,7 @@ public class GHLabel {
     }
 
     public void delete() throws IOException {
-        repo.root.retrieve().method("DELETE").to(url);
+        repo.getRoot().retrieve().method("DELETE").to(url);
     }
 
     /**
@@ -53,7 +53,7 @@ public class GHLabel {
      *      6-letter hex color code, like "f29513"
      */
     public void setColor(String newColor) throws IOException {
-        repo.root.retrieve().method("PATCH")
+        repo.getRoot().retrieve().method("PATCH")
                 .withPreview(SYMMETRA)
                 .with("name", name)
                 .with("color", newColor)
@@ -67,7 +67,7 @@ public class GHLabel {
      */
     @Preview @Deprecated
     public void setDescription(String newDescription) throws IOException {
-        repo.root.retrieve().method("PATCH")
+        repo.getRoot().retrieve().method("PATCH")
                 .withPreview(SYMMETRA)
                 .with("name", name)
                 .with("color", color)

--- a/src/main/java/org/kohsuke/github/GHLabel.java
+++ b/src/main/java/org/kohsuke/github/GHLabel.java
@@ -44,7 +44,7 @@ public class GHLabel {
     }
 
     public void delete() throws IOException {
-        repo.getRoot().createRequest().method("GET").method("DELETE").to(url);
+        repo.getRoot().createRequest().method("DELETE").to(url);
     }
 
     /**
@@ -52,7 +52,7 @@ public class GHLabel {
      *      6-letter hex color code, like "f29513"
      */
     public void setColor(String newColor) throws IOException {
-        repo.createRequest().method("GET").method("PATCH")
+        repo.createRequest().method("PATCH")
                 .withPreview(SYMMETRA)
                 .with("name", name)
                 .with("color", newColor)
@@ -66,7 +66,7 @@ public class GHLabel {
      */
     @Preview @Deprecated
     public void setDescription(String newDescription) throws IOException {
-        repo.createRequest().method("GET").method("PATCH")
+        repo.createRequest().method("PATCH")
                 .withPreview(SYMMETRA)
                 .with("name", name)
                 .with("color", color)

--- a/src/main/java/org/kohsuke/github/GHLicense.java
+++ b/src/main/java/org/kohsuke/github/GHLicense.java
@@ -155,7 +155,4 @@ public class GHLicense extends GHObject {
         return url.hashCode();
     }
 
-    /*package*/ GHLicense wrap(GitHub root) {
-        return this;
-    }
 }

--- a/src/main/java/org/kohsuke/github/GHLicense.java
+++ b/src/main/java/org/kohsuke/github/GHLicense.java
@@ -138,7 +138,7 @@ public class GHLicense extends GHObject {
     protected synchronized void populate() throws IOException {
         if (description!=null)    return; // already populated
 
-        getRoot().retrieve().to(url, this);
+        getRoot().createRequest().method("GET").to(url, this);
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHLicense.java
+++ b/src/main/java/org/kohsuke/github/GHLicense.java
@@ -138,7 +138,7 @@ public class GHLicense extends GHObject {
     protected synchronized void populate() throws IOException {
         if (description!=null)    return; // already populated
 
-        root.retrieve().to(url, this);
+        getRoot().retrieve().to(url, this);
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHLicense.java
+++ b/src/main/java/org/kohsuke/github/GHLicense.java
@@ -156,7 +156,6 @@ public class GHLicense extends GHObject {
     }
 
     /*package*/ GHLicense wrap(GitHub root) {
-        this.root = root;
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHLicense.java
+++ b/src/main/java/org/kohsuke/github/GHLicense.java
@@ -45,8 +45,6 @@ import java.util.List;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
         "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
 public class GHLicense extends GHObject {
-    @SuppressFBWarnings("IS2_INCONSISTENT_SYNC") // root is set before the object is returned to the app
-    /*package almost final*/ GitHub root;
 
     // these fields are always present, even in the short form
     protected String key, name;

--- a/src/main/java/org/kohsuke/github/GHMembership.java
+++ b/src/main/java/org/kohsuke/github/GHMembership.java
@@ -44,7 +44,7 @@ public class GHMembership extends GHObjectBase {
      * @see GHMyself#getMembership(GHOrganization)
      */
     public void activate() throws IOException {
-        root.retrieve().method("PATCH").with("state",State.ACTIVE).to(url,this);
+        getRoot().retrieve().method("PATCH").with("state",State.ACTIVE).to(url,this);
     }
 
     /*package*/ GHMembership wrap(GitHub root) {

--- a/src/main/java/org/kohsuke/github/GHMembership.java
+++ b/src/main/java/org/kohsuke/github/GHMembership.java
@@ -48,7 +48,6 @@ public class GHMembership extends GHObjectBase {
     }
 
     /*package*/ GHMembership wrap(GitHub root) {
-        this.root = root;
         if (user!=null)     user = root.getUser(user.wrapUp(root));
         if (organization!=null) organization.wrapUp(root);
         return this;

--- a/src/main/java/org/kohsuke/github/GHMembership.java
+++ b/src/main/java/org/kohsuke/github/GHMembership.java
@@ -44,9 +44,9 @@ public class GHMembership extends GHObjectBase {
      * @see GHMyself#getMembership(GHOrganization)
      */
     public void activate() throws IOException {
-        getRoot().retrieve().method("PATCH").with("state",State.ACTIVE).to(url,this);
+        getRoot().createRequest().method("GET").method("PATCH").with("state",State.ACTIVE).to(url,this);
     }
-    
+
     /**
      * Role of a user in an organization.
      */

--- a/src/main/java/org/kohsuke/github/GHMembership.java
+++ b/src/main/java/org/kohsuke/github/GHMembership.java
@@ -10,9 +10,8 @@ import java.util.Locale;
  * @author Kohsuke Kawaguchi
  * @see GHMyself#listOrgMemberships()
  */
-public class GHMembership /* extends GHObject --- but it doesn't have id, created_at, etc. */ {
-    GitHub root;
-
+public class GHMembership extends GHObjectBase {
+    /* effectively extends GHObject --- but it doesn't have id, created_at, etc. */
     String url;
     String state;
     String role;

--- a/src/main/java/org/kohsuke/github/GHMembership.java
+++ b/src/main/java/org/kohsuke/github/GHMembership.java
@@ -46,18 +46,7 @@ public class GHMembership extends GHObjectBase {
     public void activate() throws IOException {
         getRoot().retrieve().method("PATCH").with("state",State.ACTIVE).to(url,this);
     }
-
-    /*package*/ GHMembership wrap(GitHub root) {
-        if (user!=null)     user = root.getUser(user.wrapUp(root));
-        if (organization!=null) organization.wrapUp(root);
-        return this;
-    }
-
-    /*package*/ static void wrap(GHMembership[] page, GitHub root) {
-        for (GHMembership m : page)
-            m.wrap(root);
-    }
-
+    
     /**
      * Role of a user in an organization.
      */

--- a/src/main/java/org/kohsuke/github/GHMembership.java
+++ b/src/main/java/org/kohsuke/github/GHMembership.java
@@ -44,7 +44,7 @@ public class GHMembership extends GHObjectBase {
      * @see GHMyself#getMembership(GHOrganization)
      */
     public void activate() throws IOException {
-        getRoot().createRequest().method("GET").method("PATCH").with("state",State.ACTIVE).to(url,this);
+        getRoot().createRequest().method("PATCH").with("state",State.ACTIVE).to(url,this);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHMilestone.java
+++ b/src/main/java/org/kohsuke/github/GHMilestone.java
@@ -92,7 +92,7 @@ public class GHMilestone extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(getRoot())._with(key, value).method("PATCH").to(getApiRoute());
+        createRequest()._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     public void setTitle(String title) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHMilestone.java
+++ b/src/main/java/org/kohsuke/github/GHMilestone.java
@@ -113,7 +113,6 @@ public class GHMilestone extends GHObject {
 
     public GHMilestone wrap(GHRepository repo) {
         this.owner = repo;
-        this.root = repo.root;
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHMilestone.java
+++ b/src/main/java/org/kohsuke/github/GHMilestone.java
@@ -92,7 +92,7 @@ public class GHMilestone extends GHObject {
      * Deletes this milestone.
      */
     public void delete() throws IOException {
-        getRoot().createRequest().method("GET").method("DELETE").to(getApiRoute());
+        getRoot().createRequest().method("DELETE").to(getApiRoute());
     }
 
     private void edit(String key, Object value) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHMilestone.java
+++ b/src/main/java/org/kohsuke/github/GHMilestone.java
@@ -11,7 +11,6 @@ import java.util.Locale;
  *
  */
 public class GHMilestone extends GHObject {
-    GitHub root;
     GHRepository owner;
 
     GHUser creator;

--- a/src/main/java/org/kohsuke/github/GHMilestone.java
+++ b/src/main/java/org/kohsuke/github/GHMilestone.java
@@ -19,7 +19,7 @@ public class GHMilestone extends GHObject {
     protected String closed_at;
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
     
     public GHRepository getOwner() {
@@ -27,7 +27,7 @@ public class GHMilestone extends GHObject {
     }
     
     public GHUser getCreator() throws IOException {
-        return root.intern(creator);
+        return getRoot().intern(creator);
     }
     
     public Date getDueOn() {
@@ -88,11 +88,11 @@ public class GHMilestone extends GHObject {
      * Deletes this milestone.
      */
     public void delete() throws IOException {
-        root.retrieve().method("DELETE").to(getApiRoute());
+        getRoot().retrieve().method("DELETE").to(getApiRoute());
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(root)._with(key, value).method("PATCH").to(getApiRoute());
+        new Requester(getRoot())._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     public void setTitle(String title) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHMilestone.java
+++ b/src/main/java/org/kohsuke/github/GHMilestone.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+
 import java.io.IOException;
 import java.net.URL;
 import java.util.Date;
@@ -11,6 +13,8 @@ import java.util.Locale;
  *
  */
 public class GHMilestone extends GHObject {
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     GHRepository owner;
 
     GHUser creator;
@@ -88,7 +92,7 @@ public class GHMilestone extends GHObject {
      * Deletes this milestone.
      */
     public void delete() throws IOException {
-        getRoot().retrieve().method("DELETE").to(getApiRoute());
+        getRoot().createRequest().method("GET").method("DELETE").to(getApiRoute());
     }
 
     private void edit(String key, Object value) throws IOException {
@@ -109,10 +113,5 @@ public class GHMilestone extends GHObject {
 
     protected String getApiRoute() {
         return "/repos/"+owner.getOwnerName()+"/"+owner.getName()+"/milestones/"+number;
-    }
-
-    public GHMilestone wrap(GHRepository repo) {
-        this.owner = repo;
-        return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHMyself.java
+++ b/src/main/java/org/kohsuke/github/GHMyself.java
@@ -201,7 +201,7 @@ public class GHMyself extends GHUser {
     }
 
 //    public void addEmails(Collection<String> emails) throws IOException {
-////        new Requester(getRoot(),ApiVersion.V3).withCredential().to("/user/emails");
+////       createRequester().withCredential().to("/user/emails");
 //        getRoot().retrieveWithAuth3()
 //    }
 }

--- a/src/main/java/org/kohsuke/github/GHMyself.java
+++ b/src/main/java/org/kohsuke/github/GHMyself.java
@@ -160,8 +160,7 @@ public class GHMyself extends GHUser {
             .with("type",repoType)
             .asPagedIterable(
                 "/user/repos",
-                GHRepository[].class,
-                item -> item.wrap(getRoot())
+                GHRepository[].class
             ).withPageSize(pageSize);
     }
 
@@ -191,15 +190,14 @@ public class GHMyself extends GHUser {
             .with("state",state)
             .asPagedIterable(
                 "/user/memberships/orgs",
-                GHMembership[].class,
-                item -> item.wrap(getRoot()) );
+                GHMembership[].class);
     }
 
     /**
      * Gets your membership in a specific organization.
      */
     public GHMembership getMembership(GHOrganization o) throws IOException {
-        return getRoot().retrieve().to("/user/memberships/orgs/"+o.getLogin(),GHMembership.class).wrap(getRoot());
+        return getRoot().retrieve().to("/user/memberships/orgs/"+o.getLogin(),GHMembership.class);
     }
 
 //    public void addEmails(Collection<String> emails) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHMyself.java
+++ b/src/main/java/org/kohsuke/github/GHMyself.java
@@ -67,7 +67,7 @@ public class GHMyself extends GHUser {
      *      Always non-null.
      */
     public List<GHEmail> getEmails2() throws IOException {
-        GHEmail[] addresses = root.retrieve().to("/user/emails", GHEmail[].class);
+        GHEmail[] addresses = getRoot().retrieve().to("/user/emails", GHEmail[].class);
         return Collections.unmodifiableList(Arrays.asList(addresses));
     }
 
@@ -81,7 +81,7 @@ public class GHMyself extends GHUser {
      *      Always non-null.
      */
     public List<GHKey> getPublicKeys() throws IOException {
-        return Collections.unmodifiableList(Arrays.asList(root.retrieve().to("/user/keys", GHKey[].class)));
+        return Collections.unmodifiableList(Arrays.asList(getRoot().retrieve().to("/user/keys", GHKey[].class)));
     }
 
     /**
@@ -95,7 +95,7 @@ public class GHMyself extends GHUser {
      *      Always non-null.
      */
   public List<GHVerifiedKey> getPublicVerifiedKeys() throws IOException {
-    return Collections.unmodifiableList(Arrays.asList(root.retrieve().to(
+    return Collections.unmodifiableList(Arrays.asList(getRoot().retrieve().to(
         "/users/" + getLogin() + "/keys", GHVerifiedKey[].class)));
   }
 
@@ -105,9 +105,9 @@ public class GHMyself extends GHUser {
     public GHPersonSet<GHOrganization> getAllOrganizations() throws IOException {
         GHPersonSet<GHOrganization> orgs = new GHPersonSet<GHOrganization>();
         Set<String> names = new HashSet<String>();
-        for (GHOrganization o : root.retrieve().to("/user/orgs", GHOrganization[].class)) {
+        for (GHOrganization o : getRoot().retrieve().to("/user/orgs", GHOrganization[].class)) {
             if (names.add(o.getLogin()))    // in case of rumoured duplicates in the data
-                orgs.add(root.getOrganization(o.getLogin()));
+                orgs.add(getRoot().getOrganization(o.getLogin()));
         }
         return orgs;
     }
@@ -156,12 +156,12 @@ public class GHMyself extends GHUser {
      * @param repoType type of repository returned in the listing
      */
     public PagedIterable<GHRepository> listRepositories(final int pageSize, final RepositoryListFilter repoType) {
-        return root.retrieve()
+        return getRoot().retrieve()
             .with("type",repoType)
             .asPagedIterable(
                 "/user/repos",
                 GHRepository[].class,
-                item -> item.wrap(root)
+                item -> item.wrap(getRoot())
             ).withPageSize(pageSize);
     }
 
@@ -187,23 +187,23 @@ public class GHMyself extends GHUser {
      *      Filter by a specific state
      */
     public PagedIterable<GHMembership> listOrgMemberships(final GHMembership.State state) {
-        return root.retrieve()
+        return getRoot().retrieve()
             .with("state",state)
             .asPagedIterable(
                 "/user/memberships/orgs",
                 GHMembership[].class,
-                item -> item.wrap(root) );
+                item -> item.wrap(getRoot()) );
     }
 
     /**
      * Gets your membership in a specific organization.
      */
     public GHMembership getMembership(GHOrganization o) throws IOException {
-        return root.retrieve().to("/user/memberships/orgs/"+o.getLogin(),GHMembership.class).wrap(root);
+        return getRoot().retrieve().to("/user/memberships/orgs/"+o.getLogin(),GHMembership.class).wrap(getRoot());
     }
 
 //    public void addEmails(Collection<String> emails) throws IOException {
-////        new Requester(root,ApiVersion.V3).withCredential().to("/user/emails");
-//        root.retrieveWithAuth3()
+////        new Requester(getRoot(),ApiVersion.V3).withCredential().to("/user/emails");
+//        getRoot().retrieveWithAuth3()
 //    }
 }

--- a/src/main/java/org/kohsuke/github/GHMyself.java
+++ b/src/main/java/org/kohsuke/github/GHMyself.java
@@ -67,7 +67,7 @@ public class GHMyself extends GHUser {
      *      Always non-null.
      */
     public List<GHEmail> getEmails2() throws IOException {
-        GHEmail[] addresses = getRoot().retrieve().to("/user/emails", GHEmail[].class);
+        GHEmail[] addresses = getRoot().createRequest().method("GET").to("/user/emails", GHEmail[].class);
         return Collections.unmodifiableList(Arrays.asList(addresses));
     }
 
@@ -81,7 +81,7 @@ public class GHMyself extends GHUser {
      *      Always non-null.
      */
     public List<GHKey> getPublicKeys() throws IOException {
-        return Collections.unmodifiableList(Arrays.asList(getRoot().retrieve().to("/user/keys", GHKey[].class)));
+        return Collections.unmodifiableList(Arrays.asList(getRoot().createRequest().method("GET").to("/user/keys", GHKey[].class)));
     }
 
     /**
@@ -95,7 +95,7 @@ public class GHMyself extends GHUser {
      *      Always non-null.
      */
   public List<GHVerifiedKey> getPublicVerifiedKeys() throws IOException {
-    return Collections.unmodifiableList(Arrays.asList(getRoot().retrieve().to(
+    return Collections.unmodifiableList(Arrays.asList(getRoot().createRequest().method("GET").to(
         "/users/" + getLogin() + "/keys", GHVerifiedKey[].class)));
   }
 
@@ -105,7 +105,7 @@ public class GHMyself extends GHUser {
     public GHPersonSet<GHOrganization> getAllOrganizations() throws IOException {
         GHPersonSet<GHOrganization> orgs = new GHPersonSet<GHOrganization>();
         Set<String> names = new HashSet<String>();
-        for (GHOrganization o : getRoot().retrieve().to("/user/orgs", GHOrganization[].class)) {
+        for (GHOrganization o : getRoot().createRequest().method("GET").to("/user/orgs", GHOrganization[].class)) {
             if (names.add(o.getLogin()))    // in case of rumoured duplicates in the data
                 orgs.add(getRoot().getOrganization(o.getLogin()));
         }
@@ -156,7 +156,7 @@ public class GHMyself extends GHUser {
      * @param repoType type of repository returned in the listing
      */
     public PagedIterable<GHRepository> listRepositories(final int pageSize, final RepositoryListFilter repoType) {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .with("type",repoType)
             .asPagedIterable(
                 "/user/repos",
@@ -186,7 +186,7 @@ public class GHMyself extends GHUser {
      *      Filter by a specific state
      */
     public PagedIterable<GHMembership> listOrgMemberships(final GHMembership.State state) {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .with("state",state)
             .asPagedIterable(
                 "/user/memberships/orgs",
@@ -197,7 +197,7 @@ public class GHMyself extends GHUser {
      * Gets your membership in a specific organization.
      */
     public GHMembership getMembership(GHOrganization o) throws IOException {
-        return getRoot().retrieve().to("/user/memberships/orgs/"+o.getLogin(),GHMembership.class);
+        return getRoot().createRequest().method("GET").to("/user/memberships/orgs/"+o.getLogin(),GHMembership.class);
     }
 
 //    public void addEmails(Collection<String> emails) throws IOException {

--- a/src/main/java/org/kohsuke/github/GHNotificationStream.java
+++ b/src/main/java/org/kohsuke/github/GHNotificationStream.java
@@ -27,8 +27,7 @@ import java.util.NoSuchElementException;
  * @see GitHub#listNotifications()
  * @see GHRepository#listNotifications()
  */
-public class GHNotificationStream implements Iterable<GHThread> {
-    private final GitHub root;
+public class GHNotificationStream extends GHObjectBase implements Iterable<GHThread> {
 
     private Boolean all, participating;
     private String since;

--- a/src/main/java/org/kohsuke/github/GHNotificationStream.java
+++ b/src/main/java/org/kohsuke/github/GHNotificationStream.java
@@ -35,7 +35,7 @@ public class GHNotificationStream extends GHObjectBase implements Iterable<GHThr
     private boolean nonBlocking = false;
 
     /*package*/ GHNotificationStream(GitHub root, String apiUrl) {
-        this.root = root;
+        super(root);
         this.apiUrl = apiUrl;
     }
 

--- a/src/main/java/org/kohsuke/github/GHNotificationStream.java
+++ b/src/main/java/org/kohsuke/github/GHNotificationStream.java
@@ -80,7 +80,7 @@ public class GHNotificationStream extends GHObjectBase implements Iterable<GHThr
      */
     public Iterator<GHThread> iterator() {
         // capture the configuration setting here
-        final Requester req = new Requester(root).method("GET")
+        final Requester req = new Requester(getRoot()).method("GET")
                 .with("all", all).with("participating", participating).with("since", since);
 
         return new Iterator<GHThread>() {
@@ -140,7 +140,7 @@ public class GHNotificationStream extends GHObjectBase implements Iterable<GHThr
                             long nt = n.getUpdatedAt().getTime();
                             if (nt >= lastUpdated) {
                                 lastUpdated = nt;
-                                return n.wrap(root);
+                                return n.wrap(getRoot());
                             }
                         }
 
@@ -197,7 +197,7 @@ public class GHNotificationStream extends GHObjectBase implements Iterable<GHThr
      * Marks all the notifications as read.
      */
     public void markAsRead(long timestamp) throws IOException {
-        final Requester req = new Requester(root).method("PUT");
+        final Requester req = new Requester(getRoot()).method("PUT");
         if (timestamp>=0)
             req.with("last_read_at", GitHub.printDate(new Date(timestamp)));
         req.asHttpStatusCode(apiUrl);

--- a/src/main/java/org/kohsuke/github/GHNotificationStream.java
+++ b/src/main/java/org/kohsuke/github/GHNotificationStream.java
@@ -140,7 +140,7 @@ public class GHNotificationStream extends GHObjectBase implements Iterable<GHThr
                             long nt = n.getUpdatedAt().getTime();
                             if (nt >= lastUpdated) {
                                 lastUpdated = nt;
-                                return n.wrap(getRoot());
+                                return n;
                             }
                         }
 

--- a/src/main/java/org/kohsuke/github/GHNotificationStream.java
+++ b/src/main/java/org/kohsuke/github/GHNotificationStream.java
@@ -80,7 +80,7 @@ public class GHNotificationStream extends GHObjectBase implements Iterable<GHThr
      */
     public Iterator<GHThread> iterator() {
         // capture the configuration setting here
-        final Requester req = new Requester(getRoot()).method("GET")
+        final Requester req = createRequest().method("GET")
                 .with("all", all).with("participating", participating).with("since", since);
 
         return new Iterator<GHThread>() {
@@ -197,7 +197,7 @@ public class GHNotificationStream extends GHObjectBase implements Iterable<GHThr
      * Marks all the notifications as read.
      */
     public void markAsRead(long timestamp) throws IOException {
-        final Requester req = new Requester(getRoot()).method("PUT");
+        final Requester req = createRequest().method("PUT");
         if (timestamp>=0)
             req.with("last_read_at", GitHub.printDate(new Date(timestamp)));
         req.asHttpStatusCode(apiUrl);

--- a/src/main/java/org/kohsuke/github/GHObject.java
+++ b/src/main/java/org/kohsuke/github/GHObject.java
@@ -30,6 +30,7 @@ public abstract class GHObject extends GHObjectBase {
     protected String updated_at;
 
     /*package*/ GHObject() {
+
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHObject.java
+++ b/src/main/java/org/kohsuke/github/GHObject.java
@@ -18,7 +18,7 @@ import java.util.Map;
  */
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
-public abstract class GHObject {
+public abstract class GHObject extends GHObjectBase {
     /**
      * Capture response HTTP headers on the state object.
      */

--- a/src/main/java/org/kohsuke/github/GHObjectBase.java
+++ b/src/main/java/org/kohsuke/github/GHObjectBase.java
@@ -13,5 +13,13 @@ import org.kohsuke.github.GitHub;
 public abstract class GHObjectBase {
 
     @JacksonInject
-    GitHub root = null;
+    final GitHub root;
+
+    GHObjectBase() {
+        this(GitHub.offline());
+    }
+
+    GHObjectBase(GitHub root) {
+        this.root = root;
+    }
 }

--- a/src/main/java/org/kohsuke/github/GHObjectBase.java
+++ b/src/main/java/org/kohsuke/github/GHObjectBase.java
@@ -1,9 +1,9 @@
 package org.kohsuke.github;
 
 import com.fasterxml.jackson.annotation.JacksonInject;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.kohsuke.github.GitHub;
+
+import javax.annotation.Nonnull;
 
 /**
  * Most (all?) domain objects in GitHub seems to have these 4 properties.
@@ -12,14 +12,31 @@ import org.kohsuke.github.GitHub;
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
 public abstract class GHObjectBase {
 
-    @JacksonInject
-    final GitHub root;
+    /**
+     * Effectively final.
+     */
+    @Nonnull
+    private GitHub root;
 
     GHObjectBase() {
         this(GitHub.offline());
     }
 
-    GHObjectBase(GitHub root) {
+    GHObjectBase(@Nonnull GitHub root) {
         this.root = root;
     }
+
+    GitHub getRoot() {
+        return root;
+    }
+
+    /**
+     * Adding this setter to allow objects to override and hook in.
+     * @param root
+     */
+    @JacksonInject(value = "org.kohsuke.github.GitHub")
+    void setRoot(@Nonnull GitHub root) {
+        this.root = root;
+    }
+
 }

--- a/src/main/java/org/kohsuke/github/GHObjectBase.java
+++ b/src/main/java/org/kohsuke/github/GHObjectBase.java
@@ -35,8 +35,10 @@ public abstract class GHObjectBase {
      * @param root
      */
     @JacksonInject(value = "org.kohsuke.github.GitHub")
-    void setRoot(@Nonnull GitHub root) {
-        this.root = root;
+    void setRoot(GitHub root) {
+        if (root != null) {
+            this.root = root;
+        }
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHObjectBase.java
+++ b/src/main/java/org/kohsuke/github/GHObjectBase.java
@@ -6,25 +6,29 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import javax.annotation.Nonnull;
 
 /**
- * Most (all?) domain objects in GitHub seems to have these 4 properties.
+ *
  */
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
 public abstract class GHObjectBase {
 
+    private final static GitHub DEFAULT_OFFLINE_ROOT = GitHub.offline();
     /**
      * Effectively final.
+     * TODO: Make this actually final.
      */
     @Nonnull
+    @JacksonInject(value = "org.kohsuke.github.GitHub")
     private GitHub root;
 
     GHObjectBase() {
-        this(GitHub.offline());
+        this(DEFAULT_OFFLINE_ROOT);
     }
 
     GHObjectBase(@Nonnull GitHub root) {
         this.root = root;
     }
+
 
     GitHub getRoot() {
         return root;
@@ -32,13 +36,20 @@ public abstract class GHObjectBase {
 
     /**
      * Adding this setter to allow objects to override and hook in.
-     * @param root
+     *
+     * @param root the ro
+     * @deprecated This will be removed soon. Root should be final.
      */
-    @JacksonInject(value = "org.kohsuke.github.GitHub")
     void setRoot(GitHub root) {
         if (root != null) {
             this.root = root;
         }
     }
+
+    @Nonnull
+    Requester createRequest() {
+        return getRoot().createRequest();
+    }
+
 
 }

--- a/src/main/java/org/kohsuke/github/GHObjectBase.java
+++ b/src/main/java/org/kohsuke/github/GHObjectBase.java
@@ -1,0 +1,17 @@
+package org.kohsuke.github;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.kohsuke.github.GitHub;
+
+/**
+ * Most (all?) domain objects in GitHub seems to have these 4 properties.
+ */
+@SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
+    "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
+public abstract class GHObjectBase {
+
+    @JacksonInject
+    GitHub root = null;
+}

--- a/src/main/java/org/kohsuke/github/GHOrgHook.java
+++ b/src/main/java/org/kohsuke/github/GHOrgHook.java
@@ -17,7 +17,7 @@ class GHOrgHook extends GHHook {
 
     @Override
     GitHub getRoot() {
-        return organization.root;
+        return organization.getRoot();
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -203,8 +203,7 @@ public class GHOrganization extends GHPerson {
                         .with("state", status)
                         .asPagedIterable(
                             String.format("/orgs/%s/projects", login),
-                            GHProject[].class,
-                            item -> item.wrap(getRoot()) );
+                            GHProject[].class);
     }
 
     /**
@@ -222,7 +221,7 @@ public class GHOrganization extends GHPerson {
                 .withPreview(INERTIA)
                 .with("name", name)
                 .with("body", body)
-                .to(String.format("/orgs/%s/projects", login), GHProject.class).wrap(getRoot());
+                .to(String.format("/orgs/%s/projects", login), GHProject.class);
     }
 
     public enum Permission { ADMIN, PUSH, PULL }
@@ -279,8 +278,7 @@ public class GHOrganization extends GHPerson {
         return getRoot().retrieve()
             .asPagedIterable(
                 String.format("/orgs/%s/events", login),
-                GHEventInfo[].class,
-                item -> item.wrapUp(getRoot()) );
+                GHEventInfo[].class);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -112,7 +112,7 @@ public class GHOrganization extends GHPerson {
      * @see <a href="https://developer.github.com/v3/orgs/members/#add-or-update-organization-membership">documentation</a>
      */
     public void add(GHUser user, Role role) throws IOException {
-        getRoot().createRequest().method("GET").method("PUT")
+        getRoot().createRequest().method("PUT")
                 .with("role", role.name().toLowerCase())
                 .to("/orgs/" + login + "/memberships/" + user.getLogin());
     }
@@ -134,7 +134,7 @@ public class GHOrganization extends GHPerson {
      * all teams, and remove their access to the organization’s repositories.
      */
     public void remove(GHUser user) throws IOException {
-        getRoot().createRequest().method("GET").method("DELETE").to("/orgs/" + login + "/members/"  + user.getLogin());
+        getRoot().createRequest().method("DELETE").to("/orgs/" + login + "/members/"  + user.getLogin());
     }
 
     /**
@@ -153,7 +153,7 @@ public class GHOrganization extends GHPerson {
      * Publicizes the membership.
      */
     public void publicize(GHUser u) throws IOException {
-        getRoot().createRequest().method("GET").method("PUT").to("/orgs/" + login + "/public_members/" + u.getLogin(), null);
+        getRoot().createRequest().method("PUT").to("/orgs/" + login + "/public_members/" + u.getLogin(), null);
     }
 
     /**
@@ -197,7 +197,7 @@ public class GHOrganization extends GHPerson {
      * Conceals the membership.
      */
     public void conceal(GHUser u) throws IOException {
-        getRoot().createRequest().method("GET").method("DELETE").to("/orgs/" + login + "/public_members/" + u.getLogin(), null);
+        getRoot().createRequest().method("DELETE").to("/orgs/" + login + "/public_members/" + u.getLogin(), null);
     }
 
     /**
@@ -223,7 +223,7 @@ public class GHOrganization extends GHPerson {
      * Creates a project for the organization.
      */
     public GHProject createProject(String name, String body) throws IOException {
-        return getRoot().createRequest().method("GET").method("POST")
+        return getRoot().createRequest().method("POST")
                 .withPreview(INERTIA)
                 .with("name", name)
                 .with("body", body)

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -230,7 +230,7 @@ public class GHOrganization extends GHPerson {
      * Creates a new team and assigns the repositories.
      */
     public GHTeam createTeam(String name, Permission p, Collection<GHRepository> repositories) throws IOException {
-        Requester post = new Requester(getRoot()).with("name", name).with("permission", p);
+        Requester post = createRequest().with("name", name).with("permission", p);
         List<String> repo_names = new ArrayList<String>();
         for (GHRepository r : repositories) {
             repo_names.add(login + "/" + r.getName());

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -15,10 +15,6 @@ import static org.kohsuke.github.Previews.INERTIA;
  * @author Kohsuke Kawaguchi
  */
 public class GHOrganization extends GHPerson {
-    /*package*/ GHOrganization wrapUp(GitHub root) {
-        return this;
-    }
-
     /**
      * Creates a new repository.
      *
@@ -188,8 +184,7 @@ public class GHOrganization extends GHPerson {
         return getRoot().retrieve()
             .asPagedIterable(
                 String.format("/orgs/%s/%s%s", login, suffix, filterParams),
-                GHUser[].class,
-                item -> item.wrapUp(getRoot()) );
+                GHUser[].class);
     }
 
     /**
@@ -258,7 +253,6 @@ public class GHOrganization extends GHPerson {
     public List<GHRepository> getRepositoriesWithOpenPullRequests() throws IOException {
         List<GHRepository> r = new ArrayList<GHRepository>();
         for (GHRepository repository : listRepositories(100)) {
-            repository.wrap(getRoot());
             List<GHPullRequest> pullRequests = repository.getPullRequests(GHIssueState.OPEN);
             if (pullRequests.size() > 0) {
                 r.add(repository);
@@ -301,8 +295,7 @@ public class GHOrganization extends GHPerson {
         return getRoot().retrieve()
             .asPagedIterable(
                 "/orgs/" + login + "/repos",
-                GHRepository[].class,
-                item -> item.wrap(getRoot())
+                GHRepository[].class
             ).withPageSize(pageSize);
     }
 

--- a/src/main/java/org/kohsuke/github/GHPermission.java
+++ b/src/main/java/org/kohsuke/github/GHPermission.java
@@ -51,9 +51,5 @@ import java.util.Locale;
     }
 
     void wrapUp(GitHub root) {
-        if (user != null) {
-            user.root = root;
-        }
     }
-
 }

--- a/src/main/java/org/kohsuke/github/GHPermission.java
+++ b/src/main/java/org/kohsuke/github/GHPermission.java
@@ -49,7 +49,4 @@ import java.util.Locale;
     public GHUser getUser() {
         return user;
     }
-
-    void wrapUp(GitHub root) {
-    }
 }

--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -17,8 +17,6 @@ import java.util.TreeMap;
  * @author Kohsuke Kawaguchi
  */
 public abstract class GHPerson extends GHObject {
-    /*package almost final*/ GitHub root;
-
     // core data fields that exist even for "small" user data (such as the user info in pull request)
     protected String login, avatar_url, gravatar_id;
 

--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -37,7 +37,7 @@ public abstract class GHPerson extends GHObject {
         if (getRoot() == null || getRoot().isOffline()) {
             return; // cannot populate, will have to live with what we have
         }
-        getRoot().retrieve().to(url, this);
+        getRoot().createRequest().method("GET").to(url, this);
     }
 
     /**
@@ -72,7 +72,7 @@ public abstract class GHPerson extends GHObject {
      * Unlike {@link #getRepositories()}, this does not wait until all the repositories are returned.
      */
     public PagedIterable<GHRepository> listRepositories(final int pageSize) {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .asPagedIterable(
                 "/users/" + login + "/repos",
                 GHRepository[].class
@@ -96,7 +96,7 @@ public abstract class GHPerson extends GHObject {
     public synchronized Iterable<List<GHRepository>> iterateRepositories(final int pageSize) {
         return new Iterable<List<GHRepository>>() {
             public Iterator<List<GHRepository>> iterator() {
-                final Iterator<GHRepository[]> pager = getRoot().retrieve().asIterator("/users/" + login + "/repos",GHRepository[].class, pageSize);
+                final Iterator<GHRepository[]> pager = getRoot().createRequest().method("GET").asIterator("/users/" + login + "/repos",GHRepository[].class, pageSize);
 
                 return new Iterator<List<GHRepository>>() {
                     public boolean hasNext() {
@@ -123,7 +123,7 @@ public abstract class GHPerson extends GHObject {
      */
     public GHRepository getRepository(String name) throws IOException {
         try {
-            return getRoot().retrieve().to("/repos/" + login + '/' + name, GHRepository.class);
+            return getRoot().createRequest().method("GET").to("/repos/" + login + '/' + name, GHRepository.class);
         } catch (FileNotFoundException e) {
             return null;
         }

--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -25,10 +25,6 @@ public abstract class GHPerson extends GHObject {
     protected String html_url;
     protected int followers,following,public_repos,public_gists;
 
-    /*package*/ GHPerson wrapUp(GitHub root) {
-        return this;
-    }
-
     /**
      * Fully populate the data by retrieving missing data.
      *
@@ -38,10 +34,10 @@ public abstract class GHPerson extends GHObject {
         if (created_at!=null) {
             return; // already populated
         }
-        if (root == null || root.isOffline()) {
+        if (getRoot() == null || getRoot().isOffline()) {
             return; // cannot populate, will have to live with what we have
         }
-        root.retrieve().to(url, this);
+        getRoot().retrieve().to(url, this);
     }
 
     /**
@@ -76,11 +72,11 @@ public abstract class GHPerson extends GHObject {
      * Unlike {@link #getRepositories()}, this does not wait until all the repositories are returned.
      */
     public PagedIterable<GHRepository> listRepositories(final int pageSize) {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 "/users/" + login + "/repos",
                 GHRepository[].class,
-                item -> item.wrap(root)
+                item -> item.wrap(getRoot())
             ).withPageSize(pageSize);
     }
 
@@ -101,7 +97,7 @@ public abstract class GHPerson extends GHObject {
     public synchronized Iterable<List<GHRepository>> iterateRepositories(final int pageSize) {
         return new Iterable<List<GHRepository>>() {
             public Iterator<List<GHRepository>> iterator() {
-                final Iterator<GHRepository[]> pager = root.retrieve().asIterator("/users/" + login + "/repos",GHRepository[].class, pageSize);
+                final Iterator<GHRepository[]> pager = getRoot().retrieve().asIterator("/users/" + login + "/repos",GHRepository[].class, pageSize);
 
                 return new Iterator<List<GHRepository>>() {
                     public boolean hasNext() {
@@ -128,7 +124,7 @@ public abstract class GHPerson extends GHObject {
      */
     public GHRepository getRepository(String name) throws IOException {
         try {
-            return root.retrieve().to("/repos/" + login + '/' + name, GHRepository.class).wrap(root);
+            return getRoot().retrieve().to("/repos/" + login + '/' + name, GHRepository.class).wrap(getRoot());
         } catch (FileNotFoundException e) {
             return null;
         }

--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -26,7 +26,6 @@ public abstract class GHPerson extends GHObject {
     protected int followers,following,public_repos,public_gists;
 
     /*package*/ GHPerson wrapUp(GitHub root) {
-        this.root = root;
         return this;
     }
 
@@ -111,8 +110,6 @@ public abstract class GHPerson extends GHObject {
 
                     public List<GHRepository> next() {
                         GHRepository[] batch = pager.next();
-                        for (GHRepository r : batch)
-                            r.root = root;
                         return Arrays.asList(batch);
                     }
 

--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -75,8 +75,7 @@ public abstract class GHPerson extends GHObject {
         return getRoot().retrieve()
             .asPagedIterable(
                 "/users/" + login + "/repos",
-                GHRepository[].class,
-                item -> item.wrap(getRoot())
+                GHRepository[].class
             ).withPageSize(pageSize);
     }
 
@@ -124,7 +123,7 @@ public abstract class GHPerson extends GHObject {
      */
     public GHRepository getRepository(String name) throws IOException {
         try {
-            return getRoot().retrieve().to("/repos/" + login + '/' + name, GHRepository.class).wrap(getRoot());
+            return getRoot().retrieve().to("/repos/" + login + '/' + name, GHRepository.class);
         } catch (FileNotFoundException e) {
             return null;
         }

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -60,11 +60,11 @@ public class GHProject extends GHObject {
         if(owner == null) {
             try {
                 if(owner_url.contains("/orgs/")) {
-                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHOrganization.class);
+                    owner = getRoot().createRequest().method("GET").to(getOwnerUrl().getPath(), GHOrganization.class);
                 } else if(owner_url.contains("/users/")) {
-                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHUser.class);
+                    owner = getRoot().createRequest().method("GET").to(getOwnerUrl().getPath(), GHUser.class);
                 } else if(owner_url.contains("/repos/")) {
-                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHRepository.class);
+                    owner = getRoot().createRequest().method("GET").to(getOwnerUrl().getPath(), GHRepository.class);
                 }
             } catch (FileNotFoundException e) {
                 return null;
@@ -159,7 +159,7 @@ public class GHProject extends GHObject {
 
     public PagedIterable<GHProjectColumn> listColumns() throws IOException {
         final GHProject project = this;
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .withPreview(INERTIA)
             .asPagedIterable(
                 String.format("/projects/%d/columns", id),
@@ -168,7 +168,7 @@ public class GHProject extends GHObject {
     }
 
     public GHProjectColumn createColumn(String name) throws IOException {
-        return getRoot().retrieve().method("POST")
+        return getRoot().createRequest().method("GET").method("POST")
                 .withPreview(INERTIA)
                 .with("name", name)
                 .to(String.format("/projects/%d/columns", id), GHProjectColumn.class).wrap(this);

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -168,7 +168,7 @@ public class GHProject extends GHObject {
     }
 
     public GHProjectColumn createColumn(String name) throws IOException {
-        return getRoot().createRequest().method("GET").method("POST")
+        return getRoot().createRequest().method("POST")
                 .withPreview(INERTIA)
                 .with("name", name)
                 .to(String.format("/projects/%d/columns", id), GHProjectColumn.class).wrap(this);

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -53,18 +53,18 @@ public class GHProject extends GHObject {
     }
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
     public GHObject getOwner() throws IOException {
         if(owner == null) {
             try {
                 if(owner_url.contains("/orgs/")) {
-                    owner = root.retrieve().to(getOwnerUrl().getPath(), GHOrganization.class).wrapUp(root);
+                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHOrganization.class).wrapUp(getRoot());
                 } else if(owner_url.contains("/users/")) {
-                    owner = root.retrieve().to(getOwnerUrl().getPath(), GHUser.class).wrapUp(root);
+                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHUser.class).wrapUp(getRoot());
                 } else if(owner_url.contains("/repos/")) {
-                    owner = root.retrieve().to(getOwnerUrl().getPath(), GHRepository.class).wrap(root);
+                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHRepository.class).wrap(getRoot());
                 }
             } catch (FileNotFoundException e) {
                 return null;
@@ -111,7 +111,7 @@ public class GHProject extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(root).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+        new Requester(getRoot()).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     protected String getApiRoute() {
@@ -158,12 +158,12 @@ public class GHProject extends GHObject {
     }
 
     public void delete() throws IOException {
-        new Requester(root).withPreview(INERTIA).method("DELETE").to(getApiRoute());
+        new Requester(getRoot()).withPreview(INERTIA).method("DELETE").to(getApiRoute());
     }
 
     public PagedIterable<GHProjectColumn> listColumns() throws IOException {
         final GHProject project = this;
-        return root.retrieve()
+        return getRoot().retrieve()
             .withPreview(INERTIA)
             .asPagedIterable(
                 String.format("/projects/%d/columns", id),
@@ -172,7 +172,7 @@ public class GHProject extends GHObject {
     }
 
     public GHProjectColumn createColumn(String name) throws IOException {
-        return root.retrieve().method("POST")
+        return getRoot().retrieve().method("POST")
                 .withPreview(INERTIA)
                 .with("name", name)
                 .to(String.format("/projects/%d/columns", id), GHProjectColumn.class).wrap(this);

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -107,7 +107,7 @@ public class GHProject extends GHObject {
     }
 
     private void edit(String key, Object value) throws IOException {
-        new Requester(getRoot()).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+        createRequest().withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
     }
 
     protected String getApiRoute() {
@@ -154,7 +154,7 @@ public class GHProject extends GHObject {
     }
 
     public void delete() throws IOException {
-        new Requester(getRoot()).withPreview(INERTIA).method("DELETE").to(getApiRoute());
+        createRequest().withPreview(INERTIA).method("DELETE").to(getApiRoute());
     }
 
     public PagedIterable<GHProjectColumn> listColumns() throws IOException {

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -106,10 +106,6 @@ public class GHProject extends GHObject {
         return this;
     }
 
-    public GHProject wrap(GitHub root) {
-        return this;
-    }
-
     private void edit(String key, Object value) throws IOException {
         new Requester(getRoot()).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
     }

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -103,12 +103,10 @@ public class GHProject extends GHObject {
 
     public GHProject wrap(GHRepository repo) {
         this.owner = repo;
-        this.root = repo.root;
         return this;
     }
 
     public GHProject wrap(GitHub root) {
-        this.root = root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -36,7 +36,6 @@ import static org.kohsuke.github.Previews.INERTIA;
  * @author Martin van Zijl
  */
 public class GHProject extends GHObject {
-    protected GitHub root;
     protected GHObject owner;
 
     private String owner_url;

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -60,11 +60,11 @@ public class GHProject extends GHObject {
         if(owner == null) {
             try {
                 if(owner_url.contains("/orgs/")) {
-                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHOrganization.class).wrapUp(getRoot());
+                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHOrganization.class);
                 } else if(owner_url.contains("/users/")) {
-                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHUser.class).wrapUp(getRoot());
+                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHUser.class);
                 } else if(owner_url.contains("/repos/")) {
-                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHRepository.class).wrap(getRoot());
+                    owner = getRoot().retrieve().to(getOwnerUrl().getPath(), GHRepository.class);
                 }
             } catch (FileNotFoundException e) {
                 return null;

--- a/src/main/java/org/kohsuke/github/GHProjectCard.java
+++ b/src/main/java/org/kohsuke/github/GHProjectCard.java
@@ -103,7 +103,7 @@ public class GHProjectCard extends GHObject {
 	}
 
 	private void edit(String key, Object value) throws IOException {
-		new Requester(getRoot()).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+		createRequest().withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
 	}
 
 	protected String getApiRoute() {
@@ -111,6 +111,6 @@ public class GHProjectCard extends GHObject {
 	}
 
 	public void delete() throws IOException {
-		new Requester(getRoot()).withPreview(INERTIA).method("DELETE").to(getApiRoute());
+		createRequest().withPreview(INERTIA).method("DELETE").to(getApiRoute());
 	}
 }

--- a/src/main/java/org/kohsuke/github/GHProjectCard.java
+++ b/src/main/java/org/kohsuke/github/GHProjectCard.java
@@ -24,10 +24,6 @@ public class GHProjectCard extends GHObject {
 		return null;
 	}
 
-	public GHProjectCard wrap(GitHub root) {
-		return this;
-	}
-
 	public GHProjectCard wrap(GHProjectColumn column) {
 		this.column = column;
 		this.project = column.project;
@@ -41,7 +37,7 @@ public class GHProjectCard extends GHObject {
 	public GHProject getProject() throws IOException {
 		if(project == null) {
 			try {
-				project = getRoot().retrieve().to(getProjectUrl().getPath(), GHProject.class).wrap(getRoot());
+				project = getRoot().retrieve().to(getProjectUrl().getPath(), GHProject.class);
 			} catch (FileNotFoundException e) {
 				return null;
 			}
@@ -52,7 +48,7 @@ public class GHProjectCard extends GHObject {
 	public GHProjectColumn getColumn() throws IOException {
 		if(column == null) {
 			try {
-				column = getRoot().retrieve().to(getColumnUrl().getPath(), GHProjectColumn.class).wrap(getRoot());
+				column = getRoot().retrieve().to(getColumnUrl().getPath(), GHProjectColumn.class);
 			} catch (FileNotFoundException e) {
 				return null;
 			}

--- a/src/main/java/org/kohsuke/github/GHProjectCard.java
+++ b/src/main/java/org/kohsuke/github/GHProjectCard.java
@@ -37,7 +37,7 @@ public class GHProjectCard extends GHObject {
 	public GHProject getProject() throws IOException {
 		if(project == null) {
 			try {
-				project = getRoot().retrieve().to(getProjectUrl().getPath(), GHProject.class);
+				project = getRoot().createRequest().method("GET").to(getProjectUrl().getPath(), GHProject.class);
 			} catch (FileNotFoundException e) {
 				return null;
 			}
@@ -48,7 +48,7 @@ public class GHProjectCard extends GHObject {
 	public GHProjectColumn getColumn() throws IOException {
 		if(column == null) {
 			try {
-				column = getRoot().retrieve().to(getColumnUrl().getPath(), GHProjectColumn.class);
+				column = getRoot().createRequest().method("GET").to(getColumnUrl().getPath(), GHProjectColumn.class);
 			} catch (FileNotFoundException e) {
 				return null;
 			}
@@ -61,9 +61,9 @@ public class GHProjectCard extends GHObject {
 			return null;
 		try {
 			if(content_url.contains("/pulls")) {
-				return getRoot().retrieve().to(getContentUrl().getPath(), GHPullRequest.class);
+				return getRoot().createRequest().method("GET").to(getContentUrl().getPath(), GHPullRequest.class);
 			} else {
-				return getRoot().retrieve().to(getContentUrl().getPath(), GHIssue.class);
+				return getRoot().createRequest().method("GET").to(getContentUrl().getPath(), GHIssue.class);
 			}
 		} catch (FileNotFoundException e) {
 			return null;

--- a/src/main/java/org/kohsuke/github/GHProjectCard.java
+++ b/src/main/java/org/kohsuke/github/GHProjectCard.java
@@ -25,14 +25,12 @@ public class GHProjectCard extends GHObject {
 	}
 
 	public GHProjectCard wrap(GitHub root) {
-		this.root = root;
 		return this;
 	}
 
 	public GHProjectCard wrap(GHProjectColumn column) {
 		this.column = column;
 		this.project = column.project;
-		this.root = column.root;
 		return this;
 	}
 

--- a/src/main/java/org/kohsuke/github/GHProjectCard.java
+++ b/src/main/java/org/kohsuke/github/GHProjectCard.java
@@ -12,7 +12,6 @@ import static org.kohsuke.github.Previews.INERTIA;
  * @author Gunnar Skjold
  */
 public class GHProjectCard extends GHObject {
-	private GitHub root;
 	private GHProject project;
 	private GHProjectColumn column;
 

--- a/src/main/java/org/kohsuke/github/GHProjectCard.java
+++ b/src/main/java/org/kohsuke/github/GHProjectCard.java
@@ -65,9 +65,9 @@ public class GHProjectCard extends GHObject {
 			return null;
 		try {
 			if(content_url.contains("/pulls")) {
-				return getRoot().retrieve().to(getContentUrl().getPath(), GHPullRequest.class).wrap(getRoot());
+				return getRoot().retrieve().to(getContentUrl().getPath(), GHPullRequest.class);
 			} else {
-				return getRoot().retrieve().to(getContentUrl().getPath(), GHIssue.class).wrap(getRoot());
+				return getRoot().retrieve().to(getContentUrl().getPath(), GHIssue.class);
 			}
 		} catch (FileNotFoundException e) {
 			return null;

--- a/src/main/java/org/kohsuke/github/GHProjectCard.java
+++ b/src/main/java/org/kohsuke/github/GHProjectCard.java
@@ -35,13 +35,13 @@ public class GHProjectCard extends GHObject {
 	}
 
 	public GitHub getRoot() {
-		return root;
+		return super.getRoot();
 	}
 
 	public GHProject getProject() throws IOException {
 		if(project == null) {
 			try {
-				project = root.retrieve().to(getProjectUrl().getPath(), GHProject.class).wrap(root);
+				project = getRoot().retrieve().to(getProjectUrl().getPath(), GHProject.class).wrap(getRoot());
 			} catch (FileNotFoundException e) {
 				return null;
 			}
@@ -52,7 +52,7 @@ public class GHProjectCard extends GHObject {
 	public GHProjectColumn getColumn() throws IOException {
 		if(column == null) {
 			try {
-				column = root.retrieve().to(getColumnUrl().getPath(), GHProjectColumn.class).wrap(root);
+				column = getRoot().retrieve().to(getColumnUrl().getPath(), GHProjectColumn.class).wrap(getRoot());
 			} catch (FileNotFoundException e) {
 				return null;
 			}
@@ -65,9 +65,9 @@ public class GHProjectCard extends GHObject {
 			return null;
 		try {
 			if(content_url.contains("/pulls")) {
-				return root.retrieve().to(getContentUrl().getPath(), GHPullRequest.class).wrap(root);
+				return getRoot().retrieve().to(getContentUrl().getPath(), GHPullRequest.class).wrap(getRoot());
 			} else {
-				return root.retrieve().to(getContentUrl().getPath(), GHIssue.class).wrap(root);
+				return getRoot().retrieve().to(getContentUrl().getPath(), GHIssue.class).wrap(getRoot());
 			}
 		} catch (FileNotFoundException e) {
 			return null;
@@ -107,7 +107,7 @@ public class GHProjectCard extends GHObject {
 	}
 
 	private void edit(String key, Object value) throws IOException {
-		new Requester(root).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+		new Requester(getRoot()).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
 	}
 
 	protected String getApiRoute() {
@@ -115,6 +115,6 @@ public class GHProjectCard extends GHObject {
 	}
 
 	public void delete() throws IOException {
-		new Requester(root).withPreview(INERTIA).method("DELETE").to(getApiRoute());
+		new Requester(getRoot()).withPreview(INERTIA).method("DELETE").to(getApiRoute());
 	}
 }

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -10,7 +10,6 @@ import static org.kohsuke.github.Previews.INERTIA;
  * @author Gunnar Skjold
  */
 public class GHProjectColumn extends GHObject {
-	protected GitHub root;
 	protected GHProject project;
 
 	private String name;

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -75,14 +75,14 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	public GHProjectCard createCard(String note) throws IOException {
-		return getRoot().createRequest().method("GET").method("POST")
+		return getRoot().createRequest().method("POST")
 				.withPreview(INERTIA)
 				.with("note", note)
 				.to(String.format("/projects/columns/%d/cards", id), GHProjectCard.class).wrap(this);
 	}
 
 	public GHProjectCard createCard(GHIssue issue) throws IOException {
-		return getRoot().createRequest().method("GET").method("POST")
+		return getRoot().createRequest().method("POST")
 				.withPreview(INERTIA)
 				.with("content_type", issue instanceof GHPullRequest ? "PullRequest" : "Issue")
 				.with("content_id", issue.getId())

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -30,13 +30,13 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	public GitHub getRoot() {
-		return root;
+		return super.getRoot();
 	}
 
 	public GHProject getProject() throws IOException {
 		if(project == null) {
 			try {
-				project = root.retrieve().to(getProjectUrl().getPath(), GHProject.class).wrap(root);
+				project = getRoot().retrieve().to(getProjectUrl().getPath(), GHProject.class).wrap(getRoot());
 			} catch (FileNotFoundException e) {
 				return null;
 			}
@@ -57,7 +57,7 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	private void edit(String key, Object value) throws IOException {
-		new Requester(root).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+		new Requester(getRoot()).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
 	}
 
 	protected String getApiRoute() {
@@ -65,12 +65,12 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	public void delete() throws IOException {
-		new Requester(root).withPreview(INERTIA).method("DELETE").to(getApiRoute());
+		new Requester(getRoot()).withPreview(INERTIA).method("DELETE").to(getApiRoute());
 	}
 
 	public PagedIterable<GHProjectCard> listCards() throws IOException {
 		final GHProjectColumn column = this;
-		return root.retrieve()
+		return getRoot().retrieve()
 			.withPreview(INERTIA)
 			.asPagedIterable(
 				String.format("/projects/columns/%d/cards", id),
@@ -79,14 +79,14 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	public GHProjectCard createCard(String note) throws IOException {
-		return root.retrieve().method("POST")
+		return getRoot().retrieve().method("POST")
 				.withPreview(INERTIA)
 				.with("note", note)
 				.to(String.format("/projects/columns/%d/cards", id), GHProjectCard.class).wrap(this);
 	}
 
 	public GHProjectCard createCard(GHIssue issue) throws IOException {
-		return root.retrieve().method("POST")
+		return getRoot().retrieve().method("POST")
 				.withPreview(INERTIA)
 				.with("content_type", issue instanceof GHPullRequest ? "PullRequest" : "Issue")
 				.with("content_id", issue.getId())

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -21,13 +21,11 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	public GHProjectColumn wrap(GitHub root) {
-		this.root = root;
 		return this;
 	}
 
 	public GHProjectColumn wrap(GHProject project) {
 		this.project = project;
-		this.root = project.root;
 		return this;
 	}
 

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -32,7 +32,7 @@ public class GHProjectColumn extends GHObject {
 	public GHProject getProject() throws IOException {
 		if(project == null) {
 			try {
-				project = getRoot().retrieve().to(getProjectUrl().getPath(), GHProject.class);
+				project = getRoot().createRequest().method("GET").to(getProjectUrl().getPath(), GHProject.class);
 			} catch (FileNotFoundException e) {
 				return null;
 			}
@@ -66,7 +66,7 @@ public class GHProjectColumn extends GHObject {
 
 	public PagedIterable<GHProjectCard> listCards() throws IOException {
 		final GHProjectColumn column = this;
-		return getRoot().retrieve()
+		return getRoot().createRequest().method("GET")
 			.withPreview(INERTIA)
 			.asPagedIterable(
 				String.format("/projects/columns/%d/cards", id),
@@ -75,14 +75,14 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	public GHProjectCard createCard(String note) throws IOException {
-		return getRoot().retrieve().method("POST")
+		return getRoot().createRequest().method("GET").method("POST")
 				.withPreview(INERTIA)
 				.with("note", note)
 				.to(String.format("/projects/columns/%d/cards", id), GHProjectCard.class).wrap(this);
 	}
 
 	public GHProjectCard createCard(GHIssue issue) throws IOException {
-		return getRoot().retrieve().method("POST")
+		return getRoot().createRequest().method("GET").method("POST")
 				.withPreview(INERTIA)
 				.with("content_type", issue instanceof GHPullRequest ? "PullRequest" : "Issue")
 				.with("content_id", issue.getId())

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -53,7 +53,7 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	private void edit(String key, Object value) throws IOException {
-		new Requester(getRoot()).withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
+		createRequest().withPreview(INERTIA)._with(key, value).method("PATCH").to(getApiRoute());
 	}
 
 	protected String getApiRoute() {
@@ -61,7 +61,7 @@ public class GHProjectColumn extends GHObject {
 	}
 
 	public void delete() throws IOException {
-		new Requester(getRoot()).withPreview(INERTIA).method("DELETE").to(getApiRoute());
+		createRequest().withPreview(INERTIA).method("DELETE").to(getApiRoute());
 	}
 
 	public PagedIterable<GHProjectCard> listCards() throws IOException {

--- a/src/main/java/org/kohsuke/github/GHProjectColumn.java
+++ b/src/main/java/org/kohsuke/github/GHProjectColumn.java
@@ -20,10 +20,6 @@ public class GHProjectColumn extends GHObject {
 		return null;
 	}
 
-	public GHProjectColumn wrap(GitHub root) {
-		return this;
-	}
-
 	public GHProjectColumn wrap(GHProject project) {
 		this.project = project;
 		return this;
@@ -36,7 +32,7 @@ public class GHProjectColumn extends GHObject {
 	public GHProject getProject() throws IOException {
 		if(project == null) {
 			try {
-				project = getRoot().retrieve().to(getProjectUrl().getPath(), GHProject.class).wrap(getRoot());
+				project = getRoot().retrieve().to(getProjectUrl().getPath(), GHProject.class);
 			} catch (FileNotFoundException e) {
 				return null;
 			}

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -78,16 +78,6 @@ public class GHPullRequest extends GHIssue implements Refreshable {
 
     GHPullRequest wrapUp(GHRepository owner) {
         this.wrap(owner);
-        return wrapUp(owner.getRoot());
-    }
-
-    GHPullRequest wrapUp(GitHub root) {
-        if (owner != null) owner.wrap(root);
-        if (base != null) base.wrapUp(root);
-        if (head != null) head.wrapUp(root);
-        if (merged_by != null) merged_by.wrapUp(root);
-        if (requested_reviewers != null) GHUser.wrap(requested_reviewers, root);
-        if (requested_teams != null) GHTeam.wrapUp(requested_teams, this);
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -78,7 +78,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
 
     GHPullRequest wrapUp(GHRepository owner) {
         this.wrap(owner);
-        return wrapUp(owner.root);
+        return wrapUp(owner.getRoot());
     }
 
     GHPullRequest wrapUp(GitHub root) {
@@ -268,10 +268,10 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      * Repopulates this object.
      */
     public void refresh() throws IOException {
-        if (root.isOffline()) {
+        if (getRoot().isOffline()) {
             return; // cannot populate, will have to live with what we have
         }
-        root.retrieve()
+        getRoot().retrieve()
             .withPreview(SHADOW_CAT)
             .to(url, this).wrapUp(owner);
     }
@@ -280,7 +280,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      * Retrieves all the files associated to this pull request.
      */
     public PagedIterable<GHPullRequestFileDetail> listFiles() {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 String.format("%s/files", getApiRoute()),
                 GHPullRequestFileDetail[].class,
@@ -291,7 +291,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      * Retrieves all the reviews associated to this pull request.
      */
     public PagedIterable<GHPullRequestReview> listReviews() {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 String.format("%s/reviews", getApiRoute()),
                 GHPullRequestReview[].class,
@@ -302,7 +302,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      * Obtains all the review comments associated with this pull request.
      */
     public PagedIterable<GHPullRequestReviewComment> listReviewComments() throws IOException {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 getApiRoute() + COMMENTS_ACTION,
                         GHPullRequestReviewComment[].class,
@@ -313,7 +313,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      * Retrieves all the commits associated to this pull request.
      */
     public PagedIterable<GHPullRequestCommitDetail> listCommits() {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                         String.format("%s/commits", getApiRoute()),
                         GHPullRequestCommitDetail[].class,
@@ -347,7 +347,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     }
 
     public GHPullRequestReviewComment createReviewComment(String body, String sha, String path, int position) throws IOException {
-        return new Requester(root).method("POST")
+        return new Requester(getRoot()).method("POST")
                 .with("body", body)
                 .with("commit_id", sha)
                 .with("path", path)
@@ -356,7 +356,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     }
 
     public void requestReviewers(List<GHUser> reviewers) throws IOException {
-        new Requester(root).method("POST")
+        new Requester(getRoot()).method("POST")
                 .withLogins("reviewers", reviewers)
                 .to(getApiRoute() + REQUEST_REVIEWERS);
     }
@@ -366,7 +366,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
         for (GHTeam team : teams) {
           teamReviewers.add(team.getSlug());
         }
-        new Requester(root).method("POST")
+        new Requester(getRoot()).method("POST")
                 .with("team_reviewers", teamReviewers)
                 .to(getApiRoute() + REQUEST_REVIEWERS);
     }
@@ -408,7 +408,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      *      SHA that pull request head must match to allow merge.
      */
     public void merge(String msg, String sha, MergeMethod method) throws IOException {
-        new Requester(root).method("PUT")
+        new Requester(getRoot()).method("PUT")
                 .with("commit_message", msg)
                 .with("sha", sha)
                 .with("merge_method", method)
@@ -419,7 +419,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
 
     private void fetchIssue() throws IOException {
         if (!fetchedIssueDetails) {
-            new Requester(root).method("GET").to(getIssuesApiRoute(), this);
+            new Requester(getRoot()).method("GET").to(getIssuesApiRoute(), this);
             fetchedIssueDetails = true;
         }
     }

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -79,7 +79,9 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     @Nonnull
     @Override
     Requester createRequest() {
-        return owner.createRequest().inject(this);
+        return owner.createRequest()
+            .inject(this)
+            .inject(GHIssue.class.getName(), this);
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHPullRequest.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequest.java
@@ -337,7 +337,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     }
 
     public GHPullRequestReviewComment createReviewComment(String body, String sha, String path, int position) throws IOException {
-        return new Requester(getRoot()).method("POST")
+        return createRequest().method("POST")
                 .with("body", body)
                 .with("commit_id", sha)
                 .with("path", path)
@@ -346,7 +346,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
     }
 
     public void requestReviewers(List<GHUser> reviewers) throws IOException {
-        new Requester(getRoot()).method("POST")
+        createRequest().method("POST")
                 .withLogins("reviewers", reviewers)
                 .to(getApiRoute() + REQUEST_REVIEWERS);
     }
@@ -356,7 +356,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
         for (GHTeam team : teams) {
           teamReviewers.add(team.getSlug());
         }
-        new Requester(getRoot()).method("POST")
+        createRequest().method("POST")
                 .with("team_reviewers", teamReviewers)
                 .to(getApiRoute() + REQUEST_REVIEWERS);
     }
@@ -398,7 +398,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
      *      SHA that pull request head must match to allow merge.
      */
     public void merge(String msg, String sha, MergeMethod method) throws IOException {
-        new Requester(getRoot()).method("PUT")
+        createRequest().method("PUT")
                 .with("commit_message", msg)
                 .with("sha", sha)
                 .with("merge_method", method)
@@ -409,7 +409,7 @@ public class GHPullRequest extends GHIssue implements Refreshable {
 
     private void fetchIssue() throws IOException {
         if (!fetchedIssueDetails) {
-            new Requester(getRoot()).method("GET").to(getIssuesApiRoute(), this);
+            createRequest().method("GET").to(getIssuesApiRoute(), this);
             fetchedIssueDetails = true;
         }
     }

--- a/src/main/java/org/kohsuke/github/GHPullRequestCommitDetail.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestCommitDetail.java
@@ -23,6 +23,7 @@
  */
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -37,11 +38,9 @@ import java.net.URL;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
     "NP_UNWRITTEN_FIELD", "URF_UNREAD_FIELD"}, justification = "JSON API")
 public class GHPullRequestCommitDetail {
-    private GHPullRequest owner;
 
-    /*package*/ void wrapUp(GHPullRequest owner) {
-        this.owner = owner;
-    }
+    @JacksonInject("org.kohsuke.github.GHPullRequest")
+    private GHPullRequest owner;
 
     /**
      * @deprecated Use {@link GitUser}

--- a/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
@@ -12,7 +12,7 @@ public class GHPullRequestQueryBuilder extends GHQueryBuilder<GHPullRequest> {
     private final GHRepository repo;
 
     /*package*/ GHPullRequestQueryBuilder(GHRepository repo) {
-        super(repo.getRoot());
+        super(repo.getRoot(), repo.createRequest());
         this.repo = repo;
     }
 
@@ -52,7 +52,6 @@ public class GHPullRequestQueryBuilder extends GHQueryBuilder<GHPullRequest> {
             .withPreview(SHADOW_CAT)
             .asPagedIterable(
             repo.getApiTailUrl("pulls"),
-            GHPullRequest[].class,
-            item -> item.wrapUp(repo) );
+            GHPullRequest[].class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestQueryBuilder.java
@@ -12,7 +12,7 @@ public class GHPullRequestQueryBuilder extends GHQueryBuilder<GHPullRequest> {
     private final GHRepository repo;
 
     /*package*/ GHPullRequestQueryBuilder(GHRepository repo) {
-        super(repo.root);
+        super(repo.getRoot());
         this.repo = repo;
     }
 

--- a/src/main/java/org/kohsuke/github/GHPullRequestReview.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReview.java
@@ -69,7 +69,7 @@ public class GHPullRequestReview extends GHObject {
      * Gets the user who posted this review.
      */
     public GHUser getUser() throws IOException {
-        return owner.root.getUser(user.getLogin());
+        return owner.getRoot().getUser(user.getLogin());
     }
 
     public String getCommitId() {
@@ -118,7 +118,7 @@ public class GHPullRequestReview extends GHObject {
      * Updates the comment.
      */
     public void submit(String body, GHPullRequestReviewEvent event) throws IOException {
-        new Requester(owner.root).method("POST")
+        new Requester(owner.getRoot()).method("POST")
                 .with("body", body)
                 .with("event", event.action())
                 .to(getApiRoute()+"/events",this);
@@ -130,7 +130,7 @@ public class GHPullRequestReview extends GHObject {
      * Deletes this review.
      */
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE")
+        new Requester(owner.getRoot()).method("DELETE")
                 .to(getApiRoute());
     }
 
@@ -138,7 +138,7 @@ public class GHPullRequestReview extends GHObject {
      * Dismisses this review.
      */
     public void dismiss(String message) throws IOException {
-        new Requester(owner.root).method("PUT")
+        new Requester(owner.getRoot()).method("PUT")
                 .with("message", message)
                 .to(getApiRoute()+"/dismissals");
         state = GHPullRequestReviewState.DISMISSED;
@@ -148,7 +148,7 @@ public class GHPullRequestReview extends GHObject {
      * Obtains all the review comments associated with this pull request review.
      */
     public PagedIterable<GHPullRequestReviewComment> listReviewComments() throws IOException {
-        return owner.root.retrieve()
+        return owner.getRoot().retrieve()
             .asPagedIterable(
                 getApiRoute() + "/comments",
                 GHPullRequestReviewComment[].class,

--- a/src/main/java/org/kohsuke/github/GHPullRequestReview.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReview.java
@@ -118,7 +118,7 @@ public class GHPullRequestReview extends GHObject {
      * Updates the comment.
      */
     public void submit(String body, GHPullRequestReviewEvent event) throws IOException {
-        new Requester(owner.getRoot()).method("POST")
+        owner.createRequest().method("POST")
                 .with("body", body)
                 .with("event", event.action())
                 .to(getApiRoute()+"/events",this);
@@ -130,7 +130,7 @@ public class GHPullRequestReview extends GHObject {
      * Deletes this review.
      */
     public void delete() throws IOException {
-        new Requester(owner.getRoot()).method("DELETE")
+        owner.createRequest().method("DELETE")
                 .to(getApiRoute());
     }
 
@@ -138,7 +138,7 @@ public class GHPullRequestReview extends GHObject {
      * Dismisses this review.
      */
     public void dismiss(String message) throws IOException {
-        new Requester(owner.getRoot()).method("PUT")
+        owner.createRequest().method("PUT")
                 .with("message", message)
                 .to(getApiRoute()+"/dismissals");
         state = GHPullRequestReviewState.DISMISSED;

--- a/src/main/java/org/kohsuke/github/GHPullRequestReview.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReview.java
@@ -23,6 +23,7 @@
  */
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Date;
@@ -38,6 +39,8 @@ import java.net.URL;
  */
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_FIELD"}, justification = "JSON API")
 public class GHPullRequestReview extends GHObject {
+
+    @JacksonInject("org.kohsuke.github.GHPullRequest")
     GHPullRequest owner;
 
     private String body;
@@ -45,11 +48,6 @@ public class GHPullRequestReview extends GHObject {
     private String commit_id;
     private GHPullRequestReviewState state;
     private String submitted_at;
-
-    /*package*/ GHPullRequestReview wrapUp(GHPullRequest owner) {
-        this.owner = owner;
-        return this;
-    }
 
     /**
      * Gets the pull request to which this review is associated.
@@ -148,10 +146,9 @@ public class GHPullRequestReview extends GHObject {
      * Obtains all the review comments associated with this pull request review.
      */
     public PagedIterable<GHPullRequestReviewComment> listReviewComments() throws IOException {
-        return owner.getRoot().retrieve()
+        return owner.createRequest().method("GET")
             .asPagedIterable(
                 getApiRoute() + "/comments",
-                GHPullRequestReviewComment[].class,
-                item -> item.wrapUp(owner) );
+                GHPullRequestReviewComment[].class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
@@ -17,7 +17,7 @@ public class GHPullRequestReviewBuilder {
 
     /*package*/ GHPullRequestReviewBuilder(GHPullRequest pr) {
         this.pr = pr;
-        this.builder = new Requester(pr.getRoot());
+        this.builder = pr.createRequest();
     }
 
     //     public GHPullRequestReview createReview(@Nullable String commitId, String body, GHPullRequestReviewEvent event,

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
@@ -61,8 +61,7 @@ public class GHPullRequestReviewBuilder {
 
     public GHPullRequestReview create() throws IOException {
         return builder.method("POST")._with("comments",comments)
-                .to(pr.getApiRoute() + "/reviews", GHPullRequestReview.class)
-                .wrapUp(pr);
+                .to(pr.getApiRoute() + "/reviews", GHPullRequestReview.class);
     }
 
     private static class DraftReviewComment {

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewBuilder.java
@@ -17,7 +17,7 @@ public class GHPullRequestReviewBuilder {
 
     /*package*/ GHPullRequestReviewBuilder(GHPullRequest pr) {
         this.pr = pr;
-        this.builder = new Requester(pr.root);
+        this.builder = new Requester(pr.getRoot());
     }
 
     //     public GHPullRequestReview createReview(@Nullable String commitId, String body, GHPullRequestReviewEvent event,

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
@@ -116,7 +116,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
      * Updates the comment.
      */
     public void update(String body) throws IOException {
-        new Requester(owner.getRoot()).method("PATCH").with("body", body).to(getApiRoute(),this);
+        owner.createRequest().method("PATCH").with("body", body).to(getApiRoute(),this);
         this.body = body;
     }
 
@@ -124,14 +124,14 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
      * Deletes this review comment.
      */
     public void delete() throws IOException {
-        new Requester(owner.getRoot()).method("DELETE").to(getApiRoute());
+        owner.createRequest().method("DELETE").to(getApiRoute());
     }
 
     /**
      * Create a new comment that replies to this comment.
      */
     public GHPullRequestReviewComment reply(String body) throws IOException {
-        return new Requester(owner.getRoot()).method("POST")
+        return owner.createRequest().method("POST")
                 .with("body", body)
                 .with("in_reply_to", getId())
                 .to(getApiRoute() + "/comments", GHPullRequestReviewComment.class)
@@ -140,7 +140,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.getRoot())
+        return owner.createRequest()
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
                 .to(getApiRoute()+"/reactions", GHReaction.class);

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
@@ -23,6 +23,8 @@
  */
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+
 import java.io.IOException;
 import java.net.URL;
 import javax.annotation.CheckForNull;
@@ -37,6 +39,8 @@ import static org.kohsuke.github.Previews.*;
  * @see GHPullRequest#createReviewComment(String, String, String, int)
  */
 public class GHPullRequestReviewComment extends GHObject implements Reactable {
+
+    @JacksonInject("org.kohsuke.github.GHPullRequest")
     GHPullRequest owner;
 
     private String body;
@@ -57,11 +61,6 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
         result.path = path;
         result.position = position;
         return result;
-    }
-
-    /*package*/ GHPullRequestReviewComment wrapUp(GHPullRequest owner) {
-        this.owner = owner;
-        return this;
     }
 
     /**
@@ -134,8 +133,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
         return owner.createRequest().method("POST")
                 .with("body", body)
                 .with("in_reply_to", getId())
-                .to(getApiRoute() + "/comments", GHPullRequestReviewComment.class)
-                .wrapUp(owner);
+                .to(getApiRoute() + "/comments", GHPullRequestReviewComment.class);
     }
 
     @Preview @Deprecated
@@ -148,7 +146,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return owner.getRoot().retrieve()
+        return owner.getRoot().createRequest().method("GET")
             .withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiRoute() + "/reactions",

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
@@ -82,7 +82,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
      * Gets the user who posted this comment.
      */
     public GHUser getUser() throws IOException {
-        return owner.root.getUser(user.getLogin());
+        return owner.getRoot().getUser(user.getLogin());
     }
 
     public String getPath() {
@@ -116,7 +116,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
      * Updates the comment.
      */
     public void update(String body) throws IOException {
-        new Requester(owner.root).method("PATCH").with("body", body).to(getApiRoute(),this);
+        new Requester(owner.getRoot()).method("PATCH").with("body", body).to(getApiRoute(),this);
         this.body = body;
     }
 
@@ -124,14 +124,14 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
      * Deletes this review comment.
      */
     public void delete() throws IOException {
-        new Requester(owner.root).method("DELETE").to(getApiRoute());
+        new Requester(owner.getRoot()).method("DELETE").to(getApiRoute());
     }
 
     /**
      * Create a new comment that replies to this comment.
      */
     public GHPullRequestReviewComment reply(String body) throws IOException {
-        return new Requester(owner.root).method("POST")
+        return new Requester(owner.getRoot()).method("POST")
                 .with("body", body)
                 .with("in_reply_to", getId())
                 .to(getApiRoute() + "/comments", GHPullRequestReviewComment.class)
@@ -140,19 +140,19 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
 
     @Preview @Deprecated
     public GHReaction createReaction(ReactionContent content) throws IOException {
-        return new Requester(owner.root)
+        return new Requester(owner.getRoot())
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
-                .to(getApiRoute()+"/reactions", GHReaction.class).wrap(owner.root);
+                .to(getApiRoute()+"/reactions", GHReaction.class).wrap(owner.getRoot());
     }
 
     @Preview @Deprecated
     public PagedIterable<GHReaction> listReactions() {
-        return owner.root.retrieve()
+        return owner.getRoot().retrieve()
             .withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiRoute() + "/reactions",
                 GHReaction[].class,
-                item -> item.wrap(owner.root) );
+                item -> item.wrap(owner.getRoot()) );
     }
 }

--- a/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
+++ b/src/main/java/org/kohsuke/github/GHPullRequestReviewComment.java
@@ -143,7 +143,7 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
         return new Requester(owner.getRoot())
                 .withPreview(SQUIRREL_GIRL)
                 .with("content", content.getContent())
-                .to(getApiRoute()+"/reactions", GHReaction.class).wrap(owner.getRoot());
+                .to(getApiRoute()+"/reactions", GHReaction.class);
     }
 
     @Preview @Deprecated
@@ -152,7 +152,6 @@ public class GHPullRequestReviewComment extends GHObject implements Reactable {
             .withPreview(SQUIRREL_GIRL)
             .asPagedIterable(
                 getApiRoute() + "/reactions",
-                GHReaction[].class,
-                item -> item.wrap(owner.getRoot()) );
+                GHReaction[].class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHQueryBuilder.java
@@ -5,8 +5,7 @@ package org.kohsuke.github;
  *
  * @author Kohsuke Kawaguchi
  */
-public abstract class GHQueryBuilder<T> {
-    protected final GitHub root;
+public abstract class GHQueryBuilder<T> extends GHObjectBase {
     protected final Requester req;
 
     /*package*/ GHQueryBuilder(GitHub root) {

--- a/src/main/java/org/kohsuke/github/GHQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHQueryBuilder.java
@@ -8,9 +8,9 @@ package org.kohsuke.github;
 public abstract class GHQueryBuilder<T> extends GHObjectBase {
     protected final Requester req;
 
-    /*package*/ GHQueryBuilder(GitHub root) {
+    /*package*/ GHQueryBuilder(GitHub root, Requester requester) {
         super(root);
-        this.req = root.retrieve();
+        this.req = requester;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHQueryBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHQueryBuilder.java
@@ -9,7 +9,7 @@ public abstract class GHQueryBuilder<T> extends GHObjectBase {
     protected final Requester req;
 
     /*package*/ GHQueryBuilder(GitHub root) {
-        this.root = root;
+        super(root);
         this.req = root.retrieve();
     }
 

--- a/src/main/java/org/kohsuke/github/GHReaction.java
+++ b/src/main/java/org/kohsuke/github/GHReaction.java
@@ -13,8 +13,6 @@ import static org.kohsuke.github.Previews.*;
  */
 @Preview @Deprecated
 public class GHReaction extends GHObject {
-    private GitHub root;
-
     private GHUser user;
     private ReactionContent content;
 

--- a/src/main/java/org/kohsuke/github/GHReaction.java
+++ b/src/main/java/org/kohsuke/github/GHReaction.java
@@ -47,6 +47,6 @@ public class GHReaction extends GHObject {
      * Removes this reaction.
      */
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").withPreview(SQUIRREL_GIRL).to("/reactions/"+id);
+        new Requester(getRoot()).method("DELETE").withPreview(SQUIRREL_GIRL).to("/reactions/"+id);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHReaction.java
+++ b/src/main/java/org/kohsuke/github/GHReaction.java
@@ -16,11 +16,6 @@ public class GHReaction extends GHObject {
     private GHUser user;
     private ReactionContent content;
 
-    /*package*/ GHReaction wrap(GitHub root) {
-        user.wrapUp(root);
-        return this;
-    }
-
     /**
      * The kind of reaction left.
      */

--- a/src/main/java/org/kohsuke/github/GHReaction.java
+++ b/src/main/java/org/kohsuke/github/GHReaction.java
@@ -17,7 +17,6 @@ public class GHReaction extends GHObject {
     private ReactionContent content;
 
     /*package*/ GHReaction wrap(GitHub root) {
-        this.root = root;
         user.wrapUp(root);
         return this;
     }

--- a/src/main/java/org/kohsuke/github/GHReaction.java
+++ b/src/main/java/org/kohsuke/github/GHReaction.java
@@ -42,6 +42,6 @@ public class GHReaction extends GHObject {
      * Removes this reaction.
      */
     public void delete() throws IOException {
-        new Requester(getRoot()).method("DELETE").withPreview(SQUIRREL_GIRL).to("/reactions/"+id);
+        createRequest().method("DELETE").withPreview(SQUIRREL_GIRL).to("/reactions/"+id);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHRef.java
+++ b/src/main/java/org/kohsuke/github/GHRef.java
@@ -56,7 +56,7 @@ public class GHRef extends GHObjectBase {
      */
     public void updateTo(String sha, Boolean force) throws IOException {
       new Requester(getRoot())
-          .with("sha", sha).with("force", force).method("PATCH").to(url, GHRef.class).wrap(getRoot());
+          .with("sha", sha).with("force", force).method("PATCH").to(url, GHRef.class);
     }
 
     /**
@@ -64,17 +64,6 @@ public class GHRef extends GHObjectBase {
      */
     public void delete() throws IOException {
       new Requester(getRoot()).method("DELETE").to(url);
-    }
-
-    /*package*/ GHRef wrap(GitHub root) {
-        return this;
-    }
-
-    /*package*/ static GHRef[] wrap(GHRef[] in, GitHub root) {
-        for (GHRef r : in) {
-            r.wrap(root);
-        }
-        return in;
     }
 
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 

--- a/src/main/java/org/kohsuke/github/GHRef.java
+++ b/src/main/java/org/kohsuke/github/GHRef.java
@@ -55,15 +55,15 @@ public class GHRef extends GHObjectBase {
      *      Whether or not to force this ref update.
      */
     public void updateTo(String sha, Boolean force) throws IOException {
-      new Requester(root)
-          .with("sha", sha).with("force", force).method("PATCH").to(url, GHRef.class).wrap(root);
+      new Requester(getRoot())
+          .with("sha", sha).with("force", force).method("PATCH").to(url, GHRef.class).wrap(getRoot());
     }
 
     /**
      * Deletes this ref from the repository using the GitHub API.
      */
     public void delete() throws IOException {
-      new Requester(root).method("DELETE").to(url);
+      new Requester(getRoot()).method("DELETE").to(url);
     }
 
     /*package*/ GHRef wrap(GitHub root) {

--- a/src/main/java/org/kohsuke/github/GHRef.java
+++ b/src/main/java/org/kohsuke/github/GHRef.java
@@ -55,7 +55,7 @@ public class GHRef extends GHObjectBase {
      *      Whether or not to force this ref update.
      */
     public void updateTo(String sha, Boolean force) throws IOException {
-      new Requester(getRoot())
+      createRequest()
           .with("sha", sha).with("force", force).method("PATCH").to(url, GHRef.class);
     }
 
@@ -63,7 +63,7 @@ public class GHRef extends GHObjectBase {
      * Deletes this ref from the repository using the GitHub API.
      */
     public void delete() throws IOException {
-      new Requester(getRoot()).method("DELETE").to(url);
+      createRequest().method("DELETE").to(url);
     }
 
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 

--- a/src/main/java/org/kohsuke/github/GHRef.java
+++ b/src/main/java/org/kohsuke/github/GHRef.java
@@ -10,8 +10,7 @@ import java.net.URL;
  *
  * @author Michael Clarke
  */
-public class GHRef {
-    /*package almost final*/ GitHub root;
+public class GHRef extends GHObjectBase {
 
     private String ref, url;
     private GHObject object;

--- a/src/main/java/org/kohsuke/github/GHRef.java
+++ b/src/main/java/org/kohsuke/github/GHRef.java
@@ -67,7 +67,6 @@ public class GHRef extends GHObjectBase {
     }
 
     /*package*/ GHRef wrap(GitHub root) {
-        this.root = root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -82,7 +82,7 @@ public class GHRelease extends GHObject {
     }
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
     public String getTagName() {
@@ -133,7 +133,7 @@ public class GHRelease extends GHObject {
     }
     
     public GHAsset uploadAsset(String filename, InputStream stream, String contentType) throws IOException {
-        Requester builder = new Requester(owner.root);
+        Requester builder = new Requester(owner.getRoot());
 
         String url = format("https://uploads.github.com%s/releases/%d/assets?name=%s",
                 owner.getApiTailUrl(""), getId(), filename);
@@ -143,7 +143,7 @@ public class GHRelease extends GHObject {
     }
 
     public List<GHAsset> getAssets() throws IOException {
-        Requester builder = new Requester(owner.root);
+        Requester builder = new Requester(owner.getRoot());
 
         GHAsset[] assets = builder
                 .method("GET")
@@ -155,7 +155,7 @@ public class GHRelease extends GHObject {
      * Deletes this release.
      */
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").to(owner.getApiTailUrl("releases/"+id));
+        new Requester(getRoot()).method("DELETE").to(owner.getApiTailUrl("releases/"+id));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -133,7 +133,7 @@ public class GHRelease extends GHObject {
     }
     
     public GHAsset uploadAsset(String filename, InputStream stream, String contentType) throws IOException {
-        Requester builder = new Requester(owner.getRoot());
+        Requester builder = owner.createRequest();
 
         String url = format("https://uploads.github.com%s/releases/%d/assets?name=%s",
                 owner.getApiTailUrl(""), getId(), filename);
@@ -143,7 +143,7 @@ public class GHRelease extends GHObject {
     }
 
     public List<GHAsset> getAssets() throws IOException {
-        Requester builder = new Requester(owner.getRoot());
+        Requester builder = owner.createRequest();
 
         GHAsset[] assets = builder
                 .method("GET")
@@ -155,7 +155,7 @@ public class GHRelease extends GHObject {
      * Deletes this release.
      */
     public void delete() throws IOException {
-        new Requester(getRoot()).method("DELETE").to(owner.getApiTailUrl("releases/"+id));
+        createRequest().method("DELETE").to(owner.getApiTailUrl("releases/"+id));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -18,7 +18,6 @@ import static java.lang.String.*;
  * @see GHRepository#createRelease(String)
  */
 public class GHRelease extends GHObject {
-    GitHub root;
     GHRepository owner;
 
     private String html_url;

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -18,6 +20,8 @@ import static java.lang.String.*;
  * @see GHRepository#createRelease(String)
  */
 public class GHRelease extends GHObject {
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     GHRepository owner;
 
     private String html_url;
@@ -103,18 +107,6 @@ public class GHRelease extends GHObject {
 
     public String getTarballUrl() {
         return tarball_url;
-    }
-
-    GHRelease wrap(GHRepository owner) {
-        this.owner = owner;
-        return this;
-    }
-
-    static GHRelease[] wrap(GHRelease[] releases, GHRepository owner) {
-        for (GHRelease release : releases) {
-            release.wrap(owner);
-        }
-        return releases;
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -107,7 +107,6 @@ public class GHRelease extends GHObject {
 
     GHRelease wrap(GHRepository owner) {
         this.owner = owner;
-        this.root = owner.root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHReleaseBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHReleaseBuilder.java
@@ -68,6 +68,6 @@ public class GHReleaseBuilder {
     }
 
     public GHRelease create() throws IOException {
-        return builder.to(repo.getApiTailUrl("releases"), GHRelease.class).wrap(repo);
+        return builder.to(repo.getApiTailUrl("releases"), GHRelease.class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHReleaseBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHReleaseBuilder.java
@@ -13,7 +13,7 @@ public class GHReleaseBuilder {
 
     public GHReleaseBuilder(GHRepository ghRepository, String tag) {
         this.repo = ghRepository;
-        this.builder = new Requester(repo.root);
+        this.builder = new Requester(repo.getRoot());
         builder.with("tag_name", tag);
     }
 

--- a/src/main/java/org/kohsuke/github/GHReleaseBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHReleaseBuilder.java
@@ -13,7 +13,7 @@ public class GHReleaseBuilder {
 
     public GHReleaseBuilder(GHRepository ghRepository, String tag) {
         this.repo = ghRepository;
-        this.builder = new Requester(repo.getRoot());
+        this.builder = repo.createRequest();
         builder.with("tag_name", tag);
     }
 

--- a/src/main/java/org/kohsuke/github/GHReleaseUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHReleaseUpdater.java
@@ -14,7 +14,7 @@ public class GHReleaseUpdater {
 
     GHReleaseUpdater(GHRelease base) {
         this.base = base;
-        this.builder = new Requester(base.getRoot());
+        this.builder = base.createRequest();
     }
 
     public GHReleaseUpdater tag(String tag) {

--- a/src/main/java/org/kohsuke/github/GHReleaseUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHReleaseUpdater.java
@@ -14,7 +14,7 @@ public class GHReleaseUpdater {
 
     GHReleaseUpdater(GHRelease base) {
         this.base = base;
-        this.builder = base.createRequest();
+        this.builder = base.getOwner().createRequest();
     }
 
     public GHReleaseUpdater tag(String tag) {
@@ -75,7 +75,7 @@ public class GHReleaseUpdater {
     public GHRelease update() throws IOException {
         return builder
                 .method("PATCH")
-                .to(base.owner.getApiTailUrl("releases/"+base.id), GHRelease.class).wrap(base.owner);
+                .to(base.owner.getApiTailUrl("releases/"+base.id), GHRelease.class);
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHReleaseUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHReleaseUpdater.java
@@ -14,7 +14,7 @@ public class GHReleaseUpdater {
 
     GHReleaseUpdater(GHRelease base) {
         this.base = base;
-        this.builder = new Requester(base.root);
+        this.builder = new Requester(base.getRoot());
     }
 
     public GHReleaseUpdater tag(String tag) {

--- a/src/main/java/org/kohsuke/github/GHRepoHook.java
+++ b/src/main/java/org/kohsuke/github/GHRepoHook.java
@@ -13,7 +13,7 @@ class GHRepoHook extends GHHook {
 
     @Override
     GitHub getRoot() {
-        return repository.root;
+        return repository.getRoot();
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -510,7 +510,7 @@ public class GHRepository extends GHObject {
      */
     public Set<String> getCollaboratorNames() throws IOException {
         Set<String> r = new HashSet<String>();
-        for (GHUser u : GHUser.wrap(getRoot().retrieve().to(getApiTailUrl("collaborators"), GHUser[].class), getRoot()))
+        for (GHUser u : getRoot().retrieve().to(getApiTailUrl("collaborators"), GHUser[].class))
             r.add(u.login);
         return r;
     }
@@ -688,8 +688,7 @@ public class GHRepository extends GHObject {
         return getRoot().retrieve().with("sort",sort)
             .asPagedIterable(
                 getApiTailUrl("forks"),
-                GHRepository[].class,
-                item -> item.wrap(getRoot()) );
+                GHRepository[].class);
     }
 
     /**
@@ -1124,8 +1123,7 @@ public class GHRepository extends GHObject {
         return getRoot().retrieve()
             .asPagedIterable(
                 String.format("/repos/%s/%s/statuses/%s", getOwnerName(), name, sha1),
-                GHCommitStatus[].class,
-                item -> item.wrapUp(getRoot()) );
+                GHCommitStatus[].class);
     }
 
     /**
@@ -1152,7 +1150,7 @@ public class GHRepository extends GHObject {
                 .with("target_url", targetUrl)
                 .with("description", description)
                 .with("context", context)
-                .to(String.format("/repos/%s/%s/statuses/%s",getOwnerName(),this.name,sha1),GHCommitStatus.class).wrapUp(getRoot());
+                .to(String.format("/repos/%s/%s/statuses/%s",getOwnerName(),this.name,sha1),GHCommitStatus.class);
     }
 
     /**
@@ -1262,8 +1260,7 @@ public class GHRepository extends GHObject {
         return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl(suffix),
-                GHUser[].class,
-                item -> item.wrapUp(getRoot()) );
+                GHUser[].class);
     }
 
     /**
@@ -1368,13 +1365,6 @@ public class GHRepository extends GHObject {
             }
         }
     };
-
-    /*package*/ GHRepository wrap(GitHub root) {
-        if (getRoot().isOffline()) {
-            owner.wrapUp(root);
-        }
-        return this;
-    }
 
     /**
      * Gets branches by {@linkplain GHBranch#getName() their names}.
@@ -1596,8 +1586,7 @@ public class GHRepository extends GHObject {
         return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl("contributors"),
-                Contributor[].class,
-                item -> item.wrapUp(getRoot()) );
+                Contributor[].class);
     }
 
     public static class Contributor extends GHUser {

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -70,7 +70,6 @@ import static org.kohsuke.github.Previews.*;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
 public class GHRepository extends GHObject {
-    /*package almost final*/ GitHub root;
 
     private String description, homepage, name, full_name;
     private String html_url;    // this is the UI

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1374,7 +1374,6 @@ public class GHRepository extends GHObject {
     };
 
     /*package*/ GHRepository wrap(GitHub root) {
-        this.root = root;
         if (root.isOffline()) {
             owner.wrapUp(root);
         }
@@ -1442,7 +1441,6 @@ public class GHRepository extends GHObject {
         if (m == null) {
             m = root.retrieve().to(getApiTailUrl("milestones/" + number), GHMilestone.class);
             m.owner = this;
-            m.root = root;
             milestones.put(m.getNumber(), m);
         }
         return m;

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1200,7 +1200,7 @@ public class GHRepository extends GHObject {
      */
     @Preview @Deprecated
     public GHLabel createLabel(String name, String color, String description) throws IOException {
-        return createRequest().method("GET").method("POST")
+        return createRequest().method("POST")
                 .withPreview(SYMMETRA)
                 .with("name",name)
                 .with("color", color)
@@ -1606,7 +1606,7 @@ public class GHRepository extends GHObject {
      * Create a project for this repository.
      */
     public GHProject createProject(String name, String body) throws IOException {
-        return createRequest().method("GET").method("POST")
+        return createRequest().method("POST")
                 .withPreview(INERTIA)
                 .with("name", name)
                 .with("body", body)

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -295,7 +295,7 @@ public class GHRepository extends GHObject {
      */
     public GHRef createRef(String name, String sha) throws IOException {
         return new Requester(getRoot())
-                .with("ref", name).with("sha", sha).method("POST").to(getApiTailUrl("git/refs"), GHRef.class).wrap(getRoot());
+                .with("ref", name).with("sha", sha).method("POST").to(getApiTailUrl("git/refs"), GHRef.class);
     }
 
     /**
@@ -523,7 +523,6 @@ public class GHRepository extends GHObject {
      */
     public GHPermissionType getPermission(String user) throws IOException {
         GHPermission perm = getRoot().retrieve().to(getApiTailUrl("collaborators/" + user + "/permission"), GHPermission.class);
-        perm.wrapUp(getRoot());
         return perm.getPermissionType();
     }
 
@@ -901,7 +900,7 @@ public class GHRepository extends GHObject {
      * @throws IOException on failure communicating with GitHub
      */
     public GHRef[] getRefs() throws IOException {
-       return GHRef.wrap(getRoot().retrieve().to(String.format("/repos/%s/%s/git/refs", getOwnerName(), name), GHRef[].class), getRoot());
+       return getRoot().retrieve().to(String.format("/repos/%s/%s/git/refs", getOwnerName(), name), GHRef[].class);
     }
 
 
@@ -916,8 +915,7 @@ public class GHRepository extends GHObject {
         return getRoot().retrieve()
             .asPagedIterable(
                 url,
-                GHRef[].class,
-                item -> item.wrap(getRoot()) );
+                GHRef[].class);
     }
 
     /**
@@ -927,7 +925,7 @@ public class GHRepository extends GHObject {
      * @throws IOException on failure communicating with GitHub, potentially due to an invalid ref type being requested
      */
     public GHRef[] getRefs(String refType) throws IOException {
-        return GHRef.wrap(getRoot().retrieve().to(String.format("/repos/%s/%s/git/refs/%s", getOwnerName(), name, refType), GHRef[].class), getRoot());
+        return getRoot().retrieve().to(String.format("/repos/%s/%s/git/refs/%s", getOwnerName(), name, refType), GHRef[].class);
     }
 
     /**
@@ -942,8 +940,7 @@ public class GHRepository extends GHObject {
         return getRoot().retrieve()
             .asPagedIterable(
                 url,
-                GHRef[].class,
-                item -> item.wrap(getRoot()));
+                GHRef[].class);
     }
 
     /**
@@ -961,7 +958,7 @@ public class GHRepository extends GHObject {
         // FIXME: how about other URL unsafe characters, like space, @, : etc? do we need to be using URLEncoder.encode()?
         // OTOH, '/' need no escaping
         refName = refName.replaceAll("#", "%23");
-        return getRoot().retrieve().to(String.format("/repos/%s/%s/git/refs/%s", getOwnerName(), name, refName), GHRef.class).wrap(getRoot());
+        return getRoot().retrieve().to(String.format("/repos/%s/%s/git/refs/%s", getOwnerName(), name, refName), GHRef.class);
     }
 
     /**
@@ -1167,8 +1164,7 @@ public class GHRepository extends GHObject {
         return getRoot().retrieve()
             .asPagedIterable(
                 String.format("/repos/%s/%s/events", getOwnerName(), name),
-                GHEventInfo[].class,
-                item -> item.wrapUp(getRoot()) );
+                GHEventInfo[].class);
     }
 
     /**
@@ -1221,8 +1217,7 @@ public class GHRepository extends GHObject {
         return getRoot().retrieve()
             .asPagedIterable(
                 String.format("/repos/%s/%s/invitations", getOwnerName(), name),
-                GHInvitation[].class,
-                item -> item.wrapUp(getRoot()) );
+                GHInvitation[].class);
     }
 
     /**
@@ -1537,8 +1532,7 @@ public class GHRepository extends GHObject {
      */
     public GHRepository getSource() throws IOException {
         if (source == null) return null;
-        if (source.getRoot() == null)
-            source = getRoot().getRepository(source.getFullName());
+        source = getRoot().getRepository(source.getFullName());
         return source;
     }
 
@@ -1554,8 +1548,7 @@ public class GHRepository extends GHObject {
      */
     public GHRepository getParent() throws IOException {
         if (parent == null) return null;
-        if (parent.getRoot() == null)
-            parent = getRoot().getRepository(parent.getFullName());
+        parent = getRoot().getRepository(parent.getFullName());
         return parent;
     }
 
@@ -1715,8 +1708,7 @@ public class GHRepository extends GHObject {
     public PagedIterable<GHIssueEvent> listIssueEvents() throws IOException {
         return getRoot().retrieve().asPagedIterable(
             getApiTailUrl("issues/events"),
-            GHIssueEvent[].class,
-            item -> item.wrapUp(getRoot()) );
+            GHIssueEvent[].class);
     }
 
     /**
@@ -1724,7 +1716,7 @@ public class GHRepository extends GHObject {
      * See https://developer.github.com/v3/issues/events/#get-a-single-event
      */
     public GHIssueEvent getIssueEvent(long id) throws IOException {
-        return getRoot().retrieve().to(getApiTailUrl("issues/events/" + id), GHIssueEvent.class).wrapUp(getRoot());
+        return getRoot().retrieve().to(getApiTailUrl("issues/events/" + id), GHIssueEvent.class);
     }
 
     // Only used within listTopics().

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -294,7 +294,7 @@ public class GHRepository extends GHObject {
      *      The SHA1 value to set this reference to
      */
     public GHRef createRef(String name, String sha) throws IOException {
-        return new Requester(getRoot())
+        return createRequest()
                 .with("ref", name).with("sha", sha).method("POST").to(getApiTailUrl("git/refs"), GHRef.class);
     }
 
@@ -560,19 +560,19 @@ public class GHRepository extends GHObject {
 
     private void modifyCollaborators(Collection<GHUser> users, String method) throws IOException {
         for (GHUser user : users) {
-            new Requester(getRoot()).method(method).to(getApiTailUrl("collaborators/" + user.getLogin()));
+            createRequest().method(method).to(getApiTailUrl("collaborators/" + user.getLogin()));
         }
     }
 
     public void setEmailServiceHook(String address) throws IOException {
         Map<String, String> config = new HashMap<String, String>();
         config.put("address", address);
-        new Requester(getRoot()).method("POST").with("name", "email").with("config", config).with("active", true)
+        createRequest().method("POST").with("name", "email").with("config", config).with("active", true)
                 .to(getApiTailUrl("hooks"));
     }
 
     private void edit(String key, String value) throws IOException {
-        Requester requester = new Requester(getRoot());
+        Requester requester = createRequest();
         if (!key.equals("name"))
             requester.with("name", name);   // even when we don't change the name, we need to send it in
         requester.with(key, value).method("PATCH").to(getApiTailUrl(""));
@@ -636,7 +636,7 @@ public class GHRepository extends GHObject {
      */
     public void delete() throws IOException {
         try {
-            new Requester(getRoot()).method("DELETE").to(getApiTailUrl(""));
+            createRequest().method("DELETE").to(getApiTailUrl(""));
         } catch (FileNotFoundException x) {
             throw (FileNotFoundException) new FileNotFoundException("Failed to delete " + getOwnerName() + "/" + name + "; might not exist, or you might need the delete_repo scope in your token: http://stackoverflow.com/a/19327004/12916").initCause(x);
         }
@@ -697,7 +697,7 @@ public class GHRepository extends GHObject {
      *      Newly forked repository that belong to you.
      */
     public GHRepository fork() throws IOException {
-        new Requester(getRoot()).method("POST").to(getApiTailUrl("forks"), null);
+        createRequest().method("POST").to(getApiTailUrl("forks"), null);
 
         // this API is asynchronous. we need to wait for a bit
         for (int i=0; i<10; i++) {
@@ -719,7 +719,7 @@ public class GHRepository extends GHObject {
      *      Newly forked repository that belong to you.
      */
     public GHRepository forkTo(GHOrganization org) throws IOException {
-        new Requester(getRoot()).to(getApiTailUrl("forks?org="+org.getLogin()));
+        createRequest().to(getApiTailUrl("forks?org="+org.getLogin()));
 
         // this API is asynchronous. we need to wait for a bit
         for (int i=0; i<10; i++) {
@@ -834,7 +834,7 @@ public class GHRepository extends GHObject {
      */
     public GHPullRequest createPullRequest(String title, String head, String base, String body,
                                            boolean maintainerCanModify, boolean draft) throws IOException {
-        return new Requester(getRoot())
+        return createRequest()
                 .withPreview(SHADOW_CAT)
                 .with("title",title)
                 .with("head",head)
@@ -1142,7 +1142,7 @@ public class GHRepository extends GHObject {
      *      Optinal commit status context.
      */
     public GHCommitStatus createCommitStatus(String sha1, GHCommitState state, String targetUrl, String description, String context) throws IOException {
-        return new Requester(getRoot())
+        return createRequest()
                 .with("state", state)
                 .with("target_url", targetUrl)
                 .with("description", description)
@@ -1504,12 +1504,12 @@ public class GHRepository extends GHObject {
     }
 
     public GHMilestone createMilestone(String title, String description) throws IOException {
-        return new Requester(getRoot())
+        return createRequest()
                 .with("title", title).with("description", description).method("POST").to(getApiTailUrl("milestones"), GHMilestone.class).wrap(this);
     }
 
     public GHDeployKey addDeployKey(String title,String key) throws IOException {
-         return new Requester(getRoot())
+         return createRequest()
          .with("title", title).with("key", key).method("POST").to(getApiTailUrl("keys"), GHDeployKey.class).wrap(this);
 
     }
@@ -1556,7 +1556,7 @@ public class GHRepository extends GHObject {
      * Subscribes to this repository to get notifications.
      */
     public GHSubscription subscribe(boolean subscribed, boolean ignored) throws IOException {
-        return new Requester(getRoot())
+        return createRequest()
             .with("subscribed", subscribed)
             .with("ignored", ignored)
             .method("PUT").to(getApiTailUrl("subscription"), GHSubscription.class).wrapUp(this);
@@ -1652,7 +1652,7 @@ public class GHRepository extends GHObject {
      */
     public Reader renderMarkdown(String text, MarkdownMode mode) throws IOException {
         return new InputStreamReader(
-            new Requester(getRoot())
+            createRequest()
                     .with("text", text)
                     .with("mode",mode==null?null:mode.toString())
                     .with("context", getFullName())
@@ -1738,7 +1738,7 @@ public class GHRepository extends GHObject {
      * See https://developer.github.com/v3/repos/#replace-all-topics-for-a-repository
      */
     public void setTopics(List<String> topics) throws IOException {
-        Requester requester = new Requester(getRoot());
+        Requester requester = createRequest();
         requester.with("names", topics);
         requester.method("PUT").withPreview(MERCY).to(getApiTailUrl("topics"));
     }

--- a/src/main/java/org/kohsuke/github/GHRepositorySearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHRepositorySearchBuilder.java
@@ -76,8 +76,6 @@ public class GHRepositorySearchBuilder extends GHSearchBuilder<GHRepository> {
 
         @Override
         /*package*/ GHRepository[] getItems(GitHub root) {
-            for (GHRepository item : items)
-                item.wrap(root);
             return items;
         }
     }

--- a/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
@@ -16,10 +16,9 @@ import java.util.NoSuchElementException;
  *
  * @author Martin van Zijl
  */
-public class GHRepositoryStatistics {
+public class GHRepositoryStatistics extends GHObjectBase {
 
     private final GHRepository repo;
-    private final GitHub root;
 
     private static final int MAX_WAIT_ITERATIONS = 3;
     private static final int WAIT_SLEEP_INTERVAL = 5000;
@@ -78,7 +77,6 @@ public class GHRepositoryStatistics {
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
         "NP_UNWRITTEN_FIELD", "URF_UNREAD_FIELD"}, justification = "JSON API")
     public static class ContributorStats extends GHObject {
-        /*package almost final*/ private GitHub root;
         private GHUser author;
         private int total;
         private List<Week> weeks;
@@ -204,7 +202,6 @@ public class GHRepositoryStatistics {
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
         "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
     public static class CommitActivity extends GHObject {
-        /*package almost final*/ private GitHub root;
         private List<Integer> days;
         private int total;
         private long week;
@@ -329,7 +326,6 @@ public class GHRepositoryStatistics {
     }
 
     public static class Participation extends GHObject {
-        /*package almost final*/ private GitHub root;
         private List<Integer> all;
         private List<Integer> owner;
 

--- a/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
@@ -24,8 +24,8 @@ public class GHRepositoryStatistics extends GHObjectBase {
     private static final int WAIT_SLEEP_INTERVAL = 5000;
 
     public GHRepositoryStatistics(GHRepository repo) {
+        super(repo.root);
         this.repo = repo;
-        this.root = repo.root;
     }
 
     /**
@@ -182,7 +182,6 @@ public class GHRepositoryStatistics extends GHObjectBase {
         }
 
         /*package*/ ContributorStats wrapUp(GitHub root) {
-            this.root = root;
             return this;
         }
     }
@@ -229,7 +228,6 @@ public class GHRepositoryStatistics extends GHObjectBase {
         }
 
         /*package*/ CommitActivity wrapUp(GitHub root) {
-            this.root = root;
             return this;
         }
 
@@ -355,7 +353,6 @@ public class GHRepositoryStatistics extends GHObjectBase {
         }
 
         /*package*/ Participation wrapUp(GitHub root) {
-        this.root = root;
         return this;
         }
     }

--- a/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
@@ -70,8 +70,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
         return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl("contributors"),
-                ContributorStats[].class,
-                item -> item.wrapUp(getRoot()) );
+                ContributorStats[].class);
     }
 
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
@@ -180,10 +179,6 @@ public class GHRepositoryStatistics extends GHObjectBase {
                 return String.format("Week starting %d - Additions: %d, Deletions: %d, Commits: %d", w, a, d, c);
             }
         }
-
-        /*package*/ ContributorStats wrapUp(GitHub root) {
-            return this;
-        }
     }
 
     /**
@@ -194,8 +189,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
         return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl("commit_activity"),
-                CommitActivity[].class,
-                item -> item.wrapUp(getRoot()) );
+                CommitActivity[].class);
     }
 
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
@@ -225,10 +219,6 @@ public class GHRepositoryStatistics extends GHObjectBase {
          */
         public long getWeek() {
             return week;
-        }
-
-        /*package*/ CommitActivity wrapUp(GitHub root) {
-            return this;
         }
 
         public GitHub getRoot() {
@@ -350,10 +340,6 @@ public class GHRepositoryStatistics extends GHObjectBase {
          */
         public List<Integer> getOwnerCommits() {
             return owner;
-        }
-
-        /*package*/ Participation wrapUp(GitHub root) {
-        return this;
         }
     }
 

--- a/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
@@ -67,7 +67,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
      * are still being cached.
      */
     private PagedIterable<ContributorStats> getContributorStatsImpl() throws IOException {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .asPagedIterable(
                 getApiTailUrl("contributors"),
                 ContributorStats[].class);
@@ -186,7 +186,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
      * https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data
      */
     public PagedIterable<CommitActivity> getCommitActivity() throws IOException {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .asPagedIterable(
                 getApiTailUrl("commit_activity"),
                 CommitActivity[].class);
@@ -239,7 +239,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
         // Map to ArrayLists first, since there are no field names in the
         // returned JSON.
         try {
-            InputStream stream = getRoot().retrieve().asStream(getApiTailUrl("code_frequency"));
+            InputStream stream = getRoot().createRequest().method("GET").asStream(getApiTailUrl("code_frequency"));
 
             ObjectMapper mapper = new ObjectMapper();
             TypeReference<ArrayList<ArrayList<Integer> > > typeRef =
@@ -310,7 +310,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
      * See https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repository-owner-and-everyone-else
      */
     public Participation getParticipation() throws IOException {
-        return getRoot().retrieve().to(getApiTailUrl("participation"), Participation.class);
+        return getRoot().createRequest().method("GET").to(getApiTailUrl("participation"), Participation.class);
     }
 
     public static class Participation extends GHObject {
@@ -350,7 +350,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
     public List<PunchCardItem> getPunchCard() throws IOException {
         // Map to ArrayLists first, since there are no field names in the
         // returned JSON.
-        InputStream stream = getRoot().retrieve().asStream(getApiTailUrl("punch_card"));
+        InputStream stream = getRoot().createRequest().method("GET").asStream(getApiTailUrl("punch_card"));
 
         ObjectMapper mapper = new ObjectMapper();
         TypeReference<ArrayList<ArrayList<Integer> > > typeRef =

--- a/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
+++ b/src/main/java/org/kohsuke/github/GHRepositoryStatistics.java
@@ -24,7 +24,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
     private static final int WAIT_SLEEP_INTERVAL = 5000;
 
     public GHRepositoryStatistics(GHRepository repo) {
-        super(repo.root);
+        super(repo.getRoot());
         this.repo = repo;
     }
 
@@ -67,11 +67,11 @@ public class GHRepositoryStatistics extends GHObjectBase {
      * are still being cached.
      */
     private PagedIterable<ContributorStats> getContributorStatsImpl() throws IOException {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl("contributors"),
                 ContributorStats[].class,
-                item -> item.wrapUp(root) );
+                item -> item.wrapUp(getRoot()) );
     }
 
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
@@ -87,7 +87,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
         }
 
         public GitHub getRoot() {
-            return root;
+            return super.getRoot();
         }
 
         /**
@@ -191,11 +191,11 @@ public class GHRepositoryStatistics extends GHObjectBase {
      * https://developer.github.com/v3/repos/statistics/#get-the-last-year-of-commit-activity-data
      */
     public PagedIterable<CommitActivity> getCommitActivity() throws IOException {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl("commit_activity"),
                 CommitActivity[].class,
-                item -> item.wrapUp(root) );
+                item -> item.wrapUp(getRoot()) );
     }
 
     @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
@@ -232,7 +232,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
         }
 
         public GitHub getRoot() {
-            return root;
+            return super.getRoot();
         }
 
         @Override
@@ -249,7 +249,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
         // Map to ArrayLists first, since there are no field names in the
         // returned JSON.
         try {
-            InputStream stream = root.retrieve().asStream(getApiTailUrl("code_frequency"));
+            InputStream stream = getRoot().retrieve().asStream(getApiTailUrl("code_frequency"));
 
             ObjectMapper mapper = new ObjectMapper();
             TypeReference<ArrayList<ArrayList<Integer> > > typeRef =
@@ -320,7 +320,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
      * See https://developer.github.com/v3/repos/statistics/#get-the-weekly-commit-count-for-the-repository-owner-and-everyone-else
      */
     public Participation getParticipation() throws IOException {
-        return root.retrieve().to(getApiTailUrl("participation"), Participation.class);
+        return getRoot().retrieve().to(getApiTailUrl("participation"), Participation.class);
     }
 
     public static class Participation extends GHObject {
@@ -333,7 +333,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
         }
 
         public GitHub getRoot() {
-            return root;
+            return super.getRoot();
         }
 
         /**
@@ -364,7 +364,7 @@ public class GHRepositoryStatistics extends GHObjectBase {
     public List<PunchCardItem> getPunchCard() throws IOException {
         // Map to ArrayLists first, since there are no field names in the
         // returned JSON.
-        InputStream stream = root.retrieve().asStream(getApiTailUrl("punch_card"));
+        InputStream stream = getRoot().retrieve().asStream(getApiTailUrl("punch_card"));
 
         ObjectMapper mapper = new ObjectMapper();
         TypeReference<ArrayList<ArrayList<Integer> > > typeRef =

--- a/src/main/java/org/kohsuke/github/GHSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHSearchBuilder.java
@@ -36,7 +36,7 @@ public abstract class GHSearchBuilder<T> extends GHQueryBuilder<T> {
      */
     @Override
     public PagedSearchIterable<T> list() {
-        return new PagedSearchIterable<T>(root) {
+        return new PagedSearchIterable<T>(getRoot()) {
             public PagedIterator<T> _iterator(int pageSize) {
                 req.set("q", StringUtils.join(terms, " "));
                 return new PagedIterator<T>(adapt(req.asIterator(getApiUrl(), receiverType, pageSize))) {

--- a/src/main/java/org/kohsuke/github/GHSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHSearchBuilder.java
@@ -20,6 +20,8 @@ public abstract class GHSearchBuilder<T> extends GHQueryBuilder<T> {
 
     /*package*/ GHSearchBuilder(GitHub root, Class<? extends SearchResult<T>> receiverType) {
         super(root, root.createRequest());
+
+        this.req.lateBinding();
         this.receiverType = receiverType;
     }
 

--- a/src/main/java/org/kohsuke/github/GHSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHSearchBuilder.java
@@ -19,7 +19,7 @@ public abstract class GHSearchBuilder<T> extends GHQueryBuilder<T> {
     private final Class<? extends SearchResult<T>> receiverType;
 
     /*package*/ GHSearchBuilder(GitHub root, Class<? extends SearchResult<T>> receiverType) {
-        super(root);
+        super(root, root.createRequest());
         this.receiverType = receiverType;
     }
 

--- a/src/main/java/org/kohsuke/github/GHStargazer.java
+++ b/src/main/java/org/kohsuke/github/GHStargazer.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Date;
@@ -12,6 +13,7 @@ import java.util.Date;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_FIELD", "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
 public class GHStargazer extends GHObjectBase{
 
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     private GHRepository repository;
     private String starred_at;
     private GHUser user;
@@ -42,9 +44,5 @@ public class GHStargazer extends GHObjectBase{
      */
     public GHUser getUser() {
         return user;
-    }
-
-    void wrapUp(GHRepository repository) {
-        this.repository = repository;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHStargazer.java
+++ b/src/main/java/org/kohsuke/github/GHStargazer.java
@@ -46,6 +46,6 @@ public class GHStargazer {
 
     void wrapUp(GHRepository repository) {
         this.repository = repository;
-        user.wrapUp(repository.root);
+        user.wrapUp(repository.getRoot());
     }
 }

--- a/src/main/java/org/kohsuke/github/GHStargazer.java
+++ b/src/main/java/org/kohsuke/github/GHStargazer.java
@@ -10,7 +10,7 @@ import java.util.Date;
  * @author noctarius
  */
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_FIELD", "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
-public class GHStargazer {
+public class GHStargazer extends GHObjectBase{
 
     private GHRepository repository;
     private String starred_at;
@@ -46,6 +46,5 @@ public class GHStargazer {
 
     void wrapUp(GHRepository repository) {
         this.repository = repository;
-        user.wrapUp(repository.getRoot());
     }
 }

--- a/src/main/java/org/kohsuke/github/GHSubscription.java
+++ b/src/main/java/org/kohsuke/github/GHSubscription.java
@@ -57,7 +57,6 @@ public class GHSubscription extends GHObjectBase {
     }
 
     GHSubscription wrapUp(GitHub root) {
-        this.root = root;
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHSubscription.java
+++ b/src/main/java/org/kohsuke/github/GHSubscription.java
@@ -48,7 +48,7 @@ public class GHSubscription extends GHObjectBase {
      * Removes this subscription.
      */
     public void delete() throws IOException {
-        new Requester(getRoot()).method("DELETE").to(repo.getApiTailUrl("subscription"));
+        createRequest().method("DELETE").to(repo.getApiTailUrl("subscription"));
     }
 
     GHSubscription wrapUp(GHRepository repo) {

--- a/src/main/java/org/kohsuke/github/GHSubscription.java
+++ b/src/main/java/org/kohsuke/github/GHSubscription.java
@@ -53,10 +53,6 @@ public class GHSubscription extends GHObjectBase {
 
     GHSubscription wrapUp(GHRepository repo) {
         this.repo = repo;
-        return wrapUp(repo.getRoot());
-    }
-
-    GHSubscription wrapUp(GitHub root) {
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHSubscription.java
+++ b/src/main/java/org/kohsuke/github/GHSubscription.java
@@ -10,11 +10,10 @@ import java.util.Date;
  * @see GHRepository#getSubscription()
  * @see GHThread#getSubscription()
  */
-public class GHSubscription {
+public class GHSubscription extends GHObjectBase {
     private String created_at, url, repository_url, reason;
     private boolean subscribed, ignored;
 
-    private GitHub root;
     private GHRepository repo;
 
     public Date getCreatedAt() {

--- a/src/main/java/org/kohsuke/github/GHSubscription.java
+++ b/src/main/java/org/kohsuke/github/GHSubscription.java
@@ -48,12 +48,12 @@ public class GHSubscription extends GHObjectBase {
      * Removes this subscription.
      */
     public void delete() throws IOException {
-        new Requester(root).method("DELETE").to(repo.getApiTailUrl("subscription"));
+        new Requester(getRoot()).method("DELETE").to(repo.getApiTailUrl("subscription"));
     }
 
     GHSubscription wrapUp(GHRepository repo) {
         this.repo = repo;
-        return wrapUp(repo.root);
+        return wrapUp(repo.getRoot());
     }
 
     GHSubscription wrapUp(GitHub root) {

--- a/src/main/java/org/kohsuke/github/GHSubscription.java
+++ b/src/main/java/org/kohsuke/github/GHSubscription.java
@@ -1,5 +1,7 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+
 import java.io.IOException;
 import java.util.Date;
 
@@ -14,6 +16,7 @@ public class GHSubscription extends GHObjectBase {
     private String created_at, url, repository_url, reason;
     private boolean subscribed, ignored;
 
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     private GHRepository repo;
 
     public Date getCreatedAt() {
@@ -49,10 +52,5 @@ public class GHSubscription extends GHObjectBase {
      */
     public void delete() throws IOException {
         createRequest().method("DELETE").to(repo.getApiTailUrl("subscription"));
-    }
-
-    GHSubscription wrapUp(GHRepository repo) {
-        this.repo = repo;
-        return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHTag.java
+++ b/src/main/java/org/kohsuke/github/GHTag.java
@@ -17,7 +17,6 @@ public class GHTag extends GHObjectBase {
 
     /*package*/ GHTag wrap(GHRepository owner) {
         this.owner = owner;
-        this.root = owner.root;
         if (commit!=null)
             commit.wrapUp(owner);
         return this;

--- a/src/main/java/org/kohsuke/github/GHTag.java
+++ b/src/main/java/org/kohsuke/github/GHTag.java
@@ -27,7 +27,7 @@ public class GHTag extends GHObjectBase {
     }
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
     public String getName() {

--- a/src/main/java/org/kohsuke/github/GHTag.java
+++ b/src/main/java/org/kohsuke/github/GHTag.java
@@ -9,9 +9,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
-public class GHTag {
+public class GHTag extends GHObjectBase {
     private GHRepository owner;
-    private GitHub root;
 
     private String name;
     private GHCommit commit;

--- a/src/main/java/org/kohsuke/github/GHTag.java
+++ b/src/main/java/org/kohsuke/github/GHTag.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -10,17 +11,12 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
 public class GHTag extends GHObjectBase {
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     private GHRepository owner;
 
     private String name;
     private GHCommit commit;
-
-    /*package*/ GHTag wrap(GHRepository owner) {
-        this.owner = owner;
-        if (commit!=null)
-            commit.wrapUp(owner);
-        return this;
-    }
 
     public GHRepository getOwner() {
         return owner;

--- a/src/main/java/org/kohsuke/github/GHTagObject.java
+++ b/src/main/java/org/kohsuke/github/GHTagObject.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 /**
@@ -10,6 +11,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
 public class GHTagObject extends GHObjectBase{
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
     private GHRepository owner;
 
     private String tag;
@@ -18,11 +21,6 @@ public class GHTagObject extends GHObjectBase{
     private String message;
     private GitUser tagger;
     private GHRef.GHObject object;
-
-    /*package*/ GHTagObject wrap(GHRepository owner) {
-        this.owner = owner;
-        return this;
-    }
 
     public GHRepository getOwner() {
         return owner;

--- a/src/main/java/org/kohsuke/github/GHTagObject.java
+++ b/src/main/java/org/kohsuke/github/GHTagObject.java
@@ -29,7 +29,7 @@ public class GHTagObject extends GHObjectBase{
     }
 
     public GitHub getRoot() {
-        return root;
+        return super.getRoot();
     }
 
     public String getTag() {

--- a/src/main/java/org/kohsuke/github/GHTagObject.java
+++ b/src/main/java/org/kohsuke/github/GHTagObject.java
@@ -9,9 +9,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
  */
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
-public class GHTagObject {
+public class GHTagObject extends GHObjectBase{
     private GHRepository owner;
-    private GitHub root;
 
     private String tag;
     private String sha;

--- a/src/main/java/org/kohsuke/github/GHTagObject.java
+++ b/src/main/java/org/kohsuke/github/GHTagObject.java
@@ -21,7 +21,6 @@ public class GHTagObject extends GHObjectBase{
 
     /*package*/ GHTagObject wrap(GHRepository owner) {
         this.owner = owner;
-        this.root = owner.root;
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -66,7 +66,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
     }
 
     public void setDescription(String description) throws IOException {
-        root.retrieve().method("PATCH")
+        getRoot().retrieve().method("PATCH")
                 .with("description", description)
                 .to(api(""));
     }
@@ -79,11 +79,10 @@ public class GHTeam extends GHObjectBase implements Refreshable {
      * Retrieves the current members.
      */
     public PagedIterable<GHUser> listMembers() throws IOException {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 api("/members"),
-                GHUser[].class,
-                item -> item.wrapUp(root) );
+                GHUser[].class);
     }
 
     public Set<GHUser> getMembers() throws IOException {
@@ -95,7 +94,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
      */
     public boolean hasMember(GHUser user) {
         try {
-            root.retrieve().to("/teams/" + id + "/members/"  + user.getLogin());
+            getRoot().retrieve().to("/teams/" + id + "/members/"  + user.getLogin());
             return true;
         } catch (IOException ignore) {
             return false;
@@ -111,11 +110,11 @@ public class GHTeam extends GHObjectBase implements Refreshable {
     }
 
     public PagedIterable<GHRepository> listRepositories() {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 api("/repos"),
                 GHRepository[].class,
-                item -> item.wrap(root) );
+                item -> item.wrap(getRoot()) );
     }
 
     /**
@@ -126,7 +125,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
      * @since 1.59
      */
     public void add(GHUser u) throws IOException {
-        root.retrieve().method("PUT").to(api("/memberships/" + u.getLogin()), null);
+        getRoot().retrieve().method("PUT").to(api("/memberships/" + u.getLogin()), null);
     }
 
     /**
@@ -140,7 +139,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
      * @throws IOException
      */
     public void add(GHUser user, Role role) throws IOException {
-        root.retrieve().method("PUT")
+        getRoot().retrieve().method("PUT")
                 .with("role", role)
                 .to(api("/memberships/" + user.getLogin()), null);
     }
@@ -149,7 +148,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
      * Removes a member to the team.
      */
     public void remove(GHUser u) throws IOException {
-        root.retrieve().method("DELETE").to(api("/members/" + u.getLogin()), null);
+        getRoot().retrieve().method("DELETE").to(api("/members/" + u.getLogin()), null);
     }
 
     public void add(GHRepository r) throws IOException {
@@ -157,20 +156,20 @@ public class GHTeam extends GHObjectBase implements Refreshable {
     }
 
     public void add(GHRepository r, GHOrganization.Permission permission) throws IOException {
-        root.retrieve().method("PUT")
+        getRoot().retrieve().method("PUT")
                 .with("permission", permission)
                 .to(api("/repos/" + r.getOwnerName() + '/' + r.getName()), null);
     }
 
     public void remove(GHRepository r) throws IOException {
-        root.retrieve().method("DELETE").to(api("/repos/" + r.getOwnerName() + '/' + r.getName()), null);
+        getRoot().retrieve().method("DELETE").to(api("/repos/" + r.getOwnerName() + '/' + r.getName()), null);
     }
     
     /**
      * Deletes this team.
      */
     public void delete() throws IOException {
-        root.retrieve().method("DELETE").to(api(""));
+        getRoot().retrieve().method("DELETE").to(api(""));
     }
 
     private String api(String tail) {
@@ -184,6 +183,6 @@ public class GHTeam extends GHObjectBase implements Refreshable {
 
     @Override
     public void refresh() throws IOException {
-        root.retrieve().to(api(""), this).wrapUp(root);
+        getRoot().retrieve().to(api(""), this).wrapUp(getRoot());
     }
 }

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -11,12 +11,10 @@ import java.util.TreeMap;
  * 
  * @author Kohsuke Kawaguchi
  */
-public class GHTeam implements Refreshable {
+public class GHTeam extends GHObjectBase implements Refreshable {
     private String name,permission,slug,description;
     private int id;
     private GHOrganization organization; // populated by GET /user/teams where Teams+Orgs are returned together
-
-    protected /*final*/ GitHub root;
 
     /** Member's role in a team */
     public enum Role {

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -34,7 +34,6 @@ public class GHTeam extends GHObjectBase implements Refreshable {
     }
 
     /*package*/ GHTeam wrapUp(GitHub root) { // auto-wrapUp when organization is known from GET /user/teams
-      this.organization.wrapUp(root);
       return wrapUp(organization);
     }
 
@@ -113,8 +112,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
         return getRoot().retrieve()
             .asPagedIterable(
                 api("/repos"),
-                GHRepository[].class,
-                item -> item.wrap(getRoot()) );
+                GHRepository[].class);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -30,7 +30,6 @@ public class GHTeam extends GHObjectBase implements Refreshable {
 
     /*package*/ GHTeam wrapUp(GHOrganization owner) {
         this.organization = owner;
-        this.root = owner.root;
         return this;
     }
 
@@ -47,9 +46,6 @@ public class GHTeam extends GHObjectBase implements Refreshable {
     }
 
     /*package*/ static GHTeam[] wrapUp(GHTeam[] teams, GHPullRequest owner) {
-        for (GHTeam t : teams) {
-            t.root = owner.root;
-        }
         return teams;
     }
 

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -33,10 +33,6 @@ public class GHTeam extends GHObjectBase implements Refreshable {
         return this;
     }
 
-    /*package*/ GHTeam wrapUp(GitHub root) { // auto-wrapUp when organization is known from GET /user/teams
-      return wrapUp(organization);
-    }
-
     /*package*/ static GHTeam[] wrapUp(GHTeam[] teams, GHOrganization owner) {
         for (GHTeam t : teams) {
             t.wrapUp(owner);
@@ -181,6 +177,6 @@ public class GHTeam extends GHObjectBase implements Refreshable {
 
     @Override
     public void refresh() throws IOException {
-        getRoot().retrieve().to(api(""), this).wrapUp(getRoot());
+        getRoot().retrieve().to(api(""), this);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -56,7 +56,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
     }
 
     public void setDescription(String description) throws IOException {
-        getRoot().createRequest().method("GET").method("PATCH")
+        getRoot().createRequest().method("PATCH")
                 .with("description", description)
                 .to(api(""));
     }
@@ -114,7 +114,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
      * @since 1.59
      */
     public void add(GHUser u) throws IOException {
-        getRoot().createRequest().method("GET").method("PUT").to(api("/memberships/" + u.getLogin()), null);
+        getRoot().createRequest().method("PUT").to(api("/memberships/" + u.getLogin()), null);
     }
 
     /**
@@ -128,7 +128,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
      * @throws IOException
      */
     public void add(GHUser user, Role role) throws IOException {
-        getRoot().createRequest().method("GET").method("PUT")
+        getRoot().createRequest().method("PUT")
                 .with("role", role)
                 .to(api("/memberships/" + user.getLogin()), null);
     }
@@ -137,7 +137,7 @@ public class GHTeam extends GHObjectBase implements Refreshable {
      * Removes a member to the team.
      */
     public void remove(GHUser u) throws IOException {
-        getRoot().createRequest().method("GET").method("DELETE").to(api("/members/" + u.getLogin()), null);
+        getRoot().createRequest().method("DELETE").to(api("/members/" + u.getLogin()), null);
     }
 
     public void add(GHRepository r) throws IOException {
@@ -145,20 +145,20 @@ public class GHTeam extends GHObjectBase implements Refreshable {
     }
 
     public void add(GHRepository r, GHOrganization.Permission permission) throws IOException {
-        getRoot().createRequest().method("GET").method("PUT")
+        getRoot().createRequest().method("PUT")
                 .with("permission", permission)
                 .to(api("/repos/" + r.getOwnerName() + '/' + r.getName()), null);
     }
 
     public void remove(GHRepository r) throws IOException {
-        getRoot().createRequest().method("GET").method("DELETE").to(api("/repos/" + r.getOwnerName() + '/' + r.getName()), null);
+        getRoot().createRequest().method("DELETE").to(api("/repos/" + r.getOwnerName() + '/' + r.getName()), null);
     }
     
     /**
      * Deletes this team.
      */
     public void delete() throws IOException {
-        getRoot().createRequest().method("GET").method("DELETE").to(api(""));
+        getRoot().createRequest().method("DELETE").to(api(""));
     }
 
     private String api(String tail) {

--- a/src/main/java/org/kohsuke/github/GHThread.java
+++ b/src/main/java/org/kohsuke/github/GHThread.java
@@ -110,10 +110,6 @@ public class GHThread extends GHObject {
         return repository.getCommit(subject.url.substring(subject.url.lastIndexOf('/') + 1));
     }
 
-    /*package*/ GHThread wrap(GitHub root) {
-        return this;
-    }
-
     /**
      * Marks this thread as read.
      */
@@ -128,7 +124,7 @@ public class GHThread extends GHObject {
         return new Requester(getRoot())
             .with("subscribed", subscribed)
             .with("ignored", ignored)
-            .method("PUT").to(subscription_url, GHSubscription.class).wrapUp(getRoot());
+            .method("PUT").to(subscription_url, GHSubscription.class);
     }
 
     /**
@@ -138,7 +134,7 @@ public class GHThread extends GHObject {
      */
     public GHSubscription getSubscription() throws IOException {
         try {
-            return new Requester(getRoot()).to(subscription_url, GHSubscription.class).wrapUp(getRoot());
+            return new Requester(getRoot()).to(subscription_url, GHSubscription.class);
         } catch (FileNotFoundException e) {
             return null;
         }

--- a/src/main/java/org/kohsuke/github/GHThread.java
+++ b/src/main/java/org/kohsuke/github/GHThread.java
@@ -120,17 +120,17 @@ public class GHThread extends GHObject {
      * Marks this thread as read.
      */
     public void markAsRead() throws IOException {
-        new Requester(root).method("PATCH").to(url);
+        new Requester(getRoot()).method("PATCH").to(url);
     }
 
     /**
      * Subscribes to this conversation to get notifications.
      */
     public GHSubscription subscribe(boolean subscribed, boolean ignored) throws IOException {
-        return new Requester(root)
+        return new Requester(getRoot())
             .with("subscribed", subscribed)
             .with("ignored", ignored)
-            .method("PUT").to(subscription_url, GHSubscription.class).wrapUp(root);
+            .method("PUT").to(subscription_url, GHSubscription.class).wrapUp(getRoot());
     }
 
     /**
@@ -140,7 +140,7 @@ public class GHThread extends GHObject {
      */
     public GHSubscription getSubscription() throws IOException {
         try {
-            return new Requester(root).to(subscription_url, GHSubscription.class).wrapUp(root);
+            return new Requester(getRoot()).to(subscription_url, GHSubscription.class).wrapUp(getRoot());
         } catch (FileNotFoundException e) {
             return null;
         }

--- a/src/main/java/org/kohsuke/github/GHThread.java
+++ b/src/main/java/org/kohsuke/github/GHThread.java
@@ -114,14 +114,14 @@ public class GHThread extends GHObject {
      * Marks this thread as read.
      */
     public void markAsRead() throws IOException {
-        new Requester(getRoot()).method("PATCH").to(url);
+        createRequest().method("PATCH").to(url);
     }
 
     /**
      * Subscribes to this conversation to get notifications.
      */
     public GHSubscription subscribe(boolean subscribed, boolean ignored) throws IOException {
-        return new Requester(getRoot())
+        return createRequest()
             .with("subscribed", subscribed)
             .with("ignored", ignored)
             .method("PUT").to(subscription_url, GHSubscription.class);
@@ -134,7 +134,7 @@ public class GHThread extends GHObject {
      */
     public GHSubscription getSubscription() throws IOException {
         try {
-            return new Requester(getRoot()).to(subscription_url, GHSubscription.class);
+            return createRequest().to(subscription_url, GHSubscription.class);
         } catch (FileNotFoundException e) {
             return null;
         }

--- a/src/main/java/org/kohsuke/github/GHThread.java
+++ b/src/main/java/org/kohsuke/github/GHThread.java
@@ -111,8 +111,6 @@ public class GHThread extends GHObject {
     }
 
     /*package*/ GHThread wrap(GitHub root) {
-        if (this.repository!=null)
-            this.repository.wrap(root);
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHThread.java
+++ b/src/main/java/org/kohsuke/github/GHThread.java
@@ -111,7 +111,6 @@ public class GHThread extends GHObject {
     }
 
     /*package*/ GHThread wrap(GitHub root) {
-        this.root = root;
         if (this.repository!=null)
             this.repository.wrap(root);
         return this;

--- a/src/main/java/org/kohsuke/github/GHThread.java
+++ b/src/main/java/org/kohsuke/github/GHThread.java
@@ -17,7 +17,6 @@ import java.util.Date;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD", 
     "NP_UNWRITTEN_FIELD"}, justification = "JSON API")
 public class GHThread extends GHObject {
-    private GitHub root;
     private GHRepository repository;
     private Subject subject;
     private String reason;

--- a/src/main/java/org/kohsuke/github/GHTree.java
+++ b/src/main/java/org/kohsuke/github/GHTree.java
@@ -1,5 +1,8 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonSetter;
+
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -15,7 +18,9 @@ import java.util.List;
  * @see GHTreeEntry#asTree()
  */
 public class GHTree {
-    /* package almost final */GHRepository repo;
+
+    @JacksonInject(value = "org.kohsuke.github.GHRepository")
+    GHRepository repo;
 
     private boolean truncated;
     private String sha, url;
@@ -34,6 +39,15 @@ public class GHTree {
     public List<GHTreeEntry> getTree() {
         return Collections.unmodifiableList(Arrays.asList(tree));
     }
+
+    @JsonSetter("tree")
+    void setTree(GHTreeEntry[] tree) {
+        this.tree = tree;
+        for (GHTreeEntry e : tree) {
+            e.tree = this;
+        }
+    }
+
 
     /**
      * Finds a tree entry by its name.
@@ -62,14 +76,6 @@ public class GHTree {
      */
     public URL getUrl() {
         return GitHub.parseURL(url);
-    }
-
-    /* package */GHTree wrap(GHRepository repo) {
-        this.repo = repo;
-        for (GHTreeEntry e : tree) {
-            e.tree = this;
-        }
-        return this;
     }
 
 }

--- a/src/main/java/org/kohsuke/github/GHTreeBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHTreeBuilder.java
@@ -33,7 +33,7 @@ public class GHTreeBuilder {
 
     GHTreeBuilder(GHRepository repo) {
         this.repo = repo;
-        req = new Requester(repo.getRoot());
+        req = repo.createRequest();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHTreeBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHTreeBuilder.java
@@ -85,6 +85,6 @@ public class GHTreeBuilder {
      */
     public GHTree create() throws IOException {
         req._with("tree", treeEntries);
-        return req.method("POST").to(getApiTail(), GHTree.class).wrap(repo);
+        return req.method("POST").to(getApiTail(), GHTree.class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHTreeBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHTreeBuilder.java
@@ -33,7 +33,7 @@ public class GHTreeBuilder {
 
     GHTreeBuilder(GHRepository repo) {
         this.repo = repo;
-        req = new Requester(repo.root);
+        req = new Requester(repo.getRoot());
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -36,7 +36,7 @@ import java.util.*;
 public class GHUser extends GHPerson {
 
     public List<GHKey> getKeys() throws IOException {
-        return Collections.unmodifiableList(Arrays.asList(getRoot().retrieve().to(getApiTailUrl("keys"), GHKey[].class)));
+        return Collections.unmodifiableList(Arrays.asList(getRoot().createRequest().method("GET").to(getApiTailUrl("keys"), GHKey[].class)));
     }
 
     /**
@@ -84,7 +84,7 @@ public class GHUser extends GHPerson {
     }
 
     private PagedIterable<GHUser> listUser(final String suffix) {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .asPagedIterable(
                 getApiTailUrl(suffix),
                 GHUser[].class);
@@ -107,7 +107,7 @@ public class GHUser extends GHPerson {
     }
 
     private PagedIterable<GHRepository> listRepositories(final String suffix) {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .asPagedIterable(
                 getApiTailUrl(suffix),
                 GHRepository[].class);
@@ -141,7 +141,7 @@ public class GHUser extends GHPerson {
     public GHPersonSet<GHOrganization> getOrganizations() throws IOException {
         GHPersonSet<GHOrganization> orgs = new GHPersonSet<GHOrganization>();
         Set<String> names = new HashSet<String>();
-        for (GHOrganization o : getRoot().retrieve().to("/users/" + login + "/orgs", GHOrganization[].class)) {
+        for (GHOrganization o : getRoot().createRequest().method("GET").to("/users/" + login + "/orgs", GHOrganization[].class)) {
             if (names.add(o.getLogin()))    // I've seen some duplicates in the data
                 orgs.add(getRoot().getOrganization(o.getLogin()));
         }
@@ -152,7 +152,7 @@ public class GHUser extends GHPerson {
      * Lists events performed by a user (this includes private events if the caller is authenticated.
      */
     public PagedIterable<GHEventInfo> listEvents() throws IOException {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .asPagedIterable(
                 String.format("/users/%s/events", login),
                 GHEventInfo[].class);
@@ -162,7 +162,7 @@ public class GHUser extends GHPerson {
      * Lists Gists created by this user.
      */
     public PagedIterable<GHGist> listGists() throws IOException {
-        return getRoot().retrieve()
+        return getRoot().createRequest().method("GET")
             .inject("owner", this)
             .asPagedIterable(
                 String.format("/users/%s/gists", login),

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -155,8 +155,7 @@ public class GHUser extends GHPerson {
         return getRoot().retrieve()
             .asPagedIterable(
                 String.format("/users/%s/events", login),
-                GHEventInfo[].class,
-                item -> item.wrapUp(getRoot()) );
+                GHEventInfo[].class);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -43,14 +43,14 @@ public class GHUser extends GHPerson {
      * Follow this user.
      */
     public void follow() throws IOException {
-        new Requester(getRoot()).method("PUT").to("/user/following/" + login);
+        createRequest().method("PUT").to("/user/following/" + login);
     }
 
     /**
      * Unfollow this user.
      */
     public void unfollow() throws IOException {
-        new Requester(getRoot()).method("DELETE").to("/user/following/" + login);
+        createRequest().method("DELETE").to("/user/following/" + login);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -87,8 +87,7 @@ public class GHUser extends GHPerson {
         return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl(suffix),
-                GHUser[].class,
-                item -> item.wrapUp(getRoot()) );
+                GHUser[].class);
     }
 
     /**
@@ -111,8 +110,7 @@ public class GHUser extends GHPerson {
         return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl(suffix),
-                GHRepository[].class,
-                item -> item.wrap(getRoot()) );
+                GHRepository[].class);
     }
 
     /**
@@ -134,10 +132,6 @@ public class GHUser extends GHPerson {
      */
     public boolean isPublicMemberOf(GHOrganization org) {
         return org.hasPublicMember(this);
-    }
-
-    /*package*/ static GHUser[] wrap(GHUser[] users, GitHub root) {
-        return users;
     }
 
     /**
@@ -194,9 +188,5 @@ public class GHUser extends GHPerson {
     String getApiTailUrl(String tail) {
         if (tail.length()>0 && !tail.startsWith("/"))    tail='/'+tail;
         return "/users/" + login + tail;
-    }
-
-    /*package*/ GHUser wrapUp(GitHub root) {
-        return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -36,21 +36,21 @@ import java.util.*;
 public class GHUser extends GHPerson {
 
     public List<GHKey> getKeys() throws IOException {
-        return Collections.unmodifiableList(Arrays.asList(root.retrieve().to(getApiTailUrl("keys"), GHKey[].class)));
+        return Collections.unmodifiableList(Arrays.asList(getRoot().retrieve().to(getApiTailUrl("keys"), GHKey[].class)));
     }
 
     /**
      * Follow this user.
      */
     public void follow() throws IOException {
-        new Requester(root).method("PUT").to("/user/following/" + login);
+        new Requester(getRoot()).method("PUT").to("/user/following/" + login);
     }
 
     /**
      * Unfollow this user.
      */
     public void unfollow() throws IOException {
-        new Requester(root).method("DELETE").to("/user/following/" + login);
+        new Requester(getRoot()).method("DELETE").to("/user/following/" + login);
     }
 
     /**
@@ -84,11 +84,11 @@ public class GHUser extends GHPerson {
     }
 
     private PagedIterable<GHUser> listUser(final String suffix) {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl(suffix),
                 GHUser[].class,
-                item -> item.wrapUp(root) );
+                item -> item.wrapUp(getRoot()) );
     }
 
     /**
@@ -108,11 +108,11 @@ public class GHUser extends GHPerson {
     }
 
     private PagedIterable<GHRepository> listRepositories(final String suffix) {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 getApiTailUrl(suffix),
                 GHRepository[].class,
-                item -> item.wrap(root) );
+                item -> item.wrap(getRoot()) );
     }
 
     /**
@@ -147,9 +147,9 @@ public class GHUser extends GHPerson {
     public GHPersonSet<GHOrganization> getOrganizations() throws IOException {
         GHPersonSet<GHOrganization> orgs = new GHPersonSet<GHOrganization>();
         Set<String> names = new HashSet<String>();
-        for (GHOrganization o : root.retrieve().to("/users/" + login + "/orgs", GHOrganization[].class)) {
+        for (GHOrganization o : getRoot().retrieve().to("/users/" + login + "/orgs", GHOrganization[].class)) {
             if (names.add(o.getLogin()))    // I've seen some duplicates in the data
-                orgs.add(root.getOrganization(o.getLogin()));
+                orgs.add(getRoot().getOrganization(o.getLogin()));
         }
         return orgs;
     }
@@ -158,18 +158,18 @@ public class GHUser extends GHPerson {
      * Lists events performed by a user (this includes private events if the caller is authenticated.
      */
     public PagedIterable<GHEventInfo> listEvents() throws IOException {
-        return root.retrieve()
+        return getRoot().retrieve()
             .asPagedIterable(
                 String.format("/users/%s/events", login),
                 GHEventInfo[].class,
-                item -> item.wrapUp(root) );
+                item -> item.wrapUp(getRoot()) );
     }
 
     /**
      * Lists Gists created by this user.
      */
     public PagedIterable<GHGist> listGists() throws IOException {
-        return root.retrieve()
+        return getRoot().retrieve()
             .inject("owner", this)
             .asPagedIterable(
                 String.format("/users/%s/gists", login),
@@ -197,7 +197,6 @@ public class GHUser extends GHPerson {
     }
 
     /*package*/ GHUser wrapUp(GitHub root) {
-        super.wrapUp(root);
         return this;
     }
 }

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -137,8 +137,6 @@ public class GHUser extends GHPerson {
     }
 
     /*package*/ static GHUser[] wrap(GHUser[] users, GitHub root) {
-        for (GHUser f : users)
-            f.root = root;
         return users;
     }
 

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -172,10 +172,11 @@ public class GHUser extends GHPerson {
      */
     public PagedIterable<GHGist> listGists() throws IOException {
         return root.retrieve()
+            .inject("owner", this)
             .asPagedIterable(
                 String.format("/users/%s/gists", login),
                 GHGist[].class,
-                item -> item.wrapUp(GHUser.this) );
+                null);
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GHUserSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHUserSearchBuilder.java
@@ -64,7 +64,7 @@ public class GHUserSearchBuilder extends GHSearchBuilder<GHUser> {
 
         @Override
         /*package*/ GHUser[] getItems(GitHub root) {
-            return GHUser.wrap(items,root);
+            return items;
         }
     }
 

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -309,7 +309,11 @@ public class GitHub {
     }
 
     /*package*/ Requester retrieve() {
-        return new Requester(this).method("GET");
+        return createRequest().method("GET");
+    }
+
+    /*package*/ Requester createRequest() {
+        return new Requester(this);
     }
 
     /**
@@ -514,7 +518,6 @@ public class GitHub {
      */
     public List<GHInvitation> getMyInvitations() throws IOException {
         GHInvitation[] invitations = retrieve().to("/user/repository_invitations", GHInvitation[].class);
-
         return Arrays.asList(invitations);
     }
 
@@ -657,7 +660,7 @@ public class GitHub {
      * @see <a href="http://developer.github.com/v3/oauth/#create-a-new-authorization">Documentation</a>
      */
     public GHAuthorization createToken(Collection<String> scope, String note, String noteUrl) throws IOException{
-        Requester requester = new Requester(this)
+        Requester requester = createRequest()
                 .with("scopes", scope)
                 .with("note", note)
                 .with("note_url", noteUrl);
@@ -671,7 +674,7 @@ public class GitHub {
     public GHAuthorization createOrGetAuth(String clientId, String clientSecret, List<String> scopes, String note,
                                            String note_url)
             throws IOException {
-        Requester requester = new Requester(this)
+        Requester requester = createRequest()
                 .with("client_secret", clientSecret)
                 .with("scopes", scopes)
                 .with("note", note)
@@ -917,7 +920,7 @@ public class GitHub {
      */
     public Reader renderMarkdown(String text) throws IOException {
         return new InputStreamReader(
-            new Requester(this)
+            createRequest()
                     .with(new ByteArrayInputStream(text.getBytes("UTF-8")))
                     .contentType("text/plain;charset=UTF-8")
                     .asStream("/markdown/raw"),

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -431,7 +431,7 @@ public class GitHub {
     public GHOrganization getOrganization(String name) throws IOException {
         GHOrganization o = orgs.get(name);
         if (o==null) {
-            o = retrieve().to("/orgs/" + name, GHOrganization.class).wrapUp(this);
+            o = retrieve().to("/orgs/" + name, GHOrganization.class);
             orgs.put(name,o);
         }
         return o;
@@ -454,8 +454,7 @@ public class GitHub {
             .with("since",since)
             .asPagedIterable(
                 "/organizations",
-                GHOrganization[].class,
-                item -> item.wrapUp(GitHub.this) );
+                GHOrganization[].class);
     }
 
     /**
@@ -465,14 +464,14 @@ public class GitHub {
      */
     public GHRepository getRepository(String name) throws IOException {
         String[] tokens = name.split("/");
-        return retrieve().to("/repos/" + tokens[0] + '/' + tokens[1], GHRepository.class).wrap(this);
+        return retrieve().to("/repos/" + tokens[0] + '/' + tokens[1], GHRepository.class);
     }
 
     /**
      * Gets the repository object from its ID
      */
     public GHRepository getRepositoryById(String id) throws IOException {
-        return retrieve().to("/repositories/" + id, GHRepository.class).wrap(this);
+        return retrieve().to("/repositories/" + id, GHRepository.class);
     }
 
     /**
@@ -533,7 +532,7 @@ public class GitHub {
         Map<String, GHOrganization> r = new HashMap<String, GHOrganization>();
         for (GHOrganization o : orgs) {
             // don't put 'o' into orgs because they are shallow
-            r.put(o.getLogin(),o.wrapUp(this));
+            r.put(o.getLogin(),o);
         }
         return r;
     }
@@ -559,7 +558,7 @@ public class GitHub {
         Map<String, GHOrganization> r = new HashMap<String, GHOrganization>();
         for (GHOrganization o : orgs) {
             // don't put 'o' into orgs because they are shallow
-            r.put(o.getLogin(),o.wrapUp(this));
+            r.put(o.getLogin(),o);
         }
         return r;
     }
@@ -625,7 +624,6 @@ public class GitHub {
         InjectableValues.Std inject = new InjectableValues.Std();
         inject.addValue(GitHub.class.getName(), this);
         T t = MAPPER.reader(inject).forType(type).readValue(r);
-        t.wrapUp(this);
         return t;
     }
 
@@ -911,8 +909,7 @@ public class GitHub {
         return retrieve().with("since",since)
             .asPagedIterable(
                 "/repositories",
-                GHRepository[].class,
-                item -> item.wrap(GitHub.this) );
+                GHRepository[].class);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -418,7 +418,7 @@ public class GitHub {
         GHUser u = users.get(orig.getLogin());
         if (u==null) {
             // TODO: Do not commit this without dealing with this.
-//            orig.root = this;
+            orig.setRoot(this);
             users.put(orig.getLogin(),orig);
             return orig;
         }
@@ -497,8 +497,7 @@ public class GitHub {
         return retrieve()
             .asPagedIterable(
                 "/users",
-                GHUser[].class,
-                item -> item.wrapUp(GitHub.this) );
+                GHUser[].class);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -24,6 +24,7 @@
 package org.kohsuke.github;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker.Std;
@@ -608,7 +609,7 @@ public class GitHub {
      * Gets a single gist by ID.
      */
     public GHGist getGist(String id) throws IOException {
-        return retrieve().to("/gists/"+id,GHGist.class).wrapUp(this);
+        return retrieve().to("/gists/"+id,GHGist.class);
     }
 
     public GHGistBuilder createGist() {
@@ -623,7 +624,9 @@ public class GitHub {
      * to know the type of the payload you are expecting.
      */
     public <T extends GHEventPayload> T parseEventPayload(Reader r, Class<T> type) throws IOException {
-        T t = MAPPER.readValue(r, type);
+        InjectableValues.Std inject = new InjectableValues.Std();
+        inject.addValue(GitHub.class.getName(), this);
+        T t = MAPPER.reader(inject).forType(type).readValue(r);
         t.wrapUp(this);
         return t;
     }

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -321,7 +321,7 @@ public class GitHub {
      */
     public GHRateLimit getRateLimit() throws IOException {
         try {
-            return rateLimit = retrieve().to("/rate_limit", JsonRateLimit.class).rate;
+            return rateLimit = createRequest().method("GET").to("/rate_limit", JsonRateLimit.class).rate;
         } catch (FileNotFoundException e) {
             // GitHub Enterprise doesn't have the rate limit, so in that case
             // return some big number that's not too big.
@@ -387,7 +387,7 @@ public class GitHub {
         synchronized (this) {
             if (this.myself != null) return myself;
 
-            GHMyself u = retrieve().to("/user", GHMyself.class);
+            GHMyself u = createRequest().method("GET").to("/user", GHMyself.class);
 
             this.myself = u;
             return u;
@@ -400,7 +400,7 @@ public class GitHub {
     public GHUser getUser(String login) throws IOException {
         GHUser u = users.get(login);
         if (u == null) {
-            u = retrieve().to("/users/" + login, GHUser.class);
+            u = createRequest().method("GET").to("/users/" + login, GHUser.class);
             users.put(u.getLogin(), u);
         }
         return u;
@@ -435,7 +435,7 @@ public class GitHub {
     public GHOrganization getOrganization(String name) throws IOException {
         GHOrganization o = orgs.get(name);
         if (o==null) {
-            o = retrieve().to("/orgs/" + name, GHOrganization.class);
+            o = createRequest().method("GET").to("/orgs/" + name, GHOrganization.class);
             orgs.put(name,o);
         }
         return o;
@@ -454,7 +454,7 @@ public class GitHub {
      * @see <a href="https://developer.github.com/v3/orgs/#parameters">List All Orgs - Parameters</a>
      */
     public PagedIterable<GHOrganization> listOrganizations(final String since) {
-        return retrieve()
+        return createRequest().method("GET")
             .with("since",since)
             .asPagedIterable(
                 "/organizations",
@@ -468,14 +468,14 @@ public class GitHub {
      */
     public GHRepository getRepository(String name) throws IOException {
         String[] tokens = name.split("/");
-        return retrieve().to("/repos/" + tokens[0] + '/' + tokens[1], GHRepository.class);
+        return createRequest().method("GET").to("/repos/" + tokens[0] + '/' + tokens[1], GHRepository.class);
     }
 
     /**
      * Gets the repository object from its ID
      */
     public GHRepository getRepositoryById(String id) throws IOException {
-        return retrieve().to("/repositories/" + id, GHRepository.class);
+        return createRequest().method("GET").to("/repositories/" + id, GHRepository.class);
     }
 
     /**
@@ -486,7 +486,7 @@ public class GitHub {
      * @return a list of popular open source licenses
      */
     public PagedIterable<GHLicense> listLicenses() throws IOException {
-        return retrieve()
+        return createRequest().method("GET")
             .asPagedIterable(
                 "/licenses",
                 GHLicense[].class);
@@ -496,7 +496,7 @@ public class GitHub {
      * Returns a list of all users.
      */
     public PagedIterable<GHUser> listUsers() throws IOException {
-        return retrieve()
+        return createRequest().method("GET")
             .asPagedIterable(
                 "/users",
                 GHUser[].class);
@@ -510,14 +510,14 @@ public class GitHub {
      * @see GHLicense#getKey()
      */
     public GHLicense getLicense(String key) throws IOException {
-        return retrieve().to("/licenses/" + key, GHLicense.class);
+        return createRequest().method("GET").to("/licenses/" + key, GHLicense.class);
     }
 
     /**
      * Gets complete list of open invitations for current user.
      */
     public List<GHInvitation> getMyInvitations() throws IOException {
-        GHInvitation[] invitations = retrieve().to("/user/repository_invitations", GHInvitation[].class);
+        GHInvitation[] invitations = createRequest().method("GET").to("/user/repository_invitations", GHInvitation[].class);
         return Arrays.asList(invitations);
     }
 
@@ -528,7 +528,7 @@ public class GitHub {
      * TODO: make this automatic.
      */
     public Map<String, GHOrganization> getMyOrganizations() throws IOException {
-        GHOrganization[] orgs = retrieve().to("/user/orgs", GHOrganization[].class);
+        GHOrganization[] orgs = createRequest().method("GET").to("/user/orgs", GHOrganization[].class);
         Map<String, GHOrganization> r = new HashMap<String, GHOrganization>();
         for (GHOrganization o : orgs) {
             // don't put 'o' into orgs because they are shallow
@@ -554,7 +554,7 @@ public class GitHub {
      * @return the public Organization memberships for the user
      */
     public Map<String, GHOrganization> getUserPublicOrganizations(String login) throws IOException {
-        GHOrganization[] orgs = retrieve().to("/users/" + login + "/orgs", GHOrganization[].class);
+        GHOrganization[] orgs = createRequest().method("GET").to("/users/" + login + "/orgs", GHOrganization[].class);
         Map<String, GHOrganization> r = new HashMap<String, GHOrganization>();
         for (GHOrganization o : orgs) {
             // don't put 'o' into orgs because they are shallow
@@ -572,7 +572,7 @@ public class GitHub {
      */
     public Map<String, Set<GHTeam>> getMyTeams() throws IOException {
         Map<String, Set<GHTeam>> allMyTeams = new HashMap<String, Set<GHTeam>>();
-        for (GHTeam team : retrieve().to("/user/teams", GHTeam[].class)) {
+        for (GHTeam team : createRequest().method("GET").to("/user/teams", GHTeam[].class)) {
             String orgLogin = team.getOrganization().getLogin();
             Set<GHTeam> teamsPerOrg = allMyTeams.get(orgLogin);
             if (teamsPerOrg == null) {
@@ -588,14 +588,14 @@ public class GitHub {
      * Gets a sigle team by ID.
      */
     public GHTeam getTeam(int id) throws IOException {
-        return retrieve().to("/teams/" + id, GHTeam.class);
+        return createRequest().method("GET").to("/teams/" + id, GHTeam.class);
     }
     
     /**
      * Public events visible to you. Equivalent of what's displayed on https://github.com/
      */
     public List<GHEventInfo> getEvents() throws IOException {
-        GHEventInfo[] events = retrieve().to("/events", GHEventInfo[].class);
+        GHEventInfo[] events = createRequest().method("GET").to("/events", GHEventInfo[].class);
         return Arrays.asList(events);
     }
 
@@ -603,7 +603,7 @@ public class GitHub {
      * Gets a single gist by ID.
      */
     public GHGist getGist(String id) throws IOException {
-        return retrieve().to("/gists/"+id,GHGist.class);
+        return createRequest().method("GET").to("/gists/"+id,GHGist.class);
     }
 
     public GHGistBuilder createGist() {
@@ -619,7 +619,7 @@ public class GitHub {
      */
     public <T extends GHEventPayload> T parseEventPayload(Reader r, Class<T> type) throws IOException {
         InjectableValues.Std inject = new InjectableValues.Std();
-        inject.addValue(GitHub.class.getName(), this);
+        Requester.lateBinding(inject, this);
         T t = MAPPER.reader(inject).forType(type).readValue(r);
         return t;
     }
@@ -687,21 +687,21 @@ public class GitHub {
      * @see <a href="https://developer.github.com/v3/oauth_authorizations/#delete-an-authorization">Delete an authorization</a>
      */
     public void deleteAuth(long id) throws IOException {
-        retrieve().method("DELETE").to("/authorizations/" + id);
+        createRequest().method("DELETE").to("/authorizations/" + id);
     }
 
     /**
      * @see <a href="https://developer.github.com/v3/oauth_authorizations/#check-an-authorization">Check an authorization</a>
      */
     public GHAuthorization checkAuth(@Nonnull String clientId, @Nonnull String accessToken) throws IOException {
-        return retrieve().to("/applications/" + clientId + "/tokens/" + accessToken, GHAuthorization.class);
+        return createRequest().method("GET").to("/applications/" + clientId + "/tokens/" + accessToken, GHAuthorization.class);
     }
 
     /**
      * @see <a href="https://developer.github.com/v3/oauth_authorizations/#reset-an-authorization">Reset an authorization</a>
      */
     public GHAuthorization resetAuth(@Nonnull String clientId, @Nonnull String accessToken) throws IOException {
-        return retrieve().method("POST").to("/applications/" + clientId + "/tokens/" + accessToken, GHAuthorization.class);
+        return createRequest().method("POST").to("/applications/" + clientId + "/tokens/" + accessToken, GHAuthorization.class);
     }
 
     /**
@@ -709,7 +709,7 @@ public class GitHub {
      * @see <a href="https://developer.github.com/v3/oauth_authorizations/#list-your-authorizations">List your authorizations</a>
      */
     public PagedIterable<GHAuthorization> listMyAuthorizations() throws IOException {
-        return retrieve()
+        return createRequest().method("GET")
             .asPagedIterable(
                 "/authorizations",
                 GHAuthorization[].class);
@@ -724,7 +724,7 @@ public class GitHub {
      */
     @Preview @Deprecated
     public GHApp getApp() throws IOException {
-        return retrieve().withPreview(MACHINE_MAN).to("/app", GHApp.class);
+        return createRequest().method("GET").withPreview(MACHINE_MAN).to("/app", GHApp.class);
     }
 
     /**
@@ -732,7 +732,7 @@ public class GitHub {
      */
     public boolean isCredentialValid() {
         try {
-            retrieve().to("/user", GHUser.class);
+            createRequest().method("GET").to("/user", GHUser.class);
             return true;
         } catch (IOException e) {
             if (LOGGER.isLoggable(FINE))
@@ -754,15 +754,15 @@ public class GitHub {
     }
 
     public GHProject getProject(long id) throws IOException {
-        return retrieve().withPreview(INERTIA).to("/projects/"+id, GHProject.class);
+        return createRequest().method("GET").withPreview(INERTIA).to("/projects/"+id, GHProject.class);
     }
 
     public GHProjectColumn getProjectColumn(long id) throws IOException {
-        return retrieve().withPreview(INERTIA).to("/projects/columns/"+id, GHProjectColumn.class);
+        return createRequest().method("GET").withPreview(INERTIA).to("/projects/columns/"+id, GHProjectColumn.class);
     }
 
     public GHProjectCard getProjectCard(long id) throws IOException {
-        return retrieve().withPreview(INERTIA).to("/projects/columns/cards/"+id, GHProjectCard.class);
+        return createRequest().method("GET").withPreview(INERTIA).to("/projects/columns/cards/"+id, GHProjectCard.class);
     }
 
     private static class GHApiInfo {
@@ -789,7 +789,7 @@ public class GitHub {
      */
     public void checkApiUrlValidity() throws IOException {
         try {
-            retrieve().to("/", GHApiInfo.class).check(apiUrl);
+            createRequest().method("GET").to("/", GHApiInfo.class).check(apiUrl);
         } catch (IOException e) {
             if (isPrivateModeEnabled()) {
                 throw (IOException)new IOException("GitHub Enterprise server (" + apiUrl + ") with private mode enabled").initCause(e);
@@ -902,7 +902,7 @@ public class GitHub {
      * @see <a href="https://developer.github.com/v3/repos/#list-all-public-repositories">documentation</a>
      */
     public PagedIterable<GHRepository> listAllPublicRepositories(final String since) {
-        return retrieve().with("since",since)
+        return createRequest().method("GET").with("since",since)
             .asPagedIterable(
                 "/repositories",
                 GHRepository[].class);

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -385,7 +385,6 @@ public class GitHub {
 
             GHMyself u = retrieve().to("/user", GHMyself.class);
 
-            u.root = this;
             this.myself = u;
             return u;
         }
@@ -398,7 +397,6 @@ public class GitHub {
         GHUser u = users.get(login);
         if (u == null) {
             u = retrieve().to("/users/" + login, GHUser.class);
-            u.root = this;
             users.put(u.getLogin(), u);
         }
         return u;
@@ -419,7 +417,8 @@ public class GitHub {
     protected GHUser getUser(GHUser orig) {
         GHUser u = users.get(orig.getLogin());
         if (u==null) {
-            orig.root = this;
+            // TODO: Do not commit this without dealing with this.
+//            orig.root = this;
             users.put(orig.getLogin(),orig);
             return orig;
         }

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -485,8 +485,7 @@ public class GitHub {
         return retrieve()
             .asPagedIterable(
                 "/licenses",
-                GHLicense[].class,
-                item -> item.wrap(GitHub.this) );
+                GHLicense[].class);
     }
 
     /**
@@ -515,9 +514,7 @@ public class GitHub {
      */
     public List<GHInvitation> getMyInvitations() throws IOException {
         GHInvitation[] invitations = retrieve().to("/user/repository_invitations", GHInvitation[].class);
-        for (GHInvitation i : invitations) {
-            i.wrapUp(this);
-        }
+
         return Arrays.asList(invitations);
     }
 
@@ -573,7 +570,6 @@ public class GitHub {
     public Map<String, Set<GHTeam>> getMyTeams() throws IOException {
         Map<String, Set<GHTeam>> allMyTeams = new HashMap<String, Set<GHTeam>>();
         for (GHTeam team : retrieve().to("/user/teams", GHTeam[].class)) {
-            team.wrapUp(this);
             String orgLogin = team.getOrganization().getLogin();
             Set<GHTeam> teamsPerOrg = allMyTeams.get(orgLogin);
             if (teamsPerOrg == null) {
@@ -589,7 +585,7 @@ public class GitHub {
      * Gets a sigle team by ID.
      */
     public GHTeam getTeam(int id) throws IOException {
-        return retrieve().to("/teams/" + id, GHTeam.class).wrapUp(this);
+        return retrieve().to("/teams/" + id, GHTeam.class);
     }
     
     /**
@@ -597,8 +593,6 @@ public class GitHub {
      */
     public List<GHEventInfo> getEvents() throws IOException {
         GHEventInfo[] events = retrieve().to("/events", GHEventInfo[].class);
-        for (GHEventInfo e : events)
-            e.wrapUp(this);
         return Arrays.asList(events);
     }
 
@@ -668,7 +662,7 @@ public class GitHub {
                 .with("note", note)
                 .with("note_url", noteUrl);
 
-        return requester.method("POST").to("/authorizations", GHAuthorization.class).wrap(this);
+        return requester.method("POST").to("/authorizations", GHAuthorization.class);
     }
 
     /**
@@ -715,8 +709,7 @@ public class GitHub {
         return retrieve()
             .asPagedIterable(
                 "/authorizations",
-                GHAuthorization[].class,
-                item -> item.wrap(GitHub.this) );
+                GHAuthorization[].class);
     }
 
     /**
@@ -728,7 +721,7 @@ public class GitHub {
      */
     @Preview @Deprecated
     public GHApp getApp() throws IOException {
-        return retrieve().withPreview(MACHINE_MAN).to("/app", GHApp.class).wrapUp(this);
+        return retrieve().withPreview(MACHINE_MAN).to("/app", GHApp.class);
     }
 
     /**
@@ -758,15 +751,15 @@ public class GitHub {
     }
 
     public GHProject getProject(long id) throws IOException {
-        return retrieve().withPreview(INERTIA).to("/projects/"+id, GHProject.class).wrap(this);
+        return retrieve().withPreview(INERTIA).to("/projects/"+id, GHProject.class);
     }
 
     public GHProjectColumn getProjectColumn(long id) throws IOException {
-        return retrieve().withPreview(INERTIA).to("/projects/columns/"+id, GHProjectColumn.class).wrap(this);
+        return retrieve().withPreview(INERTIA).to("/projects/columns/"+id, GHProjectColumn.class);
     }
 
     public GHProjectCard getProjectCard(long id) throws IOException {
-        return retrieve().withPreview(INERTIA).to("/projects/columns/cards/"+id, GHProjectCard.class).wrap(this);
+        return retrieve().withPreview(INERTIA).to("/projects/columns/cards/"+id, GHProjectCard.class);
     }
 
     private static class GHApiInfo {

--- a/src/main/java/org/kohsuke/github/PagedIterable.java
+++ b/src/main/java/org/kohsuke/github/PagedIterable.java
@@ -10,7 +10,7 @@ import java.util.Set;
  *
  * @author Kohsuke Kawaguchi
  */
-public abstract class PagedIterable<T> implements Iterable<T> {
+public abstract class PagedIterable<T> extends GHObjectBase implements Iterable<T> {
     /**
      * Page size. 0 is default.
      */

--- a/src/main/java/org/kohsuke/github/PagedIterable.java
+++ b/src/main/java/org/kohsuke/github/PagedIterable.java
@@ -16,6 +16,15 @@ public abstract class PagedIterable<T> extends GHObjectBase implements Iterable<
      */
     private int size = 0;
 
+
+    /*package*/ PagedIterable() {
+        super();
+    }
+
+    /*package*/ PagedIterable(GitHub root) {
+        super(root);
+    }
+
     /**
      * Sets the pagination size.
      *

--- a/src/main/java/org/kohsuke/github/PagedSearchIterable.java
+++ b/src/main/java/org/kohsuke/github/PagedSearchIterable.java
@@ -56,7 +56,7 @@ public abstract class PagedSearchIterable<T> extends PagedIterable<T> {
             public T[] next() {
                 SearchResult<T> v = base.next();
                 if (result==null)   result = v;
-                return v.getItems(root);
+                return v.getItems(getRoot());
             }
 
             public void remove() {

--- a/src/main/java/org/kohsuke/github/PagedSearchIterable.java
+++ b/src/main/java/org/kohsuke/github/PagedSearchIterable.java
@@ -18,7 +18,7 @@ public abstract class PagedSearchIterable<T> extends PagedIterable<T> {
     private SearchResult<T> result;
 
     /*package*/ PagedSearchIterable(GitHub root) {
-        this.root = root;
+        super(root);
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/PagedSearchIterable.java
+++ b/src/main/java/org/kohsuke/github/PagedSearchIterable.java
@@ -12,8 +12,6 @@ import java.util.Iterator;
 @SuppressFBWarnings(value = {"UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
     "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"}, justification = "Constructed by JSON API")
 public abstract class PagedSearchIterable<T> extends PagedIterable<T> {
-    private final GitHub root;
-
     /**
      * As soon as we have any result fetched, it's set here so that we can report the total count.
      */

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -92,6 +92,19 @@ class Requester extends GHObjectBase {
     private HttpURLConnection uc;
     private boolean forceBody;
 
+    public void lateBinding() {
+        Requester.lateBinding(inject, getRoot());
+    }
+
+    public static void lateBinding(InjectableValues.Std inject, GitHub root) {
+        inject.addValue(GitHub.class.getName(), root);
+        inject.addValue(GHUser.class.getName(), null);
+        inject.addValue(GHOrganization.class.getName(), null);
+        inject.addValue(GHRepository.class.getName(), null);
+        inject.addValue(GHIssue.class.getName(), null);
+        inject.addValue(GHPullRequest.class.getName(), null);
+    }
+
     private static class Entry {
         String key;
         Object value;
@@ -104,7 +117,10 @@ class Requester extends GHObjectBase {
 
     Requester(GitHub root) {
         super(root);
-        inject.addValue("owner", null);
+
+        lateBinding();
+        inject.addValue(GHUser.class.getName(), null);
+
         inject.addValue(GitHub.class.getName(), root);
     }
 

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -73,8 +73,7 @@ import static org.kohsuke.github.GitHub.MAPPER;
  *
  * @author Kohsuke Kawaguchi
  */
-class Requester {
-    private final GitHub root;
+class Requester extends GHObjectBase {
     private final List<Entry> args = new ArrayList<Entry>();
     private final Map<String,String> headers = new LinkedHashMap<String, String>();
     private final InjectableValues.Std inject = new InjectableValues.Std();

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -102,7 +102,7 @@ class Requester extends GHObjectBase {
     }
 
     Requester(GitHub root) {
-        this.root = root;
+        super(root);
         inject.addValue("owner", null);
         inject.addValue(GitHub.class.getName(), root);
     }

--- a/src/test/java/org/kohsuke/github/GHGistTest.java
+++ b/src/test/java/org/kohsuke/github/GHGistTest.java
@@ -11,7 +11,7 @@ import static org.hamcrest.core.Is.is;
 /**
  * @author Kohsuke Kawaguchi
  */
-public class GistTest extends AbstractGitHubWireMockTest {
+public class GHGistTest extends AbstractGitHubWireMockTest {
     /**
      * CRUD operation.
      */

--- a/src/test/java/org/kohsuke/github/GHPullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestTest.java
@@ -307,15 +307,15 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
     public void getUserTest() throws IOException {
         GHPullRequest p = getRepository().createPullRequest("getUserTest", "test/stable", "master", "## test");
         GHPullRequest prSingle = getRepository().getPullRequest(p.getNumber());
-        assertNotNull(prSingle.getUser().root);
+        assertNotNull(prSingle.getUser().getRoot());
         prSingle.getMergeable();
-        assertNotNull(prSingle.getUser().root);
+        assertNotNull(prSingle.getUser().getRoot());
 
         PagedIterable<GHPullRequest> ghPullRequests = getRepository().listPullRequests(GHIssueState.OPEN);
         for (GHPullRequest pr : ghPullRequests) {
-            assertNotNull(pr.getUser().root);
+            assertNotNull(pr.getUser().getRoot());
             pr.getMergeable();
-            assertNotNull(pr.getUser().root);
+            assertNotNull(pr.getUser().getRoot());
         }
     }
 

--- a/src/test/java/org/kohsuke/github/RepositoryMockTest.java
+++ b/src/test/java/org/kohsuke/github/RepositoryMockTest.java
@@ -44,7 +44,7 @@ public class RepositoryMockTest {
         when(iterator.next()).thenReturn(new GHUser[] {user1}, new GHUser[] {user2});
 
         Requester requester = Mockito.mock(Requester.class);
-        when(mockGitHub.retrieve()).thenReturn(requester);
+        when(mockGitHub.createRequest()).thenReturn(requester);
 
 
         when(requester.asIterator("/repos/*/*/collaborators",


### PR DESCRIPTION
Some fiddling at #599 . 

Shows the potential to be a significant improvement in cleanliness.  
The injection feels a bit more like magic but it the same kind of magic as we're already doing.

- [x] Push the `root` injection into a base class and have absolutely everything inherit from that.
- [ ] Make `root` be `private final` and use a getter for all access.
- [ ] Remove all `wrapUp()` methods for `root`. 