### PR TITLE
Labels with description are not preview anymore

### DIFF
--- a/src/main/java/org/kohsuke/github/GHLabel.java
+++ b/src/main/java/org/kohsuke/github/GHLabel.java
@@ -6,8 +6,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import static org.kohsuke.github.Previews.SYMMETRA;
-
 /**
  * The type GHLabel.
  *
@@ -51,8 +49,6 @@ public class GHLabel {
      *
      * @return the description
      */
-    @Preview
-    @Deprecated
     public String getDescription() {
         return description;
     }
@@ -83,7 +79,6 @@ public class GHLabel {
     public void setColor(String newColor) throws IOException {
         repo.root.createRequest()
                 .method("PATCH")
-                .withPreview(SYMMETRA)
                 .with("name", name)
                 .with("color", newColor)
                 .with("description", description)
@@ -99,12 +94,9 @@ public class GHLabel {
      * @throws IOException
      *             the io exception
      */
-    @Preview
-    @Deprecated
     public void setDescription(String newDescription) throws IOException {
         repo.root.createRequest()
                 .method("PATCH")
-                .withPreview(SYMMETRA)
                 .with("name", name)
                 .with("color", color)
                 .with("description", newDescription)

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1831,12 +1831,9 @@ public class GHRepository extends GHObject {
      * @throws IOException
      *             the io exception
      */
-    @Preview
-    @Deprecated
     public GHLabel createLabel(String name, String color, String description) throws IOException {
         return root.createRequest()
                 .method("POST")
-                .withPreview(SYMMETRA)
                 .with("name", name)
                 .with("color", color)
                 .with("description", description)

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1782,7 +1782,6 @@ public class GHRepository extends GHObject {
      */
     public PagedIterable<GHLabel> listLabels() throws IOException {
         return root.createRequest()
-                .withPreview(SYMMETRA)
                 .asPagedIterable(getApiTailUrl("labels"), GHLabel[].class, item -> item.wrapUp(GHRepository.this));
     }
 
@@ -1796,11 +1795,7 @@ public class GHRepository extends GHObject {
      *             the io exception
      */
     public GHLabel getLabel(String name) throws IOException {
-        return root.createRequest()
-                .withPreview(SYMMETRA)
-                .withUrlPath(getApiTailUrl("labels/" + name))
-                .fetch(GHLabel.class)
-                .wrapUp(this);
+        return root.createRequest().withUrlPath(getApiTailUrl("labels/" + name)).fetch(GHLabel.class).wrapUp(this);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/Previews.java
+++ b/src/main/java/org/kohsuke/github/Previews.java
@@ -67,14 +67,6 @@ class Previews {
     static final String SQUIRREL_GIRL = "application/vnd.github.squirrel-girl-preview";
 
     /**
-     * Label emoji, search, and descriptions
-     *
-     * @see <a href="https://developer.github.com/v3/previews/#label-emoji-search-and-descriptions">GitHub API
-     *      Previews</a>
-     */
-    static final String SYMMETRA = "application/vnd.github.symmetra-preview+json";
-
-    /**
      * Require signed commits
      *
      * @see <a href="https://developer.github.com/v3/previews/#require-signed-commits">GitHub API Previews</a>

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-12-b2265f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-12-b2265f.json
@@ -32,7 +32,6 @@
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "",
       "Location": "https://api.github.com/repos/github-api-test-org/test-labels/labels/test2",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-3-82e643.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-3-82e643.json
@@ -24,7 +24,6 @@
       "ETag": "W/\"70c6bea1b42c9775915fdf6e8279aa26\"",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "repo",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-5-ce07a3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-5-ce07a3.json
@@ -32,7 +32,6 @@
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "",
       "Location": "https://api.github.com/repos/github-api-test-org/test-labels/labels/test",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_enhancement-4-ba366e.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_enhancement-4-ba366e.json
@@ -25,7 +25,6 @@
       "Last-Modified": "Sun, 15 Feb 2015 14:49:10 GMT",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "repo",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-10-3ee113.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-10-3ee113.json
@@ -25,7 +25,6 @@
       "Last-Modified": "Sat, 05 Oct 2019 05:21:23 GMT",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "repo",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-6-6c1d5b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-6-6c1d5b.json
@@ -25,7 +25,6 @@
       "Last-Modified": "Sat, 05 Oct 2019 05:21:23 GMT",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "repo",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-7-aceb5f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-7-aceb5f.json
@@ -31,7 +31,6 @@
       "ETag": "W/\"b6be68c4a5dbc522147f58e4b1b1aed1\"",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-8-0dc6e2.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-8-0dc6e2.json
@@ -25,7 +25,6 @@
       "Last-Modified": "Sat, 05 Oct 2019 05:21:23 GMT",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "repo",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-9-e4f1b8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-9-e4f1b8.json
@@ -31,7 +31,6 @@
       "ETag": "W/\"cd828b300f3803bcda7512b44c762a69\"",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test2-13-633a55.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test2-13-633a55.json
@@ -25,7 +25,6 @@
       "Last-Modified": "Sat, 05 Oct 2019 05:21:24 GMT",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "repo",
-      "X-GitHub-Media-Type": "github.symmetra-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",


### PR DESCRIPTION
# Description 
Labels with descriptions do not seem to be preview apis anymore - https://developer.github.com/v3/issues/labels/#create-a-label so don't mark them as such

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn -P ci install site ` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.
