### PR TITLE
Removed permission field in createTeam. It is deprecated in the API. 

### DIFF
--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -376,16 +376,14 @@ public class GHOrganization extends GHPerson {
      *
      * @param name
      *            the name
-     * @param p
-     *            the p
      * @param repositories
      *            the repositories
      * @return the gh team
      * @throws IOException
      *             the io exception
      */
-    public GHTeam createTeam(String name, Permission p, Collection<GHRepository> repositories) throws IOException {
-        Requester post = new Requester(root).with("name", name).with("permission", p);
+    public GHTeam createTeam(String name, Collection<GHRepository> repositories) throws IOException {
+        Requester post = new Requester(root).with("name", name);
         List<String> repo_names = new ArrayList<String>();
         for (GHRepository r : repositories) {
             repo_names.add(login + "/" + r.getName());
@@ -399,16 +397,14 @@ public class GHOrganization extends GHPerson {
      *
      * @param name
      *            the name
-     * @param p
-     *            the p
      * @param repositories
      *            the repositories
      * @return the gh team
      * @throws IOException
      *             the io exception
      */
-    public GHTeam createTeam(String name, Permission p, GHRepository... repositories) throws IOException {
-        return createTeam(name, p, Arrays.asList(repositories));
+    public GHTeam createTeam(String name, GHRepository... repositories) throws IOException {
+        return createTeam(name, Arrays.asList(repositories));
     }
 
     /**

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -2,13 +2,11 @@ package org.kohsuke.github;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.kohsuke.github.GHCommit.File;
-import org.kohsuke.github.GHOrganization.Permission;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -550,7 +548,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
 
     private void tryTeamCreation(GitHub gitHub) throws IOException {
         GHOrganization o = gitHub.getOrganization("HudsonLabs");
-        GHTeam t = o.createTeam("auto team", Permission.PUSH);
+        GHTeam t = o.createTeam("auto team");
         t.add(o.getRepository("auto-test"));
     }
 

--- a/src/test/java/org/kohsuke/github/GHOrganizationTest.java
+++ b/src/test/java/org/kohsuke/github/GHOrganizationTest.java
@@ -1,6 +1,5 @@
 package org.kohsuke.github;
 
-import com.jcraft.jsch.IO;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -33,8 +32,10 @@ public class GHOrganizationTest extends AbstractGitHubWireMockTest {
 
         GHOrganization org = gitHub.getOrganization(GITHUB_API_TEST_ORG);
         GHRepository repository = org.createRepository(GITHUB_API_TEST,
-                "a test repository used to test kohsuke's github-api", "http://github-api.kohsuke.org/",
-                "Core Developers", true);
+                "a test repository used to test kohsuke's github-api",
+                "http://github-api.kohsuke.org/",
+                "Core Developers",
+                true);
         Assert.assertNotNull(repository);
     }
 
@@ -45,7 +46,9 @@ public class GHOrganizationTest extends AbstractGitHubWireMockTest {
         GHOrganization org = gitHub.getOrganization(GITHUB_API_TEST_ORG);
         GHRepository repository = org.createRepository(GITHUB_API_TEST)
                 .description("a test repository used to test kohsuke's github-api")
-                .homepage("http://github-api.kohsuke.org/").team(org.getTeamByName("Core Developers")).autoInit(true)
+                .homepage("http://github-api.kohsuke.org/")
+                .team(org.getTeamByName("Core Developers"))
+                .autoInit(true)
                 .create();
         Assert.assertNotNull(repository);
         Assert.assertNotNull(repository.getReadme());
@@ -70,17 +73,5 @@ public class GHOrganizationTest extends AbstractGitHubWireMockTest {
 
         // Check the invitation has worked.
         // assertTrue(org.hasMember(user));
-    }
-
-    @Test
-    public void testCreateTeamWithRepoAccess() throws IOException {
-        String REPO_NAME = "github-api";
-
-        GHOrganization org = gitHub.getOrganization(GITHUB_API_TEST_ORG);
-        GHRepository repo = org.getRepository(REPO_NAME);
-
-        // Create team with access to repository. Check access was granted.
-        GHTeam team = org.createTeam(TEAM_NAME_CREATE, GHOrganization.Permission.PUSH, repo);
-        Assert.assertTrue(team.getRepositories().containsKey(REPO_NAME));
     }
 }


### PR DESCRIPTION
# Description 
https://developer.github.com/v3/teams/#create-team had deprecated the `permission` field but the library still expects this field. https://github.com/github-api/github-api/blob/da11702f6815f658014f33ce724f0cd2e4501081/src/main/java/org/kohsuke/github/GHOrganization.java#L387 

This PR refactors the code to remove the permission field.

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [ ] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn install site` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.
