### PR TITLE
Fixed CacheControl package name

### DIFF
--- a/src/main/java/org/kohsuke/github/extras/okhttp3/OkHttpConnector.java
+++ b/src/main/java/org/kohsuke/github/extras/okhttp3/OkHttpConnector.java
@@ -1,6 +1,6 @@
 package org.kohsuke.github.extras.okhttp3;
 
-import com.squareup.okhttp.CacheControl;
+import okhttp3.CacheControl;
 import okhttp3.ConnectionSpec;
 import okhttp3.OkHttpClient;
 import org.kohsuke.github.HttpConnector;


### PR DESCRIPTION
# Description
The `okhttp3.OkHttpConnector` class is still referencing the `okhttp.CacheControl`. However, this class is not part of OkHttp 3.x or 4.x. This creates a `ClassNotFoundException` at runtime on projects creating a `okhttp3.OkHttpConnector` with a `Cache`.

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [ ] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn install site` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.
