### PR TITLE
Remove dependency on apache commons-codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,11 +246,6 @@
       <version>3.9</version>
     </dependency>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-      <version>1.13</version>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <version>${hamcrest.version}</version>

--- a/src/main/java/org/kohsuke/github/GHBlob.java
+++ b/src/main/java/org/kohsuke/github/GHBlob.java
@@ -1,11 +1,9 @@
 package org.kohsuke.github;
 
-import org.apache.commons.codec.binary.Base64InputStream;
-
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.util.Base64;
 
 /**
  * The type GHBlob.
@@ -73,8 +71,9 @@ public class GHBlob {
     public InputStream read() {
         if (encoding.equals("base64")) {
             try {
-                return new Base64InputStream(new ByteArrayInputStream(content.getBytes("US-ASCII")), false);
-            } catch (UnsupportedEncodingException e) {
+                Base64.Decoder decoder = Base64.getMimeDecoder();
+                return new ByteArrayInputStream(decoder.decode(content));
+            } catch (IllegalArgumentException e) {
                 throw new AssertionError(e); // US-ASCII is mandatory
             }
         }

--- a/src/main/java/org/kohsuke/github/GHBlobBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHBlobBuilder.java
@@ -1,8 +1,7 @@
 package org.kohsuke.github;
 
-import org.apache.commons.codec.binary.Base64;
-
 import java.io.IOException;
+import java.util.Base64;
 
 /**
  * Builder pattern for creating a new blob. Based on https://developer.github.com/v3/git/blobs/#create-a-blob
@@ -37,7 +36,7 @@ public class GHBlobBuilder {
      * @return a GHBlobBuilder
      */
     public GHBlobBuilder binaryContent(byte[] content) {
-        String base64Content = Base64.encodeBase64String(content);
+        String base64Content = Base64.getMimeEncoder().encodeToString(content);
         req.with("content", base64Content);
         req.with("encoding", "base64");
         return this;

--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -1,13 +1,12 @@
 package org.kohsuke.github;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.binary.Base64InputStream;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * A Content of a repository.
@@ -114,7 +113,7 @@ public class GHContent implements Refreshable {
      */
     @SuppressFBWarnings("DM_DEFAULT_ENCODING")
     public String getContent() throws IOException {
-        return new String(Base64.decodeBase64(getEncodedContent()));
+        return new String(Base64.getMimeDecoder().decode(getEncodedContent()));
     }
 
     /**
@@ -175,8 +174,9 @@ public class GHContent implements Refreshable {
         refresh(content);
         if (encoding.equals("base64")) {
             try {
-                return new Base64InputStream(new ByteArrayInputStream(content.getBytes("US-ASCII")), false);
-            } catch (UnsupportedEncodingException e) {
+                Base64.Decoder decoder = Base64.getMimeDecoder();
+                return new ByteArrayInputStream(decoder.decode(content.getBytes(StandardCharsets.US_ASCII)));
+            } catch (IllegalArgumentException e) {
                 throw new AssertionError(e); // US-ASCII is mandatory
             }
         }
@@ -304,7 +304,7 @@ public class GHContent implements Refreshable {
      */
     public GHContentUpdateResponse update(byte[] newContentBytes, String commitMessage, String branch)
             throws IOException {
-        String encodedContent = Base64.encodeBase64String(newContentBytes);
+        String encodedContent = Base64.getMimeEncoder().encodeToString(newContentBytes);
 
         Requester requester = new Requester(root).with("path", path)
                 .with("message", commitMessage)

--- a/src/main/java/org/kohsuke/github/GHContentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHContentBuilder.java
@@ -1,9 +1,8 @@
 package org.kohsuke.github;
 
-import org.apache.commons.codec.binary.Base64;
-
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 /**
  * Used to create/update content.
@@ -69,7 +68,7 @@ public final class GHContentBuilder {
      * @return the gh content builder
      */
     public GHContentBuilder content(byte[] content) {
-        req.with("content", Base64.encodeBase64String(content));
+        req.with("content", Base64.getMimeEncoder().encodeToString(content));
         return this;
     }
 
@@ -81,11 +80,7 @@ public final class GHContentBuilder {
      * @return the gh content builder
      */
     public GHContentBuilder content(String content) {
-        try {
-            return content(content.getBytes("UTF-8"));
-        } catch (UnsupportedEncodingException x) {
-            throw new AssertionError();
-        }
+        return content(content.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -29,17 +29,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.introspect.VisibilityChecker.Std;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
-import org.apache.commons.codec.Charsets;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.*;
+import java.util.Base64;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
@@ -151,9 +151,9 @@ public class GitHub {
                 encodedAuthorization = "Bearer " + jwtToken;
             } else if (password != null) {
                 String authorization = (login + ':' + password);
-                String charsetName = Charsets.UTF_8.name();
+                String charsetName = StandardCharsets.UTF_8.name();
                 encodedAuthorization = "Basic "
-                        + new String(Base64.encodeBase64(authorization.getBytes(charsetName)), charsetName);
+                        + Base64.getEncoder().encodeToString(authorization.getBytes(charsetName));
             } else {// anonymous access
                 encodedAuthorization = null;
             }

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -11,6 +11,7 @@ import org.kohsuke.github.GHOrganization.Permission;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
@@ -930,7 +931,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
     }
 
     private void assertBlobContent(InputStream is) throws Exception {
-        String content = new String(IOUtils.toByteArray(is), "UTF-8");
+        String content = new String(IOUtils.toByteArray(is), StandardCharsets.UTF_8);
         assertThat(content, containsString("Copyright (c) 2011- Kohsuke Kawaguchi and other contributors"));
         assertThat(content, containsString("FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR"));
         assertThat(content.length(), is(1104));


### PR DESCRIPTION
# Description 
Now that we have moved to Java 8+, we can use Java 8 `Base64` and `StandardCharset`. 

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn install site` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.
