### PR TITLE
Enforce 'Accept' request header values

### DIFF
--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -1567,8 +1567,10 @@ public class GHRepository extends GHObject {
      */
     public InputStream readBlob(String blobSha) throws IOException {
         String target = getApiTailUrl("git/blobs/" + blobSha);
+
+        // https://developer.github.com/v3/media/ describes this media type
         return root.createRequest()
-                .withHeader("Accept", "application/vnd.github.VERSION.raw")
+                .withHeader("Accept", "application/vnd.github.v3.raw")
                 .withUrlPath(target)
                 .fetchStream();
     }

--- a/src/main/java/org/kohsuke/github/Previews.java
+++ b/src/main/java/org/kohsuke/github/Previews.java
@@ -64,7 +64,7 @@ class Previews {
      *
      * @see <a href="https://developer.github.com/v3/previews/#reactions">GitHub API Previews</a>
      */
-    static final String SQUIRREL_GIRL = "application/vnd.github.squirrel-girl-preview";
+    static final String SQUIRREL_GIRL = "application/vnd.github.squirrel-girl-preview+json";
 
     /**
      * Require signed commits

--- a/src/test/java/org/kohsuke/github/junit/GitHubWireMockRule.java
+++ b/src/test/java/org/kohsuke/github/junit/GitHubWireMockRule.java
@@ -109,9 +109,12 @@ public class GitHubWireMockRule extends WireMockMultiServerRule {
             return;
         }
 
+        // "If-None-Match" header used for ETag matching for caching connections
+        // "Accept" header is used to specify previews. If it changes expected data may not be retrieved.
         this.apiServer()
                 .snapshotRecord(recordSpec().forTarget("https://api.github.com")
                         .captureHeader("If-None-Match")
+                        .captureHeader("Accept")
                         .extractTextBodiesOver(255));
 
         // After taking the snapshot, format the output
@@ -121,6 +124,7 @@ public class GitHubWireMockRule extends WireMockMultiServerRule {
             this.rawServer()
                     .snapshotRecord(recordSpec().forTarget("https://raw.githubusercontent.com")
                             .captureHeader("If-None-Match")
+                            .captureHeader("Accept")
                             .extractTextBodiesOver(255));
 
             // For raw server, only fix up mapping files
@@ -131,6 +135,7 @@ public class GitHubWireMockRule extends WireMockMultiServerRule {
             this.uploadsServer()
                     .snapshotRecord(recordSpec().forTarget("https://uploads.github.com")
                             .captureHeader("If-None-Match")
+                            .captureHeader("Accept")
                             .extractTextBodiesOver(255));
 
             formatJsonFiles(new File(this.uploadsServer().getOptions().filesRoot().getPath()).toPath());

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/blob/mappings/repos_github-api_github-api-2-db8eac.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/blob/mappings/repos_github-api_github-api-2-db8eac.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/blob/mappings/repos_github-api_github-api_git_blobs_a12243f2fc5b8c2ba47dd677d0b0c7583539584d-3-6408bc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/blob/mappings/repos_github-api_github-api_git_blobs_a12243f2fc5b8c2ba47dd677d0b0c7583539584d-3-6408bc.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_git_blobs_a12243f2fc5b8c2ba47dd677d0b0c7583539584d",
   "request": {
     "url": "/repos/github-api/github-api/git/blobs/a12243f2fc5b8c2ba47dd677d0b0c7583539584d",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.v3.raw"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/blob/mappings/repos_github-api_github-api_git_blobs_a12243f2fc5b8c2ba47dd677d0b0c7583539584d-4-72e1ca.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/blob/mappings/repos_github-api_github-api_git_blobs_a12243f2fc5b8c2ba47dd677d0b0c7583539584d-4-72e1ca.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_git_blobs_a12243f2fc5b8c2ba47dd677d0b0c7583539584d",
   "request": {
     "url": "/repos/github-api/github-api/git/blobs/a12243f2fc5b8c2ba47dd677d0b0c7583539584d",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/blob/mappings/user-1-8996d0.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/blob/mappings/user-1-8996d0.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/directoryListing/mappings/repos_jenkinsci_jenkins-2-448d3f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/directoryListing/mappings/repos_jenkinsci_jenkins-2-448d3f.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins",
   "request": {
     "url": "/repos/jenkinsci/jenkins",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/directoryListing/mappings/repos_jenkinsci_jenkins_contents_core-3-7e1b6c.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/directoryListing/mappings/repos_jenkinsci_jenkins_contents_core-3-7e1b6c.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins_contents_core",
   "request": {
     "url": "/repos/jenkinsci/jenkins/contents/core",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/directoryListing/mappings/repos_jenkinsci_jenkins_contents_core_src-4-0566ab.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/directoryListing/mappings/repos_jenkinsci_jenkins_contents_core_src-4-0566ab.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins_contents_core_src",
   "request": {
     "url": "/repos/jenkinsci/jenkins/contents/core/src?ref=master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/directoryListing/mappings/user-1-0cdbd9.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/directoryListing/mappings/user-1-0cdbd9.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/listOrgMemberships/mappings/user-1-8636c5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/listOrgMemberships/mappings/user-1-8636c5.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/listOrgMemberships/mappings/user_memberships_orgs-2-29d7ac.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/listOrgMemberships/mappings/user_memberships_orgs-2-29d7ac.json
@@ -3,7 +3,12 @@
   "name": "user_memberships_orgs",
   "request": {
     "url": "/user/memberships/orgs",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-10-a97934.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-10-a97934.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=9",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-11-89714e.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-11-89714e.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=10",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-12-2b7183.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-12-2b7183.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=11",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-13-989db4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-13-989db4.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=12",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-14-50b907.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-14-50b907.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=13",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-15-f2648b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-15-f2648b.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=14",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-16-ee5a6c.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-16-ee5a6c.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=15",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-17-a41aee.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-17-a41aee.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=16",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-18-e1d519.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-18-e1d519.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=17",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-19-1b6948.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-19-1b6948.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=18",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-2-d85867.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-2-d85867.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-20-489082.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-20-489082.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=19",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-21-42be65.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-21-42be65.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=20",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-22-5720c4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-22-5720c4.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=21",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-23-045c36.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-23-045c36.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=22",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-24-bfc773.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-24-bfc773.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=23",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-26-ac22e3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-26-ac22e3.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-3-d96172.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-3-d96172.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-4-6dea52.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-4-6dea52.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=3",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-5-a8e944.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-5-a8e944.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-6-2658e9.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-6-2658e9.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=5",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-7-f25246.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-7-f25246.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=6",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-8-943718.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-8-943718.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=7",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-9-1de525.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications-9-1de525.json
@@ -3,7 +3,12 @@
   "name": "notifications",
   "request": {
     "url": "/notifications?all=true&page=8",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications_threads_523050578-25-3b5fa2.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/notifications_threads_523050578-25-3b5fa2.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 205,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/user-1-8439ce.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/notifications/mappings/user-1-8439ce.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/reactions_54107401-6-613187.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/reactions_54107401-6-613187.json
@@ -3,7 +3,12 @@
   "name": "reactions_54107401",
   "request": {
     "url": "/reactions/54107401",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.squirrel-girl-preview+json"
+      }
+    }
   },
   "response": {
     "status": 204,
@@ -16,7 +21,7 @@
       "X-RateLimit-Reset": "1572055286",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "",
-      "X-GitHub-Media-Type": "github.squirrel-girl-preview",
+      "X-GitHub-Media-Type": "github.squirrel-girl-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/repos_github-api_github-api-2-802b5f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/repos_github-api_github-api-2-802b5f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/repos_github-api_github-api_issues_311-3-27fe23.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/repos_github-api_github-api_issues_311-3-27fe23.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_issues_311",
   "request": {
     "url": "/repos/github-api/github-api/issues/311",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/repos_github-api_github-api_issues_311_reactions-4-4abb0b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/repos_github-api_github-api_issues_311_reactions-4-4abb0b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_issues_311_reactions",
   "request": {
     "url": "/repos/github-api/github-api/issues/311/reactions",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.squirrel-girl-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,
@@ -24,7 +29,7 @@
       "ETag": "W/\"121462c6df4333753c2e424ec1b757e9\"",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "repo",
-      "X-GitHub-Media-Type": "github.squirrel-girl-preview",
+      "X-GitHub-Media-Type": "github.squirrel-girl-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/repos_github-api_github-api_issues_311_reactions-5-031252.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/repos_github-api_github-api_issues_311_reactions-5-031252.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.squirrel-girl-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,
@@ -31,7 +36,7 @@
       "ETag": "\"114f64d23a30418378801432528d6961\"",
       "X-OAuth-Scopes": "admin:org, admin:org_hook, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user, write:discussion",
       "X-Accepted-OAuth-Scopes": "",
-      "X-GitHub-Media-Type": "github.squirrel-girl-preview",
+      "X-GitHub-Media-Type": "github.squirrel-girl-preview; format=json",
       "Access-Control-Expose-Headers": "ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type",
       "Access-Control-Allow-Origin": "*",
       "Strict-Transport-Security": "max-age=31536000; includeSubdomains; preload",

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/user-1-b7deb8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/reactions/mappings/user-1-b7deb8.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci-2-0d9fbe.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci-2-0d9fbe.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci",
   "request": {
     "url": "/orgs/jenkinsci",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci_members_b-6-ee4228.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci_members_b-6-ee4228.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_members_b",
   "request": {
     "url": "/orgs/jenkinsci/members/b",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci_members_kohsuke-5-073028.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci_members_kohsuke-5-073028.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_members_kohsuke",
   "request": {
     "url": "/orgs/jenkinsci/members/kohsuke",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci_public_members_b-8-fde843.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci_public_members_b-8-fde843.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_public_members_b",
   "request": {
     "url": "/orgs/jenkinsci/public_members/b",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci_public_members_kohsuke-7-0da2da.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/orgs_jenkinsci_public_members_kohsuke-7-0da2da.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_public_members_kohsuke",
   "request": {
     "url": "/orgs/jenkinsci/public_members/kohsuke",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/user-1-1f8ee7.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/user-1-1f8ee7.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/users_b-4-6d6a6b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/users_b-4-6d6a6b.json
@@ -3,7 +3,12 @@
   "name": "users_b",
   "request": {
     "url": "/users/b",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/users_kohsuke-3-6fc7a5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCheckMembership/mappings/users_kohsuke-3-6fc7a5.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke",
   "request": {
     "url": "/users/kohsuke",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins-3-f502af.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins-3-f502af.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins",
   "request": {
     "url": "/repos/jenkinsci/jenkins",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_commits_08c1c9970af4d609ae754fbe803e06186e3206f7-4-c46f8b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_commits_08c1c9970af4d609ae754fbe803e06186e3206f7-4-c46f8b.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins_commits_08c1c9970af4d609ae754fbe803e06186e3206f7",
   "request": {
     "url": "/repos/jenkinsci/jenkins/commits/08c1c9970af4d609ae754fbe803e06186e3206f7",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_commits_e5463e3d53fdf74e917d63dc44ec60bab60a24d4-5-8ff720.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_commits_e5463e3d53fdf74e917d63dc44ec60bab60a24d4-5-8ff720.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins_commits_e5463e3d53fdf74e917d63dc44ec60bab60a24d4",
   "request": {
     "url": "/repos/jenkinsci/jenkins/commits/e5463e3d53fdf74e917d63dc44ec60bab60a24d4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_git_blobs_187cdf651cbf44196886f87327dc3968443174fb-7-176ac3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_git_blobs_187cdf651cbf44196886f87327dc3968443174fb-7-176ac3.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins_git_blobs_187cdf651cbf44196886f87327dc3968443174fb",
   "request": {
     "url": "/repos/jenkinsci/jenkins/git/blobs/187cdf651cbf44196886f87327dc3968443174fb",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.v3.raw"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_git_trees_216d657eb6b24cb3ee300cf9dfe97b4131b7800b-8-ba2250.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_git_trees_216d657eb6b24cb3ee300cf9dfe97b4131b7800b-8-ba2250.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins_git_trees_216d657eb6b24cb3ee300cf9dfe97b4131b7800b",
   "request": {
     "url": "/repos/jenkinsci/jenkins/git/trees/216d657eb6b24cb3ee300cf9dfe97b4131b7800b",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_git_trees_d96a6e8b7231571b49af150a683177f37a180f04-6-d30d65.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/repos_jenkinsci_jenkins_git_trees_d96a6e8b7231571b49af150a683177f37a180f04-6-d30d65.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins_git_trees_d96a6e8b7231571b49af150a683177f37a180f04",
   "request": {
     "url": "/repos/jenkinsci/jenkins/git/trees/d96a6e8b7231571b49af150a683177f37a180f04",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/user-1-bddf38.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/user-1-bddf38.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/users_jenkinsci-2-0eb973.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommit/mappings/users_jenkinsci-2-0eb973.json
@@ -3,7 +3,12 @@
   "name": "users_jenkinsci",
   "request": {
     "url": "/users/jenkinsci",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitComment/mappings/repos_jenkinsci_jenkins-3-fe185a.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitComment/mappings/repos_jenkinsci_jenkins-3-fe185a.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins",
   "request": {
     "url": "/repos/jenkinsci/jenkins",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitComment/mappings/repos_jenkinsci_jenkins_comments-4-c4ee8b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitComment/mappings/repos_jenkinsci_jenkins_comments-4-c4ee8b.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins_comments",
   "request": {
     "url": "/repos/jenkinsci/jenkins/comments",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitComment/mappings/user-1-b9ac0e.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitComment/mappings/user-1-b9ac0e.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitComment/mappings/users_jenkinsci-2-2443ea.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitComment/mappings/users_jenkinsci-2-2443ea.json
@@ -3,7 +3,12 @@
   "name": "users_jenkinsci",
   "request": {
     "url": "/users/jenkinsci",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitShortInfo/mappings/repos_github-api_github-api-2-441cdf.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitShortInfo/mappings/repos_github-api_github-api-2-441cdf.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitShortInfo/mappings/repos_github-api_github-api_commits_86a2e245aa6d71d54923655066049d9e21a15f23-3-d76abe.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitShortInfo/mappings/repos_github-api_github-api_commits_86a2e245aa6d71d54923655066049d9e21a15f23-3-d76abe.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_commits_86a2e245aa6d71d54923655066049d9e21a15f23",
   "request": {
     "url": "/repos/github-api/github-api/commits/86a2e245aa6d71d54923655066049d9e21a15f23",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitShortInfo/mappings/user-1-c247f8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitShortInfo/mappings/user-1-c247f8.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitStatus/mappings/repos_github-api_github-api-2-b39326.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitStatus/mappings/repos_github-api_github-api-2-b39326.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitStatus/mappings/repos_github-api_github-api_statuses_ecbfdd7315ef2cf04b2be7f11a072ce0bd00c396-3-6fad91.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitStatus/mappings/repos_github-api_github-api_statuses_ecbfdd7315ef2cf04b2be7f11a072ce0bd00c396-3-6fad91.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_statuses_ecbfdd7315ef2cf04b2be7f11a072ce0bd00c396",
   "request": {
     "url": "/repos/github-api/github-api/statuses/ecbfdd7315ef2cf04b2be7f11a072ce0bd00c396",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitStatus/mappings/user-1-83b4bb.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCommitStatus/mappings/user-1-83b4bb.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_github-api-test-org_github-api-test-2-31a86a.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_github-api-test-org_github-api-test-2-31a86a.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api-test",
   "request": {
     "url": "/repos/github-api-test-org/github-api-test",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_github-api-test-org_github-api-test_deployments-3-702b71.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_github-api-test-org_github-api-test_deployments-3-702b71.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_github-api-test-org_github-api-test_deployments-4-b4bcda.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_github-api-test-org_github-api-test_deployments-4-b4bcda.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api-test_deployments",
   "request": {
     "url": "/repos/github-api-test-org/github-api-test/deployments?ref=master&environment=unittest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/user-1-6d2dcb.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/user-1-6d2dcb.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant-3-3fd5d2.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant-3-3fd5d2.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_sandbox-ant",
   "request": {
     "url": "/repos/kohsuke/sandbox-ant",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant_comments_35673784-6-70a63f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant_comments_35673784-6-70a63f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant_comments_35673784-7-1e9db3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant_comments_35673784-7-1e9db3.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_sandbox-ant_comments_35673784",
   "request": {
     "url": "/repos/kohsuke/sandbox-ant/comments/35673784",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant_commits_8ae38db0ea5837313ab5f39d43a6f73de3bd9000-4-d1822d.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant_commits_8ae38db0ea5837313ab5f39d43a6f73de3bd9000-4-d1822d.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_sandbox-ant_commits_8ae38db0ea5837313ab5f39d43a6f73de3bd9000",
   "request": {
     "url": "/repos/kohsuke/sandbox-ant/commits/8ae38db0ea5837313ab5f39d43a6f73de3bd9000",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant_commits_8ae38db0ea5837313ab5f39d43a6f73de3bd9000_comments-5-62d11e.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/repos_kohsuke_sandbox-ant_commits_8ae38db0ea5837313ab5f39d43a6f73de3bd9000_comments-5-62d11e.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/user-1-a9b48b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/user-1-a9b48b.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/users_kohsuke-2-a4924f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateCommitComment/mappings/users_kohsuke-2-a4924f.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke",
   "request": {
     "url": "/users/kohsuke",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test-2-2d35ce.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test-2-2d35ce.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api-test",
   "request": {
     "url": "/repos/github-api-test-org/github-api-test",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_hooks-4-0765fd.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_hooks-4-0765fd.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api-test_hooks",
   "request": {
     "url": "/repos/github-api-test-org/github-api-test/hooks",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_hooks-5-9f3310.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_hooks-5-9f3310.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api-test_hooks",
   "request": {
     "url": "/repos/github-api-test-org/github-api-test/hooks",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_hooks-7-3dddac.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_hooks-7-3dddac.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api-test_hooks",
   "request": {
     "url": "/repos/github-api-test-org/github-api-test/hooks",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_hooks-8-8cfab8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_hooks-8-8cfab8.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api-test_hooks",
   "request": {
     "url": "/repos/github-api-test-org/github-api-test/hooks",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_issues-10-4c0eec.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_issues-10-4c0eec.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_issues_1-11-b2b352.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_issues_1-11-b2b352.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_milestones-12-9f6e98.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_milestones-12-9f6e98.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_milestones-3-7cb4f1.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_milestones-3-7cb4f1.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 422,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_milestones-6-9a91aa.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_milestones-6-9a91aa.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api-test_milestones",
   "request": {
     "url": "/repos/github-api-test-org/github-api-test/milestones?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_milestones-9-c528f3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/repos_github-api-test-org_github-api-test_milestones-9-c528f3.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/user-1-8104cc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateIssue/mappings/user-1-8104cc.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCredentialValid/mappings/user-1-eba96b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCredentialValid/mappings/user-1-eba96b.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-10-3894dd.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-10-3894dd.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events?page=9",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-11-1f4bc3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-11-1f4bc3.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events?page=10",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-2-d66da8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-2-d66da8.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-3-d3ce34.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-3-d3ce34.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events?page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-4-794078.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-4-794078.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events?page=3",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-5-5d107a.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-5-5d107a.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events?page=4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-6-6f4a1d.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-6-6f4a1d.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events?page=5",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-7-6354ff.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-7-6354ff.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events?page=6",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-8-3719d1.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-8-3719d1.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events?page=7",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-9-982884.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/events-9-982884.json
@@ -3,7 +3,12 @@
   "name": "events",
   "request": {
     "url": "/events?page=8",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/user-1-01c5f6.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testEventApi/mappings/user-1-01c5f6.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/orgs_github-api-2-baecb5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/orgs_github-api-2-baecb5.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api",
   "request": {
     "url": "/orgs/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repos_github-api_github-api-3-891820.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repos_github-api_github-api-3-891820.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repos_github-api_github-api_issues-4-a70d05.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repos_github-api_github-api_issues-4-a70d05.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_issues",
   "request": {
     "url": "/repos/github-api/github-api/issues?state=closed",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-10-5a770b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-10-5a770b.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=7",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-11-e04b88.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-11-e04b88.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=8",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-12-fe625e.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-12-fe625e.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=9",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-13-ab2693.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-13-ab2693.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=10",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-14-9486f6.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-14-9486f6.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=11",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-15-c9e769.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-15-c9e769.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=12",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-16-46f0ca.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-16-46f0ca.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=13",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-17-b2fa4e.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-17-b2fa4e.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=14",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-18-7d74dc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-18-7d74dc.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=15",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-19-e22232.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-19-e22232.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=16",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-5-d2dadb.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-5-d2dadb.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-6-63d2db.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-6-63d2db.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=3",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-7-e084b8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-7-e084b8.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-8-c66e22.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-8-c66e22.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=5",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-9-ddbca5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/repositories_617210_issues-9-ddbca5.json
@@ -3,7 +3,12 @@
   "name": "repositories_617210_issues",
   "request": {
     "url": "/repositories/617210/issues?state=closed&page=6",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/user-1-7741e4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetIssues/mappings/user-1-7741e4.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetMyself/mappings/user-1-f80e1f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetMyself/mappings/user-1-f80e1f.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetMyself/mappings/user_repos-3-5f89dd.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetMyself/mappings/user_repos-3-5f89dd.json
@@ -3,7 +3,12 @@
   "name": "user_repos",
   "request": {
     "url": "/user/repos?type=all&per_page=30",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetMyself/mappings/users_bitwiseman-2-f759e6.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetMyself/mappings/users_bitwiseman-2-f759e6.json
@@ -3,7 +3,12 @@
   "name": "users_bitwiseman",
   "request": {
     "url": "/users/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetTeamsForRepo/mappings/orgs_github-api-test-org-2-e1b27b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetTeamsForRepo/mappings/orgs_github-api-test-org-2-e1b27b.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetTeamsForRepo/mappings/repos_github-api-test-org_testgetteamsforrepo-3-cf3c49.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetTeamsForRepo/mappings/repos_github-api-test-org_testgetteamsforrepo-3-cf3c49.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_testgetteamsforrepo",
   "request": {
     "url": "/repos/github-api-test-org/testGetTeamsForRepo",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetTeamsForRepo/mappings/repos_github-api-test-org_testgetteamsforrepo_teams-4-1dd41f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetTeamsForRepo/mappings/repos_github-api-test-org_testgetteamsforrepo_teams-4-1dd41f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_testgetteamsforrepo_teams",
   "request": {
     "url": "/repos/github-api-test-org/testGetTeamsForRepo/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetTeamsForRepo/mappings/user-1-692ed5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testGetTeamsForRepo/mappings/user-1-692ed5.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test-1-5e9335.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test-1-5e9335.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_test",
   "request": {
     "url": "/repos/kohsuke/test",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test_issues_3-4-805b83.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test_issues_3-4-805b83.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_test_issues_3",
   "request": {
     "url": "/repos/kohsuke/test/issues/3",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test_issues_3_comments-5-83d2db.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test_issues_3_comments-5-83d2db.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_test_issues_3_comments",
   "request": {
     "url": "/repos/kohsuke/test/issues/3/comments",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test_issues_4-2-d90a1a.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test_issues_4-2-d90a1a.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_test_issues_4",
   "request": {
     "url": "/repos/kohsuke/test/issues/4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test_issues_4_comments-3-648b70.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/repos_kohsuke_test_issues_4_comments-3-648b70.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_test_issues_4_comments",
   "request": {
     "url": "/repos/kohsuke/test/issues/4/comments",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/user-6-0d50ed.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testIssueWithNoComment/mappings/user-6-0d50ed.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testListCommits/mappings/repos_kohsuke_empty-commit-3-486d83.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testListCommits/mappings/repos_kohsuke_empty-commit-3-486d83.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_empty-commit",
   "request": {
     "url": "/repos/kohsuke/empty-commit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testListCommits/mappings/repos_kohsuke_empty-commit_commits-4-82c5e1.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testListCommits/mappings/repos_kohsuke_empty-commit_commits-4-82c5e1.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_empty-commit_commits",
   "request": {
     "url": "/repos/kohsuke/empty-commit/commits",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testListCommits/mappings/user-1-3c7e63.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testListCommits/mappings/user-1-3c7e63.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testListCommits/mappings/users_kohsuke-2-8e5007.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testListCommits/mappings/users_kohsuke-2-8e5007.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke",
   "request": {
     "url": "/users/kohsuke",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_cloudbeers-10-4936bd.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_cloudbeers-10-4936bd.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbeers",
   "request": {
     "url": "/orgs/cloudbeers",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_cloudbees-5-769fb6.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_cloudbees-5-769fb6.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees",
   "request": {
     "url": "/orgs/cloudbees",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_cloudbees-community-9-cce9ba.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_cloudbees-community-9-cce9ba.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees-community",
   "request": {
     "url": "/orgs/CloudBees-community",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_infradna-6-af7edd.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_infradna-6-af7edd.json
@@ -3,7 +3,12 @@
   "name": "orgs_infradna",
   "request": {
     "url": "/orgs/infradna",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_java-schema-utilities-8-89ed2c.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_java-schema-utilities-8-89ed2c.json
@@ -3,7 +3,12 @@
   "name": "orgs_java-schema-utilities",
   "request": {
     "url": "/orgs/java-schema-utilities",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_jenkins-infra-11-30e7c1.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_jenkins-infra-11-30e7c1.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkins-infra",
   "request": {
     "url": "/orgs/jenkins-infra",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_jenkinsci-4-100ade.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_jenkinsci-4-100ade.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci",
   "request": {
     "url": "/orgs/jenkinsci",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_jenkinsci-cert-13-0a4422.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_jenkinsci-cert-13-0a4422.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci-cert",
   "request": {
     "url": "/orgs/jenkinsci-cert",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_legomatterhorn-12-26ad87.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_legomatterhorn-12-26ad87.json
@@ -3,7 +3,12 @@
   "name": "orgs_legomatterhorn",
   "request": {
     "url": "/orgs/LegoMatterhorn",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_stapler-7-e0ce27.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/orgs_stapler-7-e0ce27.json
@@ -3,7 +3,12 @@
   "name": "orgs_stapler",
   "request": {
     "url": "/orgs/stapler",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/user-1-f4bfac.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/user-1-f4bfac.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/users_kohsuke-2-0e4039.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/users_kohsuke-2-0e4039.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke",
   "request": {
     "url": "/users/kohsuke",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/users_kohsuke_orgs-3-e6c67f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMemberOrgs/mappings/users_kohsuke_orgs-3-e6c67f.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke_orgs",
   "request": {
     "url": "/users/kohsuke/orgs",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMembership/mappings/orgs_github-api-test-org-2-f298a1.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMembership/mappings/orgs_github-api-test-org-2-f298a1.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMembership/mappings/repos_github-api-test-org_jenkins-3-e9db4f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMembership/mappings/repos_github-api-test-org_jenkins-3-e9db4f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_jenkins",
   "request": {
     "url": "/repos/github-api-test-org/jenkins",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMembership/mappings/repos_github-api-test-org_jenkins_collaborators-4-bce974.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMembership/mappings/repos_github-api-test-org_jenkins_collaborators-4-bce974.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_jenkins_collaborators",
   "request": {
     "url": "/repos/github-api-test-org/jenkins/collaborators",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMembership/mappings/user-1-4457ee.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMembership/mappings/user-1-4457ee.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizations/mappings/user-2-a4cacc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizations/mappings/user-2-a4cacc.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizations/mappings/user_orgs-1-2985ea.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizations/mappings/user_orgs-1-2985ea.json
@@ -3,7 +3,12 @@
   "name": "user_orgs",
   "request": {
     "url": "/user/orgs",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizationsContainMyTeams/mappings/user-1-fd1c25.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizationsContainMyTeams/mappings/user-1-fd1c25.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizationsContainMyTeams/mappings/user_orgs-3-f38132.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizationsContainMyTeams/mappings/user_orgs-3-f38132.json
@@ -3,7 +3,12 @@
   "name": "user_orgs",
   "request": {
     "url": "/user/orgs",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizationsContainMyTeams/mappings/user_teams-2-49ff8d.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyOrganizationsContainMyTeams/mappings/user_teams-2-49ff8d.json
@@ -3,7 +3,12 @@
   "name": "user_teams",
   "request": {
     "url": "/user/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_107424_teams-11-bed0fc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_107424_teams-11-bed0fc.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_teams",
   "request": {
     "url": "/organizations/107424/teams?page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_107424_teams-20-2fdc05.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_107424_teams-20-2fdc05.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_teams",
   "request": {
     "url": "/organizations/107424/teams?page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_107424_teams-23-864a80.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_107424_teams-23-864a80.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_teams",
   "request": {
     "url": "/organizations/107424/teams?page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_107424_teams-26-881e08.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_107424_teams-26-881e08.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_teams",
   "request": {
     "url": "/organizations/107424/teams?page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_235526_teams-35-8591cc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_235526_teams-35-8591cc.json
@@ -3,7 +3,12 @@
   "name": "organizations_235526_teams",
   "request": {
     "url": "/organizations/235526/teams?page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_235526_teams-44-3945b4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_235526_teams-44-3945b4.json
@@ -3,7 +3,12 @@
   "name": "organizations_235526_teams",
   "request": {
     "url": "/organizations/235526/teams?page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_235526_teams-47-bed317.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/organizations_235526_teams-47-bed317.json
@@ -3,7 +3,12 @@
   "name": "organizations_235526_teams",
   "request": {
     "url": "/organizations/235526/teams?page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_beautify-web-67-62298d.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_beautify-web-67-62298d.json
@@ -3,7 +3,12 @@
   "name": "orgs_beautify-web",
   "request": {
     "url": "/orgs/beautify-web",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_beautify-web_teams-68-586844.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_beautify-web_teams-68-586844.json
@@ -3,7 +3,12 @@
   "name": "orgs_beautify-web_teams",
   "request": {
     "url": "/orgs/beautify-web/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees-33-ce8716.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees-33-ce8716.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees",
   "request": {
     "url": "/orgs/cloudbees",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-34-57f5eb.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-34-57f5eb.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees_teams",
   "request": {
     "url": "/orgs/cloudbees/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-37-632605.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-37-632605.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees_teams",
   "request": {
     "url": "/orgs/cloudbees/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-39-fbf640.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-39-fbf640.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees_teams",
   "request": {
     "url": "/orgs/cloudbees/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-41-c3bba3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-41-c3bba3.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees_teams",
   "request": {
     "url": "/orgs/cloudbees/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-43-1d3fc4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-43-1d3fc4.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees_teams",
   "request": {
     "url": "/orgs/cloudbees/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-46-4d6d15.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-46-4d6d15.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees_teams",
   "request": {
     "url": "/orgs/cloudbees/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-49-35c476.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_cloudbees_teams-49-35c476.json
@@ -3,7 +3,12 @@
   "name": "orgs_cloudbees_teams",
   "request": {
     "url": "/orgs/cloudbees/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_github-api-test-org-51-a52998.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_github-api-test-org-51-a52998.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_github-api-test-org_teams-52-c4dada.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_github-api-test-org_teams-52-c4dada.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_github-api-test-org_teams-54-4eeff3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_github-api-test-org_teams-54-4eeff3.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-inc-30-e0b11b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-inc-30-e0b11b.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkins-inc",
   "request": {
     "url": "/orgs/jenkins-inc",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-inc_teams-31-383d61.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-inc_teams-31-383d61.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkins-inc_teams",
   "request": {
     "url": "/orgs/jenkins-inc/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra-56-b7c4f4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra-56-b7c4f4.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkins-infra",
   "request": {
     "url": "/orgs/jenkins-infra",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-57-196db4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-57-196db4.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkins-infra_teams",
   "request": {
     "url": "/orgs/jenkins-infra/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-59-b6bb78.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-59-b6bb78.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkins-infra_teams",
   "request": {
     "url": "/orgs/jenkins-infra/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-61-a7f22b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-61-a7f22b.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkins-infra_teams",
   "request": {
     "url": "/orgs/jenkins-infra/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-63-b5053d.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-63-b5053d.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkins-infra_teams",
   "request": {
     "url": "/orgs/jenkins-infra/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-65-f8bd81.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkins-infra_teams-65-f8bd81.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkins-infra_teams",
   "request": {
     "url": "/orgs/jenkins-infra/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci-3-eac3f0.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci-3-eac3f0.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci",
   "request": {
     "url": "/orgs/jenkinsci",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-10-bedcae.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-10-bedcae.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-13-acf98b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-13-acf98b.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-15-0aaf05.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-15-0aaf05.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-17-90bfe4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-17-90bfe4.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-19-4922cd.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-19-4922cd.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-22-4b9e60.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-22-4b9e60.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-25-51a481.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-25-51a481.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-28-a9e651.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-28-a9e651.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-4-421fa9.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-4-421fa9.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-6-7e7d35.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-6-7e7d35.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-8-2832b4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/orgs_jenkinsci_teams-8-2832b4.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_teams",
   "request": {
     "url": "/orgs/jenkinsci/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1450069_members_bitwiseman-50-4957ae.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1450069_members_bitwiseman-50-4957ae.json
@@ -3,7 +3,12 @@
   "name": "teams_1450069_members_bitwiseman",
   "request": {
     "url": "/teams/1450069/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1809126_members_bitwiseman-18-242ec4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1809126_members_bitwiseman-18-242ec4.json
@@ -3,7 +3,12 @@
   "name": "teams_1809126_members_bitwiseman",
   "request": {
     "url": "/teams/1809126/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1882929_members_bitwiseman-66-285fc3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1882929_members_bitwiseman-66-285fc3.json
@@ -3,7 +3,12 @@
   "name": "teams_1882929_members_bitwiseman",
   "request": {
     "url": "/teams/1882929/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1941826_members_bitwiseman-32-094e4d.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1941826_members_bitwiseman-32-094e4d.json
@@ -3,7 +3,12 @@
   "name": "teams_1941826_members_bitwiseman",
   "request": {
     "url": "/teams/1941826/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1986920_members_bitwiseman-29-0dd3d9.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_1986920_members_bitwiseman-29-0dd3d9.json
@@ -3,7 +3,12 @@
   "name": "teams_1986920_members_bitwiseman",
   "request": {
     "url": "/teams/1986920/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2070581_members_bitwiseman-42-e22d18.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2070581_members_bitwiseman-42-e22d18.json
@@ -3,7 +3,12 @@
   "name": "teams_2070581_members_bitwiseman",
   "request": {
     "url": "/teams/2070581/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2185547_members_bitwiseman-14-301ee9.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2185547_members_bitwiseman-14-301ee9.json
@@ -3,7 +3,12 @@
   "name": "teams_2185547_members_bitwiseman",
   "request": {
     "url": "/teams/2185547/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2188150_members_bitwiseman-58-1a21b5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2188150_members_bitwiseman-58-1a21b5.json
@@ -3,7 +3,12 @@
   "name": "teams_2188150_members_bitwiseman",
   "request": {
     "url": "/teams/2188150/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2278154_members_bitwiseman-60-2a2981.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2278154_members_bitwiseman-60-2a2981.json
@@ -3,7 +3,12 @@
   "name": "teams_2278154_members_bitwiseman",
   "request": {
     "url": "/teams/2278154/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2300722_members_bitwiseman-7-9bec56.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2300722_members_bitwiseman-7-9bec56.json
@@ -3,7 +3,12 @@
   "name": "teams_2300722_members_bitwiseman",
   "request": {
     "url": "/teams/2300722/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2384898_members_bitwiseman-40-95da17.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2384898_members_bitwiseman-40-95da17.json
@@ -3,7 +3,12 @@
   "name": "teams_2384898_members_bitwiseman",
   "request": {
     "url": "/teams/2384898/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2384906_members_bitwiseman-36-f56cc4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2384906_members_bitwiseman-36-f56cc4.json
@@ -3,7 +3,12 @@
   "name": "teams_2384906_members_bitwiseman",
   "request": {
     "url": "/teams/2384906/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2478842_members_bitwiseman-16-89727f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2478842_members_bitwiseman-16-89727f.json
@@ -3,7 +3,12 @@
   "name": "teams_2478842_members_bitwiseman",
   "request": {
     "url": "/teams/2478842/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2510135_members_bitwiseman-62-0a3910.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2510135_members_bitwiseman-62-0a3910.json
@@ -3,7 +3,12 @@
   "name": "teams_2510135_members_bitwiseman",
   "request": {
     "url": "/teams/2510135/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2658933_members_bitwiseman-64-23b3d8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2658933_members_bitwiseman-64-23b3d8.json
@@ -3,7 +3,12 @@
   "name": "teams_2658933_members_bitwiseman",
   "request": {
     "url": "/teams/2658933/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2832516_members_bitwiseman-27-01adc0.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2832516_members_bitwiseman-27-01adc0.json
@@ -3,7 +3,12 @@
   "name": "teams_2832516_members_bitwiseman",
   "request": {
     "url": "/teams/2832516/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2832517_members_bitwiseman-21-bd3f96.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2832517_members_bitwiseman-21-bd3f96.json
@@ -3,7 +3,12 @@
   "name": "teams_2832517_members_bitwiseman",
   "request": {
     "url": "/teams/2832517/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2915408_members_bitwiseman-45-b4fb18.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2915408_members_bitwiseman-45-b4fb18.json
@@ -3,7 +3,12 @@
   "name": "teams_2915408_members_bitwiseman",
   "request": {
     "url": "/teams/2915408/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2934265_members_bitwiseman-24-f07c2b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_2934265_members_bitwiseman-24-f07c2b.json
@@ -3,7 +3,12 @@
   "name": "teams_2934265_members_bitwiseman",
   "request": {
     "url": "/teams/2934265/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3023453_members_bitwiseman-12-2724fa.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3023453_members_bitwiseman-12-2724fa.json
@@ -3,7 +3,12 @@
   "name": "teams_3023453_members_bitwiseman",
   "request": {
     "url": "/teams/3023453/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3136781_members_bitwiseman-48-ea7a1b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3136781_members_bitwiseman-48-ea7a1b.json
@@ -3,7 +3,12 @@
   "name": "teams_3136781_members_bitwiseman",
   "request": {
     "url": "/teams/3136781/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3451996_members_bitwiseman-55-0e9309.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_3451996_members_bitwiseman-55-0e9309.json
@@ -3,7 +3,12 @@
   "name": "teams_3451996_members_bitwiseman",
   "request": {
     "url": "/teams/3451996/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_496711_members_bitwiseman-9-9e90f9.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_496711_members_bitwiseman-9-9e90f9.json
@@ -3,7 +3,12 @@
   "name": "teams_496711_members_bitwiseman",
   "request": {
     "url": "/teams/496711/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_663296_members_bitwiseman-69-a75539.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_663296_members_bitwiseman-69-a75539.json
@@ -3,7 +3,12 @@
   "name": "teams_663296_members_bitwiseman",
   "request": {
     "url": "/teams/663296/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_711073_members_bitwiseman-5-9723ac.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_711073_members_bitwiseman-5-9723ac.json
@@ -3,7 +3,12 @@
   "name": "teams_711073_members_bitwiseman",
   "request": {
     "url": "/teams/711073/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_820404_members_bitwiseman-53-be6df5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_820404_members_bitwiseman-53-be6df5.json
@@ -3,7 +3,12 @@
   "name": "teams_820404_members_bitwiseman",
   "request": {
     "url": "/teams/820404/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_879403_members_bitwiseman-38-189224.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/teams_879403_members_bitwiseman-38-189224.json
@@ -3,7 +3,12 @@
   "name": "teams_879403_members_bitwiseman",
   "request": {
     "url": "/teams/879403/members/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/user-1-9a7933.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/user-1-9a7933.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/user_teams-2-d60daf.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testMyTeamsShouldIncludeMyself/mappings/user_teams-2-d60daf.json
@@ -3,7 +3,12 @@
   "name": "user_teams",
   "request": {
     "url": "/user/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/orgs_github-api-test-org-3-183987.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/orgs_github-api-test-org-3-183987.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/repos_github-api-test-org_rubywm-5-5b2f01.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/repos_github-api-test-org_rubywm-5-5b2f01.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_rubywm",
   "request": {
     "url": "/repos/github-api-test-org/rubywm",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/repos_kohsuke_rubywm-2-7f6b9e.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/repos_kohsuke_rubywm-2-7f6b9e.json
@@ -3,7 +3,12 @@
   "name": "repos_kohsuke_rubywm",
   "request": {
     "url": "/repos/kohsuke/rubywm",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/repos_kohsuke_rubywm_forks-4-044af3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/repos_kohsuke_rubywm_forks-4-044af3.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 202,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/user-1-07a004.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgFork/mappings/user-1-07a004.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-10-13ae5b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-10-13ae5b.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=8",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-11-f533dd.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-11-f533dd.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=9",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-12-df03bd.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-12-df03bd.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=10",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-13-26bad5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-13-26bad5.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=11",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-14-8315bb.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-14-8315bb.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=12",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-15-ecf517.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-15-ecf517.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=13",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-16-45dd04.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-16-45dd04.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=14",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-17-a73c5a.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-17-a73c5a.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=15",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-18-e66682.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-18-e66682.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=16",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-19-0e04a7.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-19-0e04a7.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=17",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-20-5cb3f8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-20-5cb3f8.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=18",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-21-626ca8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-21-626ca8.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=19",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-22-e0e43c.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-22-e0e43c.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=20",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-23-6f8a70.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-23-6f8a70.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=21",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-24-aec88a.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-24-aec88a.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=22",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-25-d95d3c.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-25-d95d3c.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=23",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-4-471f9b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-4-471f9b.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-5-d68a56.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-5-d68a56.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=3",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-6-d4de5f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-6-d4de5f.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-7-db791f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-7-db791f.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=5",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-8-49da2f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-8-49da2f.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=6",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-9-d4d7b2.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/organizations_107424_repos-9-d4d7b2.json
@@ -3,7 +3,12 @@
   "name": "organizations_107424_repos",
   "request": {
     "url": "/organizations/107424/repos?per_page=100&page=7",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/orgs_jenkinsci-2-72681a.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/orgs_jenkinsci-2-72681a.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci",
   "request": {
     "url": "/orgs/jenkinsci",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/orgs_jenkinsci_repos-3-75d09b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/orgs_jenkinsci_repos-3-75d09b.json
@@ -3,7 +3,12 @@
   "name": "orgs_jenkinsci_repos",
   "request": {
     "url": "/orgs/jenkinsci/repos?per_page=100",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/user-1-50e8f5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgRepositories/mappings/user-1-50e8f5.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamByName/mappings/orgs_github-api-test-org-2-4f288c.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamByName/mappings/orgs_github-api-test-org-2-4f288c.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamByName/mappings/orgs_github-api-test-org_teams-3-b980fc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamByName/mappings/orgs_github-api-test-org_teams-3-b980fc.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamByName/mappings/user-1-d41553.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamByName/mappings/user-1-d41553.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamBySlug/mappings/orgs_github-api-test-org-2-805bfc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamBySlug/mappings/orgs_github-api-test-org-2-805bfc.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamBySlug/mappings/orgs_github-api-test-org_teams-3-44dbf3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamBySlug/mappings/orgs_github-api-test-org_teams-3-44dbf3.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamBySlug/mappings/user-1-04565f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeamBySlug/mappings/user-1-04565f.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeams/mappings/orgs_github-api-test-org-2-4a4f8e.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeams/mappings/orgs_github-api-test-org-2-4a4f8e.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeams/mappings/orgs_github-api-test-org_teams-3-625f65.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeams/mappings/orgs_github-api-test-org_teams-3-625f65.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeams/mappings/user-1-fc66c1.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrgTeams/mappings/user-1-fc66c1.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrganization/mappings/orgs_github-api-test-org-2-bbf24d.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrganization/mappings/orgs_github-api-test-org-2-bbf24d.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrganization/mappings/orgs_github-api-test-org_teams-3-7e66f9.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrganization/mappings/orgs_github-api-test-org_teams-3-7e66f9.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrganization/mappings/repos_github-api-test-org_jenkins-4-1d18fc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrganization/mappings/repos_github-api-test-org_jenkins-4-1d18fc.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_jenkins",
   "request": {
     "url": "/repos/github-api-test-org/jenkins",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrganization/mappings/user-1-0a855c.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testOrganization/mappings/user-1-0a855c.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRateLimit/mappings/rate_limit-1-195911.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRateLimit/mappings/rate_limit-1-195911.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRateLimit/mappings/user-2-50a73d.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRateLimit/mappings/user-2-50a73d.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRef/mappings/repos_jenkinsci_jenkins-2-284579.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRef/mappings/repos_jenkinsci_jenkins-2-284579.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins",
   "request": {
     "url": "/repos/jenkinsci/jenkins",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRef/mappings/repos_jenkinsci_jenkins_git_refs_heads_master-3-257aa3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRef/mappings/repos_jenkinsci_jenkins_git_refs_heads_master-3-257aa3.json
@@ -3,7 +3,12 @@
   "name": "repos_jenkinsci_jenkins_git_refs_heads_master",
   "request": {
     "url": "/repos/jenkinsci/jenkins/git/refs/heads/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRef/mappings/user-1-045bae.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRef/mappings/user-1-045bae.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename-2-b1b919.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename-2-b1b919.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename-3-397146.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename-3-397146.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename-4-b0c111.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename-4-b0c111.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename-5-6cc04a.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename-5-6cc04a.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename2-7-c1bd7f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename2-7-c1bd7f.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_github-api-test-rename2",
   "request": {
     "url": "/repos/bitwiseman/github-api-test-rename2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename2-8-17b2c9.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/repos_bitwiseman_github-api-test-rename2-8-17b2c9.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_github-api-test-rename2",
   "request": {
     "url": "/repos/bitwiseman/github-api-test-rename2",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/user-6-3068cd.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/user-6-3068cd.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/user_repos-1-ead413.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoCRUD/mappings/user_repos-1-ead413.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels-2-fbcd5a.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels-2-fbcd5a.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-labels",
   "request": {
     "url": "/repos/github-api-test-org/test-labels",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-12-b2265f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-12-b2265f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-3-82e643.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-3-82e643.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-labels_labels",
   "request": {
     "url": "/repos/github-api-test-org/test-labels/labels",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-5-ce07a3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels-5-ce07a3.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_enhancement-4-ba366e.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_enhancement-4-ba366e.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-labels_labels_enhancement",
   "request": {
     "url": "/repos/github-api-test-org/test-labels/labels/enhancement",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-10-3ee113.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-10-3ee113.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-labels_labels_test",
   "request": {
     "url": "/repos/github-api-test-org/test-labels/labels/test",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-11-f2667d.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-11-f2667d.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-labels_labels_test",
   "request": {
     "url": "/repos/github-api-test-org/test-labels/labels/test",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-6-6c1d5b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-6-6c1d5b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-labels_labels_test",
   "request": {
     "url": "/repos/github-api-test-org/test-labels/labels/test",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-7-aceb5f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-7-aceb5f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-8-0dc6e2.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-8-0dc6e2.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-labels_labels_test",
   "request": {
     "url": "/repos/github-api-test-org/test-labels/labels/test",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-9-e4f1b8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test-9-e4f1b8.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test2-13-633a55.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test2-13-633a55.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-labels_labels_test2",
   "request": {
     "url": "/repos/github-api-test-org/test-labels/labels/test2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test2-14-fc4fdf.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/repos_github-api-test-org_test-labels_labels_test2-14-fc4fdf.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-labels_labels_test2",
   "request": {
     "url": "/repos/github-api-test-org/test-labels/labels/test2",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/user-1-05a1d2.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepoLabel/mappings/user-1-05a1d2.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-2-64af61.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-2-64af61.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-3-a1a05f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-3-a1a05f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-4-c71176.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-4-c71176.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-7-51dabc.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-7-51dabc.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_github-api-test-autoinit",
   "request": {
     "url": "/repos/bitwiseman/github-api-test-autoinit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-8-42bbd1.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit-8-42bbd1.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_github-api-test-autoinit",
   "request": {
     "url": "/repos/bitwiseman/github-api-test-autoinit",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit_readme-5-459f37.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/repos_bitwiseman_github-api-test-autoinit_readme-5-459f37.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_github-api-test-autoinit_readme",
   "request": {
     "url": "/repos/bitwiseman/github-api-test-autoinit/readme",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/user-6-b16c3b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/user-6-b16c3b.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/user_repos-1-7be481.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testRepositoryWithAutoInitializationCRUD/mappings/user_repos-1-7be481.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/repos_bitwiseman_github-api-2-809893.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/repos_bitwiseman_github-api-2-809893.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_github-api",
   "request": {
     "url": "/repos/bitwiseman/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/repos_bitwiseman_github-api_subscribers-3-8cec42.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/repos_bitwiseman_github-api_subscribers-3-8cec42.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_github-api_subscribers",
   "request": {
     "url": "/repos/bitwiseman/github-api/subscribers",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user-1-9344f7.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user-1-9344f7.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-10-bd9bd7.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-10-bd9bd7.json
@@ -3,7 +3,12 @@
   "name": "user_1958953_repos",
   "request": {
     "url": "/user/1958953/repos?per_page=30&page=6",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-6-36527c.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-6-36527c.json
@@ -3,7 +3,12 @@
   "name": "user_1958953_repos",
   "request": {
     "url": "/user/1958953/repos?per_page=30&page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-7-923eca.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-7-923eca.json
@@ -3,7 +3,12 @@
   "name": "user_1958953_repos",
   "request": {
     "url": "/user/1958953/repos?per_page=30&page=3",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-8-6e87f8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-8-6e87f8.json
@@ -3,7 +3,12 @@
   "name": "user_1958953_repos",
   "request": {
     "url": "/user/1958953/repos?per_page=30&page=4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-9-9bdd2b.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/user_1958953_repos-9-9bdd2b.json
@@ -3,7 +3,12 @@
   "name": "user_1958953_repos",
   "request": {
     "url": "/user/1958953/repos?per_page=30&page=5",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/users_bitwiseman-4-695b59.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/users_bitwiseman-4-695b59.json
@@ -3,7 +3,12 @@
   "name": "users_bitwiseman",
   "request": {
     "url": "/users/bitwiseman",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/users_bitwiseman_repos-5-2be052.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testSubscribers/mappings/users_bitwiseman_repos-5-2be052.json
@@ -3,7 +3,12 @@
   "name": "users_bitwiseman_repos",
   "request": {
     "url": "/users/bitwiseman/repos?per_page=30",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testTreesRecursive/mappings/repos_github-api_github-api-2-1c232f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testTreesRecursive/mappings/repos_github-api_github-api-2-1c232f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testTreesRecursive/mappings/repos_github-api_github-api_git_trees_master-3-ffd3e3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testTreesRecursive/mappings/repos_github-api_github-api_git_trees_master-3-ffd3e3.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_git_trees_master",
   "request": {
     "url": "/repos/github-api/github-api/git/trees/master?recursive=1",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testTreesRecursive/mappings/user-1-ce7a01.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testTreesRecursive/mappings/user-1-ce7a01.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testUserPublicOrganizationsWhenThereAreNone/mappings/user-2-813f6f.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testUserPublicOrganizationsWhenThereAreNone/mappings/user-2-813f6f.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testUserPublicOrganizationsWhenThereAreNone/mappings/users_bitwiseman_orgs-1-94ce73.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testUserPublicOrganizationsWhenThereAreNone/mappings/users_bitwiseman_orgs-1-94ce73.json
@@ -3,7 +3,12 @@
   "name": "users_bitwiseman_orgs",
   "request": {
     "url": "/users/bitwiseman/orgs",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testUserPublicOrganizationsWhenThereAreSome/mappings/user-2-cb0c81.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testUserPublicOrganizationsWhenThereAreSome/mappings/user-2-cb0c81.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testUserPublicOrganizationsWhenThereAreSome/mappings/users_kohsuke_orgs-1-7ef9c5.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testUserPublicOrganizationsWhenThereAreSome/mappings/users_kohsuke_orgs-1-7ef9c5.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke_orgs",
   "request": {
     "url": "/users/kohsuke/orgs",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/tryHook/mappings/orgs_github-api-test-org-2-4eb608.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/tryHook/mappings/orgs_github-api-test-org-2-4eb608.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/tryHook/mappings/repos_github-api-test-org_github-api-3-6eeaa8.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/tryHook/mappings/repos_github-api-test-org_github-api-3-6eeaa8.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/tryHook/mappings/repos_github-api-test-org_github-api_hooks-4-bd2a17.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/tryHook/mappings/repos_github-api-test-org_github-api_hooks-4-bd2a17.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/tryHook/mappings/user-1-3d7769.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/tryHook/mappings/user-1-3d7769.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/lastStatus/mappings/repos_stapler_stapler-2-dea29c.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/lastStatus/mappings/repos_stapler_stapler-2-dea29c.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler",
   "request": {
     "url": "/repos/stapler/stapler",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/lastStatus/mappings/repos_stapler_stapler_statuses_6a243869aa3c3f80579102d00848a0083953d654-4-b564ee.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/lastStatus/mappings/repos_stapler_stapler_statuses_6a243869aa3c3f80579102d00848a0083953d654-4-b564ee.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_statuses_6a243869aa3c3f80579102d00848a0083953d654",
   "request": {
     "url": "/repos/stapler/stapler/statuses/6a243869aa3c3f80579102d00848a0083953d654",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/lastStatus/mappings/repos_stapler_stapler_tags-3-763721.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/lastStatus/mappings/repos_stapler_stapler_tags-3-763721.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_tags",
   "request": {
     "url": "/repos/stapler/stapler/tags",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/lastStatus/mappings/user-1-bde54f.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/lastStatus/mappings/user-1-bde54f.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler-2-342768.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler-2-342768.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler",
   "request": {
     "url": "/repos/stapler/stapler",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits-3-6214fe.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits-3-6214fe.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits",
   "request": {
     "url": "/repos/stapler/stapler/commits?path=pom.xml",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_06b1108ec041fd8d6e7f54c8578d84a672fee9e4-8-4fa8c0.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_06b1108ec041fd8d6e7f54c8578d84a672fee9e4-8-4fa8c0.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_06b1108ec041fd8d6e7f54c8578d84a672fee9e4",
   "request": {
     "url": "/repos/stapler/stapler/commits/06b1108ec041fd8d6e7f54c8578d84a672fee9e4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_06b1108ec041fd8d6e7f54c8578d84a672fee9e4-9-ad6e99.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_06b1108ec041fd8d6e7f54c8578d84a672fee9e4-9-ad6e99.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_06b1108ec041fd8d6e7f54c8578d84a672fee9e4",
   "request": {
     "url": "/repos/stapler/stapler/commits/06b1108ec041fd8d6e7f54c8578d84a672fee9e4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_2a971c4e38c6d6693f7ad8b6768e4d74840d6679-10-8ac20a.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_2a971c4e38c6d6693f7ad8b6768e4d74840d6679-10-8ac20a.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_2a971c4e38c6d6693f7ad8b6768e4d74840d6679",
   "request": {
     "url": "/repos/stapler/stapler/commits/2a971c4e38c6d6693f7ad8b6768e4d74840d6679",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_2a971c4e38c6d6693f7ad8b6768e4d74840d6679-11-c96500.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_2a971c4e38c6d6693f7ad8b6768e4d74840d6679-11-c96500.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_2a971c4e38c6d6693f7ad8b6768e4d74840d6679",
   "request": {
     "url": "/repos/stapler/stapler/commits/2a971c4e38c6d6693f7ad8b6768e4d74840d6679",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_2f4ca0f03c1e6188867bddddce12ff213a107d9d-12-dd34f1.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_2f4ca0f03c1e6188867bddddce12ff213a107d9d-12-dd34f1.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_2f4ca0f03c1e6188867bddddce12ff213a107d9d",
   "request": {
     "url": "/repos/stapler/stapler/commits/2f4ca0f03c1e6188867bddddce12ff213a107d9d",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_2f4ca0f03c1e6188867bddddce12ff213a107d9d-13-b7c821.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_2f4ca0f03c1e6188867bddddce12ff213a107d9d-13-b7c821.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_2f4ca0f03c1e6188867bddddce12ff213a107d9d",
   "request": {
     "url": "/repos/stapler/stapler/commits/2f4ca0f03c1e6188867bddddce12ff213a107d9d",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_4f260c560ec120f4e2c2ed727244690b1f4d5dca-22-3e6d36.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_4f260c560ec120f4e2c2ed727244690b1f4d5dca-22-3e6d36.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_4f260c560ec120f4e2c2ed727244690b1f4d5dca",
   "request": {
     "url": "/repos/stapler/stapler/commits/4f260c560ec120f4e2c2ed727244690b1f4d5dca",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_4f260c560ec120f4e2c2ed727244690b1f4d5dca-23-8573f1.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_4f260c560ec120f4e2c2ed727244690b1f4d5dca-23-8573f1.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_4f260c560ec120f4e2c2ed727244690b1f4d5dca",
   "request": {
     "url": "/repos/stapler/stapler/commits/4f260c560ec120f4e2c2ed727244690b1f4d5dca",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_53ce34d7d89c5172ae4f4f3167e35852b1910b59-18-4c7823.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_53ce34d7d89c5172ae4f4f3167e35852b1910b59-18-4c7823.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_53ce34d7d89c5172ae4f4f3167e35852b1910b59",
   "request": {
     "url": "/repos/stapler/stapler/commits/53ce34d7d89c5172ae4f4f3167e35852b1910b59",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_53ce34d7d89c5172ae4f4f3167e35852b1910b59-19-5f3cc3.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_53ce34d7d89c5172ae4f4f3167e35852b1910b59-19-5f3cc3.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_53ce34d7d89c5172ae4f4f3167e35852b1910b59",
   "request": {
     "url": "/repos/stapler/stapler/commits/53ce34d7d89c5172ae4f4f3167e35852b1910b59",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_6a243869aa3c3f80579102d00848a0083953d654-6-d76af9.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_6a243869aa3c3f80579102d00848a0083953d654-6-d76af9.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_6a243869aa3c3f80579102d00848a0083953d654",
   "request": {
     "url": "/repos/stapler/stapler/commits/6a243869aa3c3f80579102d00848a0083953d654",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_6a243869aa3c3f80579102d00848a0083953d654-7-a7972e.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_6a243869aa3c3f80579102d00848a0083953d654-7-a7972e.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_6a243869aa3c3f80579102d00848a0083953d654",
   "request": {
     "url": "/repos/stapler/stapler/commits/6a243869aa3c3f80579102d00848a0083953d654",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_72343298733508cced8dcb8eb43594bcc6130b26-20-73ac5f.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_72343298733508cced8dcb8eb43594bcc6130b26-20-73ac5f.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_72343298733508cced8dcb8eb43594bcc6130b26",
   "request": {
     "url": "/repos/stapler/stapler/commits/72343298733508cced8dcb8eb43594bcc6130b26",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_72343298733508cced8dcb8eb43594bcc6130b26-21-77b7d9.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_72343298733508cced8dcb8eb43594bcc6130b26-21-77b7d9.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_72343298733508cced8dcb8eb43594bcc6130b26",
   "request": {
     "url": "/repos/stapler/stapler/commits/72343298733508cced8dcb8eb43594bcc6130b26",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_950acbd60ed4289520dcd2a395e5d77f181e1cff-4-45c731.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_950acbd60ed4289520dcd2a395e5d77f181e1cff-4-45c731.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_950acbd60ed4289520dcd2a395e5d77f181e1cff",
   "request": {
     "url": "/repos/stapler/stapler/commits/950acbd60ed4289520dcd2a395e5d77f181e1cff",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_950acbd60ed4289520dcd2a395e5d77f181e1cff-5-1aa530.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_950acbd60ed4289520dcd2a395e5d77f181e1cff-5-1aa530.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_950acbd60ed4289520dcd2a395e5d77f181e1cff",
   "request": {
     "url": "/repos/stapler/stapler/commits/950acbd60ed4289520dcd2a395e5d77f181e1cff",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_d922b808068cf95d6f6ab624ce2c7f49d51f5321-14-35c73b.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_d922b808068cf95d6f6ab624ce2c7f49d51f5321-14-35c73b.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_d922b808068cf95d6f6ab624ce2c7f49d51f5321",
   "request": {
     "url": "/repos/stapler/stapler/commits/d922b808068cf95d6f6ab624ce2c7f49d51f5321",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_d922b808068cf95d6f6ab624ce2c7f49d51f5321-15-fb5ea1.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_d922b808068cf95d6f6ab624ce2c7f49d51f5321-15-fb5ea1.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_d922b808068cf95d6f6ab624ce2c7f49d51f5321",
   "request": {
     "url": "/repos/stapler/stapler/commits/d922b808068cf95d6f6ab624ce2c7f49d51f5321",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_efe737fa365a0187e052bc81391efbd84847a1b0-16-3621dd.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_efe737fa365a0187e052bc81391efbd84847a1b0-16-3621dd.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_efe737fa365a0187e052bc81391efbd84847a1b0",
   "request": {
     "url": "/repos/stapler/stapler/commits/efe737fa365a0187e052bc81391efbd84847a1b0",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_efe737fa365a0187e052bc81391efbd84847a1b0-17-ca9582.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/repos_stapler_stapler_commits_efe737fa365a0187e052bc81391efbd84847a1b0-17-ca9582.json
@@ -3,7 +3,12 @@
   "name": "repos_stapler_stapler_commits_efe737fa365a0187e052bc81391efbd84847a1b0",
   "request": {
     "url": "/repos/stapler/stapler/commits/efe737fa365a0187e052bc81391efbd84847a1b0",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/user-1-1b6473.json
+++ b/src/test/resources/org/kohsuke/github/CommitTest/wiremock/listFiles/mappings/user-1-1b6473.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableBranchProtections/mappings/repos_github-api-test-org_temp-testenablebranchprotections-2-02ee49.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableBranchProtections/mappings/repos_github-api-test-org_temp-testenablebranchprotections-2-02ee49.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testenablebranchprotections",
   "request": {
     "url": "/repos/github-api-test-org/temp-testEnableBranchProtections",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableBranchProtections/mappings/repos_github-api-test-org_temp-testenablebranchprotections_branches_master-3-040c1d.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableBranchProtections/mappings/repos_github-api-test-org_temp-testenablebranchprotections_branches_master-3-040c1d.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testenablebranchprotections_branches_master",
   "request": {
     "url": "/repos/github-api-test-org/temp-testEnableBranchProtections/branches/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableBranchProtections/mappings/repos_github-api-test-org_temp-testenablebranchprotections_branches_master_protection-4-aa97cf.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableBranchProtections/mappings/repos_github-api-test-org_temp-testenablebranchprotections_branches_master_protection-4-aa97cf.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.luke-cage-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableBranchProtections/mappings/user-1-c38b2b.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableBranchProtections/mappings/user-1-c38b2b.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/repos_github-api-test-org_temp-testenableprotectiononly-2-bc3099.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/repos_github-api-test-org_temp-testenableprotectiononly-2-bc3099.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testenableprotectiononly",
   "request": {
     "url": "/repos/github-api-test-org/temp-testEnableProtectionOnly",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/repos_github-api-test-org_temp-testenableprotectiononly_branches_master-3-883282.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/repos_github-api-test-org_temp-testenableprotectiononly_branches_master-3-883282.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testenableprotectiononly_branches_master",
   "request": {
     "url": "/repos/github-api-test-org/temp-testEnableProtectionOnly/branches/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/repos_github-api-test-org_temp-testenableprotectiononly_branches_master-5-90ab1b.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/repos_github-api-test-org_temp-testenableprotectiononly_branches_master-5-90ab1b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testenableprotectiononly_branches_master",
   "request": {
     "url": "/repos/github-api-test-org/temp-testEnableProtectionOnly/branches/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/repos_github-api-test-org_temp-testenableprotectiononly_branches_master_protection-4-857c66.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/repos_github-api-test-org_temp-testenableprotectiononly_branches_master_protection-4-857c66.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.luke-cage-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/user-1-100e44.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableProtectionOnly/mappings/user-1-100e44.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableRequireReviewsOnly/mappings/repos_github-api-test-org_temp-testenablerequirereviewsonly-2-318e0a.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableRequireReviewsOnly/mappings/repos_github-api-test-org_temp-testenablerequirereviewsonly-2-318e0a.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testenablerequirereviewsonly",
   "request": {
     "url": "/repos/github-api-test-org/temp-testEnableRequireReviewsOnly",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableRequireReviewsOnly/mappings/repos_github-api-test-org_temp-testenablerequirereviewsonly_branches_master-3-0e0c4c.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableRequireReviewsOnly/mappings/repos_github-api-test-org_temp-testenablerequirereviewsonly_branches_master-3-0e0c4c.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testenablerequirereviewsonly_branches_master",
   "request": {
     "url": "/repos/github-api-test-org/temp-testEnableRequireReviewsOnly/branches/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableRequireReviewsOnly/mappings/repos_github-api-test-org_temp-testenablerequirereviewsonly_branches_master_protection-4-b57fab.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableRequireReviewsOnly/mappings/repos_github-api-test-org_temp-testenablerequirereviewsonly_branches_master_protection-4-b57fab.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.luke-cage-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableRequireReviewsOnly/mappings/user-1-64a678.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testEnableRequireReviewsOnly/mappings/user-1-64a678.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits-2-126c7a.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits-2-126c7a.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testsignedcommits",
   "request": {
     "url": "/repos/github-api-test-org/temp-testSignedCommits",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master-3-7a0577.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master-3-7a0577.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testsignedcommits_branches_master",
   "request": {
     "url": "/repos/github-api-test-org/temp-testSignedCommits/branches/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection-4-4b8a92.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection-4-4b8a92.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.luke-cage-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-5-c0150d.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-5-c0150d.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures",
   "request": {
     "url": "/repos/github-api-test-org/temp-testSignedCommits/branches/master/protection/required_signatures",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.zzzax-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-6-e29707.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-6-e29707.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.zzzax-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-7-fa5a0d.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-7-fa5a0d.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures",
   "request": {
     "url": "/repos/github-api-test-org/temp-testSignedCommits/branches/master/protection/required_signatures",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.zzzax-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-8-8c2a08.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-8-8c2a08.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures",
   "request": {
     "url": "/repos/github-api-test-org/temp-testSignedCommits/branches/master/protection/required_signatures",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.zzzax-preview+json"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-9-c0efc3.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures-9-c0efc3.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testsignedcommits_branches_master_protection_required_signatures",
   "request": {
     "url": "/repos/github-api-test-org/temp-testSignedCommits/branches/master/protection/required_signatures",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.zzzax-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/user-1-94ed9a.json
+++ b/src/test/resources/org/kohsuke/github/GHBranchProtectionTest/wiremock/testSignedCommits/mappings/user-1-94ed9a.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-e50803.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-e50803.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50-6-3cdae0.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50-6-3cdae0.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/test+directory%20%2350",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-10-a5a649.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-10-a5a649.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/test+directory%20%2350/test%20file-to+create-%231.txt?path=test%2Bdirectory+%2350%2Ftest+file-to%2Bcreate-%231.txt&message=Enough+of+this+foolishness%21&sha=da2d3cc78776aec68881668775c46a53f0ee2288",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-11-47d978.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-11-47d978.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/test+directory%20%2350/test%20file-to+create-%231.txt",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-3-a97122.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-3-a97122.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-4-5b2d08.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-4-5b2d08.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/test%2Bdirectory%20%2350/test%20file-to%2Bcreate-%231.txt?ref=master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-5-4be43b.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-5-4be43b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/test+directory%20%2350/test%20file-to+create-%231.txt",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-7-64a83a.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-7-64a83a.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/test%2Bdirectory%20%2350/test%20file-to%2Bcreate-%231.txt?ref=master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-8-04f85e.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-8-04f85e.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-9-1d4297.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt-9-1d4297.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_testdirectory-50_test-file-tocreate-1txt",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/test%2Bdirectory%20%2350/test%20file-to%2Bcreate-%231.txt?ref=master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/user-1-6cfc78.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testCRUDContent/mappings/user-1-6cfc78.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-1d1a48.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-1d1a48.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_a-dir-with-3-entries-3-2d908c.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_a-dir-with-3-entries-3-2d908c.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_a-dir-with-3-entries",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/ghcontent-ro/a-dir-with-3-entries",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContent/mappings/user-1-34ca16.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContent/mappings/user-1-34ca16.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContentTrailingSlash/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-a5c7d0.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContentTrailingSlash/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-a5c7d0.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContentTrailingSlash/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_a-dir-with-3-entries-3-462ae7.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContentTrailingSlash/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_a-dir-with-3-entries-3-462ae7.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_a-dir-with-3-entries",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/ghcontent-ro/a-dir-with-3-entries?ref=master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContentTrailingSlash/mappings/user-1-ebccdf.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetDirectoryContentTrailingSlash/mappings/user-1-ebccdf.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetEmptyFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-1279fb.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetEmptyFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-1279fb.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetEmptyFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_an-empty-file-3-a4535a.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetEmptyFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_an-empty-file-3-a4535a.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_an-empty-file",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/ghcontent-ro/an-empty-file",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetEmptyFileContent/mappings/user-1-afa831.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetEmptyFileContent/mappings/user-1-afa831.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-788adb.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-2-788adb.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-3-54fda8.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest-3-54fda8.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_a-file-with-content-4-3e4aa2.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetFileContent/mappings/repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_a-file-with-content-4-3e4aa2.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_ghcontentintegrationtest_contents_ghcontent-ro_a-file-with-content",
   "request": {
     "url": "/repos/github-api-test-org/GHContentIntegrationTest/contents/ghcontent-ro/a-file-with-content",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetFileContent/mappings/user-1-59f0ed.json
+++ b/src/test/resources/org/kohsuke/github/GHContentIntegrationTest/wiremock/testGetFileContent/mappings/user-1-59f0ed.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentById/mappings/orgs_github-api-test-org-1-4def93.json
+++ b/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentById/mappings/orgs_github-api-test-org-1-4def93.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentById/mappings/repos_github-api-test-org_github-api-2-a1a9ff.json
+++ b/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentById/mappings/repos_github-api-test-org_github-api-2-a1a9ff.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentById/mappings/repos_github-api-test-org_github-api_deployments_178653229-3-d1d9d9.json
+++ b/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentById/mappings/repos_github-api-test-org_github-api_deployments_178653229-3-d1d9d9.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_deployments_178653229",
   "request": {
     "url": "/repos/github-api-test-org/github-api/deployments/178653229",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/gistFile/mappings/gists_9903708-2-c3067d.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/gistFile/mappings/gists_9903708-2-c3067d.json
@@ -3,7 +3,12 @@
   "name": "gists_9903708",
   "request": {
     "url": "/gists/9903708",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/gistFile/mappings/user-1-9226d6.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/gistFile/mappings/user-1-9226d6.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/lifecycleTest/mappings/gists-2-2f93ee.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/lifecycleTest/mappings/gists-2-2f93ee.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/lifecycleTest/mappings/gists_9faa55cd67b21a789bb44e34e5e41f72-3-26c314.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/lifecycleTest/mappings/gists_9faa55cd67b21a789bb44e34e5e41f72-3-26c314.json
@@ -3,7 +3,12 @@
   "name": "gists_9faa55cd67b21a789bb44e34e5e41f72",
   "request": {
     "url": "/gists/9faa55cd67b21a789bb44e34e5e41f72",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/lifecycleTest/mappings/user-1-3380f8.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/lifecycleTest/mappings/user-1-3380f8.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_8edf855833a05ce8730d609fe8bd803a-9-e0907c.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_8edf855833a05ce8730d609fe8bd803a-9-e0907c.json
@@ -3,7 +3,12 @@
   "name": "gists_8edf855833a05ce8730d609fe8bd803a",
   "request": {
     "url": "/gists/8edf855833a05ce8730d609fe8bd803a",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708-2-ab2c9d.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708-2-ab2c9d.json
@@ -3,7 +3,12 @@
   "name": "gists_9903708",
   "request": {
     "url": "/gists/9903708",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_forks-7-42d6e4.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_forks-7-42d6e4.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_forks-8-992bf5.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_forks-8-992bf5.json
@@ -3,7 +3,12 @@
   "name": "gists_9903708_forks",
   "request": {
     "url": "/gists/9903708/forks",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_star-3-dc6fd4.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_star-3-dc6fd4.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_star-4-680201.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_star-4-680201.json
@@ -3,7 +3,12 @@
   "name": "gists_9903708_star",
   "request": {
     "url": "/gists/9903708/star",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_star-5-c7d88c.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_star-5-c7d88c.json
@@ -3,7 +3,12 @@
   "name": "gists_9903708_star",
   "request": {
     "url": "/gists/9903708/star",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_star-6-584dc0.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/gists_9903708_star-6-584dc0.json
@@ -3,7 +3,12 @@
   "name": "gists_9903708_star",
   "request": {
     "url": "/gists/9903708/star",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/user-1-075004.json
+++ b/src/test/resources/org/kohsuke/github/GHGistTest/wiremock/starTest/mappings/user-1-075004.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHGistUpdaterTest/wiremock/testGitUpdater/mappings/gists-1-fde9aa.json
+++ b/src/test/resources/org/kohsuke/github/GHGistUpdaterTest/wiremock/testGitUpdater/mappings/gists-1-fde9aa.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHGistUpdaterTest/wiremock/testGitUpdater/mappings/gists_209fef72c25fe4b3f673437603ab6d5d-2-d3ef0c.json
+++ b/src/test/resources/org/kohsuke/github/GHGistUpdaterTest/wiremock/testGitUpdater/mappings/gists_209fef72c25fe4b3f673437603ab6d5d-2-d3ef0c.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHGistUpdaterTest/wiremock/testGitUpdater/mappings/gists_209fef72c25fe4b3f673437603ab6d5d-3-94cd51.json
+++ b/src/test/resources/org/kohsuke/github/GHGistUpdaterTest/wiremock/testGitUpdater/mappings/gists_209fef72c25fe4b3f673437603ab6d5d-3-94cd51.json
@@ -3,7 +3,12 @@
   "name": "gists_209fef72c25fe4b3f673437603ab6d5d",
   "request": {
     "url": "/gists/209fef72c25fe4b3f673437603ab6d5d",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/orgs_github-api-test-org-6-097490.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/orgs_github-api-test-org-6-097490.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api-7-ef3199.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api-7-ef3199.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues-5-218efd.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues-5-218efd.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues_313-6-989586.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues_313-6-989586.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues_313-9-450e6f.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues_313-9-450e6f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues_313_events-7-ef9890.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues_313_events-7-ef9890.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_issues_313_events",
   "request": {
     "url": "/repos/github-api-test-org/github-api/issues/313/events",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues_events_2704815753-8-306d40.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testEventsForSingleIssue/mappings/repos_github-api-test-org_github-api_issues_events_2704815753-8-306d40.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_issues_events_2704815753",
   "request": {
     "url": "/repos/github-api-test-org/github-api/issues/events/2704815753",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/orgs_github-api-test-org-1-b27b87.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/orgs_github-api-test-org-1-b27b87.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repos_github-api-test-org_github-api-2-2afea7.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repos_github-api-test-org_github-api-2-2afea7.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repos_github-api-test-org_github-api_issues_events-3-d61292.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repos_github-api-test-org_github-api_issues_events-3-d61292.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_issues_events",
   "request": {
     "url": "/repos/github-api-test-org/github-api/issues/events",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-10-83c7ab.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-10-83c7ab.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=8",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-11-6f0d69.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-11-6f0d69.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=9",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-12-208a37.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-12-208a37.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=10",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-13-94dd8e.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-13-94dd8e.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=11",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-14-b1ad56.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-14-b1ad56.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=12",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-15-5f55d9.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-15-5f55d9.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=13",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-16-491772.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-16-491772.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=14",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-4-2b6f60.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-4-2b6f60.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-5-72a130.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-5-72a130.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=3",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-6-9c193f.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-6-9c193f.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-7-654e00.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-7-654e00.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=5",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-8-71d796.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-8-71d796.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=6",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-9-286927.json
+++ b/src/test/resources/org/kohsuke/github/GHIssueEventTest/wiremock/testRepositoryEvents/mappings/repositories_206888201_issues_events-9-286927.json
@@ -3,7 +3,12 @@
   "name": "repositories_206888201_issues_events",
   "request": {
     "url": "/repositories/206888201/issues/events?page=7",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryFullLicense/mappings/licenses_mit-4-4cc836.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryFullLicense/mappings/licenses_mit-4-4cc836.json
@@ -3,7 +3,12 @@
   "name": "licenses_mit",
   "request": {
     "url": "/licenses/mit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryFullLicense/mappings/repos_github-api_github-api-2-631120.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryFullLicense/mappings/repos_github-api_github-api-2-631120.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryFullLicense/mappings/repos_github-api_github-api_license-3-f6ba18.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryFullLicense/mappings/repos_github-api_github-api_license-3-f6ba18.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_license",
   "request": {
     "url": "/repos/github-api/github-api/license",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryFullLicense/mappings/user-1-eeb321.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryFullLicense/mappings/user-1-eeb321.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicense/mappings/repos_github-api_github-api-2-1f9552.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicense/mappings/repos_github-api_github-api-2-1f9552.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicense/mappings/repos_github-api_github-api_license-3-b99917.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicense/mappings/repos_github-api_github-api_license-3-b99917.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_license",
   "request": {
     "url": "/repos/github-api/github-api/license",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicense/mappings/user-1-659cc2.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicense/mappings/user-1-659cc2.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseAtom/mappings/repos_atom_atom-2-bd1153.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseAtom/mappings/repos_atom_atom-2-bd1153.json
@@ -3,7 +3,12 @@
   "name": "repos_atom_atom",
   "request": {
     "url": "/repos/atom/atom",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseAtom/mappings/repos_atom_atom_license-3-a0fac7.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseAtom/mappings/repos_atom_atom_license-3-a0fac7.json
@@ -3,7 +3,12 @@
   "name": "repos_atom_atom_license",
   "request": {
     "url": "/repos/atom/atom/license",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseAtom/mappings/user-1-30af42.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseAtom/mappings/user-1-30af42.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseContent/mappings/repos_pomes_pomes-2-7c3e7b.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseContent/mappings/repos_pomes_pomes-2-7c3e7b.json
@@ -3,7 +3,12 @@
   "name": "repos_pomes_pomes",
   "request": {
     "url": "/repos/pomes/pomes",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseContent/mappings/repos_pomes_pomes_license-3-c59d46.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseContent/mappings/repos_pomes_pomes_license-3-c59d46.json
@@ -3,7 +3,12 @@
   "name": "repos_pomes_pomes_license",
   "request": {
     "url": "/repos/pomes/pomes/license",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseContent/mappings/user-1-767d65.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseContent/mappings/user-1-767d65.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseContent_raw/mappings/pomes_pomes_master_license-1-050b93.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicenseContent_raw/mappings/pomes_pomes_master_license-1-050b93.json
@@ -3,7 +3,12 @@
   "name": "pomes_pomes_master_license",
   "request": {
     "url": "/pomes/pomes/master/LICENSE",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicensePomes/mappings/repos_pomes_pomes-2-c9deed.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicensePomes/mappings/repos_pomes_pomes-2-c9deed.json
@@ -3,7 +3,12 @@
   "name": "repos_pomes_pomes",
   "request": {
     "url": "/repos/pomes/pomes",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicensePomes/mappings/repos_pomes_pomes_license-3-47a3f2.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicensePomes/mappings/repos_pomes_pomes_license-3-47a3f2.json
@@ -3,7 +3,12 @@
   "name": "repos_pomes_pomes_license",
   "request": {
     "url": "/repos/pomes/pomes/license",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicensePomes/mappings/user-1-f33aa0.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryLicensePomes/mappings/user-1-f33aa0.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryWithoutLicense/mappings/repos_github-api-test-org_empty-2-ed7892.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryWithoutLicense/mappings/repos_github-api-test-org_empty-2-ed7892.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_empty",
   "request": {
     "url": "/repos/github-api-test-org/empty",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryWithoutLicense/mappings/repos_github-api-test-org_empty_license-3-fb7ab8.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryWithoutLicense/mappings/repos_github-api-test-org_empty_license-3-fb7ab8.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_empty_license",
   "request": {
     "url": "/repos/github-api-test-org/empty/license",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryWithoutLicense/mappings/user-1-3003d0.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/checkRepositoryWithoutLicense/mappings/user-1-3003d0.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/getLicense/mappings/licenses_mit-2-2182ea.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/getLicense/mappings/licenses_mit-2-2182ea.json
@@ -3,7 +3,12 @@
   "name": "licenses_mit",
   "request": {
     "url": "/licenses/mit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/getLicense/mappings/user-1-38876a.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/getLicense/mappings/user-1-38876a.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/listLicenses/mappings/licenses-2-b3d307.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/listLicenses/mappings/licenses-2-b3d307.json
@@ -3,7 +3,12 @@
   "name": "licenses",
   "request": {
     "url": "/licenses",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/listLicenses/mappings/user-1-dfe7f7.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/listLicenses/mappings/user-1-dfe7f7.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/listLicensesCheckIndividualLicense/mappings/licenses-2-f00fa6.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/listLicensesCheckIndividualLicense/mappings/licenses-2-f00fa6.json
@@ -3,7 +3,12 @@
   "name": "licenses",
   "request": {
     "url": "/licenses",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/listLicensesCheckIndividualLicense/mappings/user-1-b8102c.json
+++ b/src/test/resources/org/kohsuke/github/GHLicenseTest/wiremock/listLicensesCheckIndividualLicense/mappings/user-1-b8102c.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/orgs_github-api-test-org-2-fdbcaf.json
+++ b/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/orgs_github-api-test-org-2-fdbcaf.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api-3-701999.json
+++ b/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api-3-701999.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones-4-a7ebf1.json
+++ b/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones-4-a7ebf1.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones_2-5-80930c.json
+++ b/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones_2-5-80930c.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones_2-6-865125.json
+++ b/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones_2-6-865125.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones_2-7-b24a5b.json
+++ b/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones_2-7-b24a5b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones_2-8-fffe46.json
+++ b/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/repos_github-api-test-org_github-api_milestones_2-8-fffe46.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_milestones_2",
   "request": {
     "url": "/repos/github-api-test-org/github-api/milestones/2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/user-1-7feb26.json
+++ b/src/test/resources/org/kohsuke/github/GHMilestoneTest/wiremock/testUpdateMilestone/mappings/user-1-7feb26.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHObjectTest/wiremock/test_toString/mappings/orgs_github-api-test-org-2-117186.json
+++ b/src/test/resources/org/kohsuke/github/GHObjectTest/wiremock/test_toString/mappings/orgs_github-api-test-org-2-117186.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHObjectTest/wiremock/test_toString/mappings/user-1-160947.json
+++ b/src/test/resources/org/kohsuke/github/GHObjectTest/wiremock/test_toString/mappings/user-1-160947.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepository/mappings/orgs_github-api-test-org-2-cf0714.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepository/mappings/orgs_github-api-test-org-2-cf0714.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepository/mappings/orgs_github-api-test-org_repos-4-43cfd5.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepository/mappings/orgs_github-api-test-org_repos-4-43cfd5.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepository/mappings/orgs_github-api-test-org_teams-3-beb3ba.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepository/mappings/orgs_github-api-test-org_teams-3-beb3ba.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepository/mappings/user-1-58ae66.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepository/mappings/user-1-58ae66.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/orgs_github-api-test-org-2-7b0ac5.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/orgs_github-api-test-org-2-7b0ac5.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/orgs_github-api-test-org_repos-4-423c77.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/orgs_github-api-test-org_repos-4-423c77.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/orgs_github-api-test-org_teams-3-eb06b2.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/orgs_github-api-test-org_teams-3-eb06b2.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/repos_github-api-test-org_github-api-test_readme-5-12092c.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/repos_github-api-test-org_github-api-test_readme-5-12092c.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api-test_readme",
   "request": {
     "url": "/repos/github-api-test-org/github-api-test/readme",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/user-1-d246cf.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateRepositoryWithAutoInitialization/mappings/user-1-d246cf.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/orgs_github-api-test-org-2-b46fc0.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/orgs_github-api-test-org-2-b46fc0.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/orgs_github-api-test-org_teams-4-93bbb3.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/orgs_github-api-test-org_teams-4-93bbb3.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/repos_github-api-test-org_github-api-3-890724.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/repos_github-api-test-org_github-api-3-890724.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/teams_3531422_repos-5-9893d5.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/teams_3531422_repos-5-9893d5.json
@@ -3,7 +3,12 @@
   "name": "teams_3531422_repos",
   "request": {
     "url": "/teams/3531422/repos",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/user-1-3a6b16.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeam/mappings/user-1-3a6b16.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/orgs_github-api-test-org-2-8c23f1.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/orgs_github-api-test-org-2-8c23f1.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/orgs_github-api-test-org_teams-4-3459b0.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/orgs_github-api-test-org_teams-4-3459b0.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/repos_github-api-test-org_github-api-3-25876e.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/repos_github-api-test-org_github-api-3-25876e.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/teams_3501817_repos-5-97bad2.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/teams_3501817_repos-5-97bad2.json
@@ -3,7 +3,12 @@
   "name": "teams_3501817_repos",
   "request": {
     "url": "/teams/3501817/repos",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/user-1-8620f0.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testCreateTeamWithRepoAccess/mappings/user-1-8620f0.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/orgs_github-api-test-org-1-6480b3.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/orgs_github-api-test-org-1-6480b3.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/orgs_github-api-test-org_members-2-e0db34.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/orgs_github-api-test-org_members-2-e0db34.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_members",
   "request": {
     "url": "/orgs/github-api-test-org/members",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/orgs_github-api-test-org_members_martinvanzijl2-4-885640.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/orgs_github-api-test-org_members_martinvanzijl2-4-885640.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_members_martinvanzijl2",
   "request": {
     "url": "/orgs/github-api-test-org/members/martinvanzijl2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/orgs_github-api-test-org_memberships_martinvanzijl2-5-d8831e.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/orgs_github-api-test-org_memberships_martinvanzijl2-5-d8831e.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/user-6-7e6e7d.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/user-6-7e6e7d.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/users_martinvanzijl2-3-26b89b.json
+++ b/src/test/resources/org/kohsuke/github/GHOrganizationTest/wiremock/testInviteUser/mappings/users_martinvanzijl2-3-26b89b.json
@@ -3,7 +3,12 @@
   "name": "users_martinvanzijl2",
   "request": {
     "url": "/users/martinvanzijl2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPersonTest/wiremock/testFieldsForOrganization/mappings/orgs_github-api-test-org-1-13f85d.json
+++ b/src/test/resources/org/kohsuke/github/GHPersonTest/wiremock/testFieldsForOrganization/mappings/orgs_github-api-test-org-1-13f85d.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPersonTest/wiremock/testFieldsForOrganization/mappings/repos_github-api-test-org_github-api-2-b3a3de.json
+++ b/src/test/resources/org/kohsuke/github/GHPersonTest/wiremock/testFieldsForOrganization/mappings/repos_github-api-test-org_github-api-2-b3a3de.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPersonTest/wiremock/testFieldsForOrganization/mappings/users_github-api-test-org-3-9edc4a.json
+++ b/src/test/resources/org/kohsuke/github/GHPersonTest/wiremock/testFieldsForOrganization/mappings/users_github-api-test-org-3-9edc4a.json
@@ -3,7 +3,12 @@
   "name": "users_github-api-test-org",
   "request": {
     "url": "/users/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPersonTest/wiremock/testFieldsForUser/mappings/users_kohsuke2-1-be47bc.json
+++ b/src/test/resources/org/kohsuke/github/GHPersonTest/wiremock/testFieldsForUser/mappings/users_kohsuke2-1-be47bc.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke2",
   "request": {
     "url": "/users/kohsuke2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/orgs_github-api-test-org-2-8a33ed.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/orgs_github-api-test-org-2-8a33ed.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/orgs_github-api-test-org_projects-3-b659e6.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/orgs_github-api-test-org_projects-3-b659e6.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/projects_3312444_columns-4-3be146.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/projects_3312444_columns-4-3be146.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/projects_columns_6706801_cards-5-45bdd9.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/projects_columns_6706801_cards-5-45bdd9.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/projects_columns_cards_27353270-6-97fd6c.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/projects_columns_cards_27353270-6-97fd6c.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/projects_columns_cards_27353270-7-75b0d2.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/projects_columns_cards_27353270-7-75b0d2.json
@@ -3,7 +3,12 @@
   "name": "projects_columns_cards_27353270",
   "request": {
     "url": "/projects/columns/cards/27353270",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/user-1-0c7200.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testArchiveCard/mappings/user-1-0c7200.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/orgs_github-api-test-org-2-2cd475.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/orgs_github-api-test-org-2-2cd475.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/orgs_github-api-test-org_projects-3-bac54b.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/orgs_github-api-test-org_projects-3-bac54b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/orgs_github-api-test-org_repos-6-c2d819.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/orgs_github-api-test-org_repos-6-c2d819.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/projects_3312449_columns-4-5b5040.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/projects_3312449_columns-4-5b5040.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/projects_columns_6706803_cards-5-e6d34d.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/projects_columns_6706803_cards-5-e6d34d.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/projects_columns_6706803_cards-8-6458c3.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/projects_columns_6706803_cards-8-6458c3.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/repos_github-api-test-org_repo-for-project-card-9-372cc0.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/repos_github-api-test-org_repo-for-project-card-9-372cc0.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_repo-for-project-card",
   "request": {
     "url": "/repos/github-api-test-org/repo-for-project-card",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/repos_github-api-test-org_repo-for-project-card_issues-7-29d82e.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/repos_github-api-test-org_repo-for-project-card_issues-7-29d82e.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/user-1-b9c4ba.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreateCardFromIssue/mappings/user-1-b9c4ba.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/orgs_github-api-test-org-2-a73c27.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/orgs_github-api-test-org-2-a73c27.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/orgs_github-api-test-org_projects-3-fd95c8.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/orgs_github-api-test-org_projects-3-fd95c8.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/projects_3312442_columns-4-264f75.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/projects_3312442_columns-4-264f75.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/projects_columns_6706799_cards-5-0a15ce.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/projects_columns_6706799_cards-5-0a15ce.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/user-1-80e348.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testCreatedCard/mappings/user-1-80e348.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/orgs_github-api-test-org-2-467a39.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/orgs_github-api-test-org-2-467a39.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/orgs_github-api-test-org_projects-3-491fbb.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/orgs_github-api-test-org_projects-3-491fbb.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/projects_3312447_columns-4-f80b32.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/projects_3312447_columns-4-f80b32.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/projects_columns_6706802_cards-5-aad1d6.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/projects_columns_6706802_cards-5-aad1d6.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/projects_columns_cards_27353272-6-e93cbd.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/projects_columns_cards_27353272-6-e93cbd.json
@@ -3,7 +3,12 @@
   "name": "projects_columns_cards_27353272",
   "request": {
     "url": "/projects/columns/cards/27353272",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/projects_columns_cards_27353272-7-a7094f.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/projects_columns_cards_27353272-7-a7094f.json
@@ -3,7 +3,12 @@
   "name": "projects_columns_cards_27353272",
   "request": {
     "url": "/projects/columns/cards/27353272",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/user-1-c2f32b.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testDeleteCard/mappings/user-1-c2f32b.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/orgs_github-api-test-org-2-049038.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/orgs_github-api-test-org-2-049038.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/orgs_github-api-test-org_projects-3-68e871.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/orgs_github-api-test-org_projects-3-68e871.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/projects_3312443_columns-4-1de47f.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/projects_3312443_columns-4-1de47f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/projects_columns_6706800_cards-5-695ce5.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/projects_columns_6706800_cards-5-695ce5.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/projects_columns_cards_27353267-6-62a0d7.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/projects_columns_cards_27353267-6-62a0d7.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/projects_columns_cards_27353267-7-93c5d2.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/projects_columns_cards_27353267-7-93c5d2.json
@@ -3,7 +3,12 @@
   "name": "projects_columns_cards_27353267",
   "request": {
     "url": "/projects/columns/cards/27353267",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/user-1-355d68.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectCardTest/wiremock/testEditCardNote/mappings/user-1-355d68.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testCreatedColumn/mappings/orgs_github-api-test-org-2-7feb42.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testCreatedColumn/mappings/orgs_github-api-test-org-2-7feb42.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testCreatedColumn/mappings/orgs_github-api-test-org_projects-3-42bd7d.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testCreatedColumn/mappings/orgs_github-api-test-org_projects-3-42bd7d.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testCreatedColumn/mappings/projects_3312440_columns-4-eb5863.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testCreatedColumn/mappings/projects_3312440_columns-4-eb5863.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testCreatedColumn/mappings/user-1-ff30f9.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testCreatedColumn/mappings/user-1-ff30f9.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/orgs_github-api-test-org-2-f4a059.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/orgs_github-api-test-org-2-f4a059.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/orgs_github-api-test-org_projects-3-bfb7de.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/orgs_github-api-test-org_projects-3-bfb7de.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/projects_3312441_columns-4-fb6e53.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/projects_3312441_columns-4-fb6e53.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/projects_columns_6706794-5-8c0cae.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/projects_columns_6706794-5-8c0cae.json
@@ -3,7 +3,12 @@
   "name": "projects_columns_6706794",
   "request": {
     "url": "/projects/columns/6706794",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/projects_columns_6706794-6-112e1e.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/projects_columns_6706794-6-112e1e.json
@@ -3,7 +3,12 @@
   "name": "projects_columns_6706794",
   "request": {
     "url": "/projects/columns/6706794",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/user-1-f818b6.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testDeleteColumn/mappings/user-1-f818b6.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/orgs_github-api-test-org-2-eb0425.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/orgs_github-api-test-org-2-eb0425.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/orgs_github-api-test-org_projects-3-97b70b.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/orgs_github-api-test-org_projects-3-97b70b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/projects_3312439_columns-4-082ed3.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/projects_3312439_columns-4-082ed3.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/projects_columns_6706791-5-85f356.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/projects_columns_6706791-5-85f356.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/projects_columns_6706791-6-1cfa5d.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/projects_columns_6706791-6-1cfa5d.json
@@ -3,7 +3,12 @@
   "name": "projects_columns_6706791",
   "request": {
     "url": "/projects/columns/6706791",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/user-1-e21e45.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectColumnTest/wiremock/testEditColumnName/mappings/user-1-e21e45.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testCreatedProject/mappings/orgs_github-api-test-org-2-713f01.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testCreatedProject/mappings/orgs_github-api-test-org-2-713f01.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testCreatedProject/mappings/orgs_github-api-test-org_projects-3-e5afd9.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testCreatedProject/mappings/orgs_github-api-test-org_projects-3-e5afd9.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testCreatedProject/mappings/user-1-a9a3d2.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testCreatedProject/mappings/user-1-a9a3d2.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/orgs_github-api-test-org-2-c30240.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/orgs_github-api-test-org-2-c30240.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/orgs_github-api-test-org_projects-3-daa6c2.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/orgs_github-api-test-org_projects-3-daa6c2.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/projects_3312437-4-f50762.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/projects_3312437-4-f50762.json
@@ -3,7 +3,12 @@
   "name": "projects_3312437",
   "request": {
     "url": "/projects/3312437",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/projects_3312437-5-8b8e6f.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/projects_3312437-5-8b8e6f.json
@@ -3,7 +3,12 @@
   "name": "projects_3312437",
   "request": {
     "url": "/projects/3312437",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/user-1-9cb867.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testDeleteProject/mappings/user-1-9cb867.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/orgs_github-api-test-org-2-2e39c7.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/orgs_github-api-test-org-2-2e39c7.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/orgs_github-api-test-org_projects-3-08231b.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/orgs_github-api-test-org_projects-3-08231b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/projects_3312435-4-004d34.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/projects_3312435-4-004d34.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/projects_3312435-5-76e0c2.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/projects_3312435-5-76e0c2.json
@@ -3,7 +3,12 @@
   "name": "projects_3312435",
   "request": {
     "url": "/projects/3312435",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/user-1-b2b126.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectBody/mappings/user-1-b2b126.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/orgs_github-api-test-org-2-e3d87f.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/orgs_github-api-test-org-2-e3d87f.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/orgs_github-api-test-org_projects-3-6a0a46.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/orgs_github-api-test-org_projects-3-6a0a46.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/projects_3312436-4-20ac7f.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/projects_3312436-4-20ac7f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/projects_3312436-5-6c28d5.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/projects_3312436-5-6c28d5.json
@@ -3,7 +3,12 @@
   "name": "projects_3312436",
   "request": {
     "url": "/projects/3312436",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/user-1-115e61.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectName/mappings/user-1-115e61.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/orgs_github-api-test-org-2-a522b5.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/orgs_github-api-test-org-2-a522b5.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/orgs_github-api-test-org_projects-3-ee429e.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/orgs_github-api-test-org_projects-3-ee429e.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/projects_3312433-4-55b16b.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/projects_3312433-4-55b16b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/projects_3312433-5-715884.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/projects_3312433-5-715884.json
@@ -3,7 +3,12 @@
   "name": "projects_3312433",
   "request": {
     "url": "/projects/3312433",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.inertia-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/user-1-f7605e.json
+++ b/src/test/resources/org/kohsuke/github/GHProjectTest/wiremock/testEditProjectState/mappings/user-1-f7605e.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/orgs_github-api-test-org-2-24dc8a.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/orgs_github-api-test-org-2-24dc8a.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api-10-b2a378.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api-10-b2a378.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api-3-0f9ebc.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api-3-0f9ebc.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api-5-1db040.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api-5-1db040.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api-8-d6b189.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api-8-d6b189.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls-11-c7f9dd.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls-11-c7f9dd.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls-4-607242.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls-4-607242.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls_272-6-480ea0.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls_272-6-480ea0.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_272",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/272",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls_272-7-601780.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls_272-7-601780.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls_272-9-649296.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/repos_github-api-test-org_github-api_pulls_272-9-649296.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_272",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/272",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/user-1-b08f02.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/closePullRequest/mappings/user-1-b08f02.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/orgs_github-api-test-org-2-449cef.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/orgs_github-api-test-org-2-449cef.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api-3-260db5.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api-3-260db5.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls-4-f9c86d.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls-4-f9c86d.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls-7-40b2ed.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls-7-40b2ed.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open&head=github-api-test-org%3Atest%2Fstable",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls_321-5-91de84.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls_321-5-91de84.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_321",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/321",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls_321-6-b01981.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls_321-6-b01981.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_321",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/321",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls_321-8-ec3d90.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/repos_github-api-test-org_github-api_pulls_321-8-ec3d90.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_321",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/321",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/user-1-26b175.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createDraftPullRequest/mappings/user-1-26b175.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/orgs_github-api-test-org-2-b2d80e.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/orgs_github-api-test-org-2-b2d80e.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api-3-e04f90.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api-3-e04f90.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api-5-315877.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api-5-315877.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api_pulls-4-e39355.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api_pulls-4-e39355.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api_pulls-6-21bacc.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api_pulls-6-21bacc.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api_pulls_273-7-667126.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/repos_github-api-test-org_github-api_pulls_273-7-667126.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/user-1-17990d.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequest/mappings/user-1-17990d.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/orgs_github-api-test-org-2-ad4f34.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/orgs_github-api-test-org-2-ad4f34.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api-3-de7260.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api-3-de7260.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api-6-6e0179.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api-6-6e0179.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api_issues_270_comments-5-2cd4dd.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api_issues_270_comments-5-2cd4dd.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api_pulls-4-4e9dad.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api_pulls-4-4e9dad.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api_pulls-7-420dc2.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api_pulls-7-420dc2.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api_pulls_270-8-1a6fbb.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/repos_github-api-test-org_github-api_pulls_270-8-1a6fbb.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/user-1-c4d4d6.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/createPullRequestComment/mappings/user-1-c4d4d6.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/orgs_github-api-test-org-2-9700f9.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/orgs_github-api-test-org-2-9700f9.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api-3-c0d68f.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api-3-c0d68f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api-5-e79ad5.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api-5-e79ad5.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api-7-43e688.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api-7-43e688.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api-9-ab2303.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api-9-ab2303.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls-10-5f8eb0.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls-10-5f8eb0.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls-4-344c3b.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls-4-344c3b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls-8-e32f79.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls-8-e32f79.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls_263-11-efb364.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls_263-11-efb364.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls_263-6-034f14.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/repos_github-api-test-org_github-api_pulls_263-6-034f14.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_263",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/263",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/user-1-079798.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/getUserTest/mappings/user-1-079798.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/orgs_github-api-test-org-2-e3ff36.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/orgs_github-api-test-org-2-e3ff36.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api-3-7a223c.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api-3-7a223c.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_commits_48eb1a9b8cd56782d11ea45adcf062eade17528e-8-59cc88.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_commits_48eb1a9b8cd56782d11ea45adcf062eade17528e-8-59cc88.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_commits_48eb1a9b8cd56782d11ea45adcf062eade17528e",
   "request": {
     "url": "/repos/github-api-test-org/github-api/commits/48eb1a9b8cd56782d11ea45adcf062eade17528e",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_pulls-4-361c15.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_pulls-4-361c15.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_pulls_309-5-1566b3.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_pulls_309-5-1566b3.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_309",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/309",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_pulls_309-6-c8fd7b.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_pulls_309-6-c8fd7b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_309",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/309",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_pulls_309-7-979661.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/repos_github-api-test-org_github-api_pulls_309-7-979661.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_309",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/309",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/user-1-c2903f.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/mergeCommitSHA/mappings/user-1-c2903f.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/orgs_github-api-test-org-2-079c3d.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/orgs_github-api-test-org-2-079c3d.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api-12-9090d2.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api-12-9090d2.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api-3-d585b5.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api-3-d585b5.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls-13-80451b.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls-13-80451b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls-4-145b44.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls-4-145b44.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266-14-f8bf7b.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266-14-f8bf7b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-11-b8142f.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-11-b8142f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_266_comments",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/266/comments",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-5-cbd425.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-5-cbd425.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_266_comments",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/266/comments",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-6-b9a8cb.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-6-b9a8cb.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-7-874427.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-7-874427.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_266_comments",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/266/comments",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-9-8d629b.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_266_comments-9-8d629b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_266_comments",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/266/comments",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_comments_321995146-10-73e6aa.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_comments_321995146-10-73e6aa.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_comments_321995146",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/comments/321995146",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_comments_321995146-8-d0df75.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/repos_github-api-test-org_github-api_pulls_comments_321995146-8-d0df75.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/user-1-f74219.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviewComments/mappings/user-1-f74219.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/orgs_github-api-test-org-2-3f7614.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/orgs_github-api-test-org-2-3f7614.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api-11-029a57.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api-11-029a57.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api-3-1efd2a.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api-3-1efd2a.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls-12-0c75c0.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls-12-0c75c0.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls-4-7f2095.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls-4-7f2095.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258-13-9406e5.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258-13-9406e5.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews-5-1fe517.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews-5-1fe517.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews-6-56d549.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews-6-56d549.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_258_reviews",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/258/reviews",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews-9-be8b55.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews-9-be8b55.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews_285200956_comments-8-15c1e2.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews_285200956_comments-8-15c1e2.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_258_reviews_285200956_comments",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/258/reviews/285200956/comments",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews_285200956_events-7-d0f59a.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews_285200956_events-7-d0f59a.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews_285200957-10-886b3f.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/repos_github-api-test-org_github-api_pulls_258_reviews_285200957-10-886b3f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_258_reviews_285200957",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/258/reviews/285200957",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/user-1-e24b33.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/pullRequestReviews/mappings/user-1-e24b33.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/orgs_github-api-test-org-2-9de3bb.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/orgs_github-api-test-org-2-9de3bb.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api-3-f81e50.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api-3-f81e50.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api-7-684ed3.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api-7-684ed3.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-4-a2c01b.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-4-a2c01b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-5-9afc3a.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-5-9afc3a.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-6-ab7461.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-6-ab7461.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open&head=github-api-test-org%3Atest%2Fstable&base=master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-8-4e73cd.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-8-4e73cd.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls_259-10-5f1852.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls_259-10-5f1852.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls_260-9-6162e3.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/repos_github-api-test-org_github-api_pulls_260-9-6162e3.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/user-1-4966fe.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsQualifiedHead/mappings/user-1-4966fe.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/orgs_github-api-test-org-2-80e70a.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/orgs_github-api-test-org-2-80e70a.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api-3-10e587.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api-3-10e587.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api-7-db8422.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api-7-db8422.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-4-cc0392.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-4-cc0392.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-5-373344.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-5-373344.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-6-3d58d4.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-6-3d58d4.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open&head=github-api-test-org%3Atest%2Fstable&base=master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-8-cfa90e.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls-8-cfa90e.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls_268-9-08817e.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls_268-9-08817e.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls_269-10-b5427c.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/repos_github-api-test-org_github-api_pulls_269-10-b5427c.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/user-1-69a2a9.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/queryPullRequestsUnqualifiedHead/mappings/user-1-69a2a9.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/orgs_github-api-test-org-2-41c140.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/orgs_github-api-test-org-2-41c140.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api-3-f25bc1.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api-3-f25bc1.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api-6-6415bd.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api-6-6415bd.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api-8-d2df6f.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api-8-d2df6f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_issues_271-5-9171d9.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_issues_271-5-9171d9.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_pulls-4-8c7123.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_pulls-4-8c7123.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_pulls-9-aee9a7.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_pulls-9-aee9a7.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_pulls_271-10-ff9fa1.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_pulls_271-10-ff9fa1.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_pulls_271-7-844a41.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/repos_github-api-test-org_github-api_pulls_271-7-844a41.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_271",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/271",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/user-1-27e106.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setAssignee/mappings/user-1-27e106.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/orgs_github-api-test-org-2-04e112.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/orgs_github-api-test-org-2-04e112.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api-3-1b1c68.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api-3-1b1c68.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api-6-4e2383.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api-6-4e2383.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api-9-caba78.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api-9-caba78.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_issues_264-5-52c082.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_issues_264-5-52c082.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_issues_264-8-1421d6.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_issues_264-8-1421d6.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_issues_264",
   "request": {
     "url": "/repos/github-api-test-org/github-api/issues/264",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_pulls-10-bd497d.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_pulls-10-bd497d.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_pulls-4-7af49b.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_pulls-4-7af49b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_pulls_264-11-cfd2cf.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_pulls_264-11-cfd2cf.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_pulls_264-7-462782.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/repos_github-api-test-org_github-api_pulls_264-7-462782.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_264",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/264",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/user-1-946afc.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/setLabels/mappings/user-1-946afc.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/orgs_github-api-test-org-2-b35d6e.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/orgs_github-api-test-org-2-b35d6e.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-12-5f2832.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-12-5f2832.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-3-957364.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-3-957364.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-5-6395c5.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-5-6395c5.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-7-3bd5c3.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-7-3bd5c3.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-9-7331ed.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api-9-7331ed.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_contents_squashmerge-8-04ae84.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_contents_squashmerge-8-04ae84.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_git_refs-6-9d910f.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_git_refs-6-9d910f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_git_refs_heads_master-4-7bfa93.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_git_refs_heads_master-4-7bfa93.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_git_refs_heads_master",
   "request": {
     "url": "/repos/github-api-test-org/github-api/git/refs/heads/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_pulls-10-d149e4.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_pulls-10-d149e4.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_pulls-13-1f5294.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_pulls-13-1f5294.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_pulls_267_merge-11-504d0b.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/repos_github-api-test-org_github-api_pulls_267_merge-11-504d0b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/user-1-b37e46.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/squashMerge/mappings/user-1-b37e46.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/orgs_github-api-test-org-2-4b0623.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/orgs_github-api-test-org-2-4b0623.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/repos_github-api-test-org_github-api-3-cafd01.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/repos_github-api-test-org_github-api-3-cafd01.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/repos_github-api-test-org_github-api_pulls-4-e7589e.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/repos_github-api-test-org_github-api_pulls-4-e7589e.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/repos_github-api-test-org_github-api_pulls_299-7-59c375.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/repos_github-api-test-org_github-api_pulls_299-7-59c375.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_299",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/299",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/repos_github-api-test-org_github-api_pulls_299_requested_reviewers-6-38f876.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/repos_github-api-test-org_github-api_pulls_299_requested_reviewers-6-38f876.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/user-1-77ed94.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/user-1-77ed94.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/users_kohsuke2-5-8bcfc0.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestReviewRequests/mappings/users_kohsuke2-5-8bcfc0.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke2",
   "request": {
     "url": "/users/kohsuke2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/orgs_github-api-test-org-2-8634de.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/orgs_github-api-test-org-2-8634de.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/orgs_github-api-test-org_teams-5-b84882.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/orgs_github-api-test-org_teams-5-b84882.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/repos_github-api-test-org_github-api-3-92a8e4.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/repos_github-api-test-org_github-api-3-92a8e4.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/repos_github-api-test-org_github-api_pulls-4-f9eb4c.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/repos_github-api-test-org_github-api_pulls-4-f9eb4c.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/repos_github-api-test-org_github-api_pulls_304-7-e091cb.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/repos_github-api-test-org_github-api_pulls_304-7-e091cb.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls_304",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls/304",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/repos_github-api-test-org_github-api_pulls_304_requested_reviewers-6-7df569.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/repos_github-api-test-org_github-api_pulls_304_requested_reviewers-6-7df569.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/teams_3451996-8-112cf6.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/teams_3451996-8-112cf6.json
@@ -3,7 +3,12 @@
   "name": "teams_3451996",
   "request": {
     "url": "/teams/3451996",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/user-1-c23a7f.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/testPullRequestTeamReviewRequests/mappings/user-1-c23a7f.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/orgs_github-api-test-org-2-ad1f58.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/orgs_github-api-test-org-2-ad1f58.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-11-262129.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-11-262129.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-14-ab6495.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-14-ab6495.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-3-5e4301.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-3-5e4301.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-5-620a6c.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-5-620a6c.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-7-3baea0.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-7-3baea0.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-9-ea7712.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api-9-ea7712.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_contents_updatecontentsquashmerge-10-70ad84.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_contents_updatecontentsquashmerge-10-70ad84.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_contents_updatecontentsquashmerge-8-1d6973.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_contents_updatecontentsquashmerge-8-1d6973.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_git_refs-6-778d66.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_git_refs-6-778d66.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_git_refs_heads_master-4-fa77be.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_git_refs_heads_master-4-fa77be.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_git_refs_heads_master",
   "request": {
     "url": "/repos/github-api-test-org/github-api/git/refs/heads/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_pulls-12-c55f08.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_pulls-12-c55f08.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_pulls-15-ac16f4.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_pulls-15-ac16f4.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_pulls",
   "request": {
     "url": "/repos/github-api-test-org/github-api/pulls?state=open",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.shadow-cat-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_pulls_261_merge-13-0b05c7.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/repos_github-api-test-org_github-api_pulls_261_merge-13-0b05c7.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/user-1-78c048.json
+++ b/src/test/resources/org/kohsuke/github/GHPullRequestTest/wiremock/updateContentSquashMerge/mappings/user-1-78c048.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit2-2-445e28.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/rate_limit2-2-445e28.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/user-0-a0bafd.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/user-0-a0bafd.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/user-1-a0bafd.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubEnterpriseDoesNotHaveRateLimit/mappings/user-1-a0bafd.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/orgs_github-api-test-org-4-7ea37b.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/orgs_github-api-test-org-4-7ea37b.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/rate_limit-2-f22b1c.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/rate_limit-2-f22b1c.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/rate_limit-3-a1f82a.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/rate_limit-3-a1f82a.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/rate_limit-5-4e2fc3.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/rate_limit-5-4e2fc3.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/user-1-a460fd.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimit/mappings/user-1-a460fd.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesAhead/mappings/rate_limit-2-f22b1c.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesAhead/mappings/rate_limit-2-f22b1c.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesAhead/mappings/rate_limit-3-a1f82a.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesAhead/mappings/rate_limit-3-a1f82a.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesAhead/mappings/rate_limit-5-4e2fc3.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesAhead/mappings/rate_limit-5-4e2fc3.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesAhead/mappings/user-1-a460fd.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesAhead/mappings/user-1-a460fd.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesBehind/mappings/rate_limit-2-f22b1c.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesBehind/mappings/rate_limit-2-f22b1c.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesBehind/mappings/rate_limit-3-a1f82a.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesBehind/mappings/rate_limit-3-a1f82a.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesBehind/mappings/rate_limit-5-4e2fc3.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesBehind/mappings/rate_limit-5-4e2fc3.json
@@ -3,7 +3,12 @@
   "name": "rate_limit",
   "request": {
     "url": "/rate_limit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesBehind/mappings/user-1-a460fd.json
+++ b/src/test/resources/org/kohsuke/github/GHRateLimitTest/wiremock/testGitHubRateLimitExpirationServerFiveMinutesBehind/mappings/user-1-a460fd.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCodeFrequency/mappings/orgs_github-api-test-org-2-17df55.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCodeFrequency/mappings/orgs_github-api-test-org-2-17df55.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCodeFrequency/mappings/repos_github-api-test-org_github-api-3-6fede0.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCodeFrequency/mappings/repos_github-api-test-org_github-api-3-6fede0.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCodeFrequency/mappings/repos_github-api-test-org_github-api_stats_code_frequency-4-09de1d.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCodeFrequency/mappings/repos_github-api-test-org_github-api_stats_code_frequency-4-09de1d.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_stats_code_frequency",
   "request": {
     "url": "/repos/github-api-test-org/github-api/stats/code_frequency",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCodeFrequency/mappings/user-1-2c19f6.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCodeFrequency/mappings/user-1-2c19f6.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCommitActivity/mappings/orgs_github-api-test-org-2-4edea4.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCommitActivity/mappings/orgs_github-api-test-org-2-4edea4.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCommitActivity/mappings/repos_github-api-test-org_github-api-3-6f33ad.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCommitActivity/mappings/repos_github-api-test-org_github-api-3-6f33ad.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCommitActivity/mappings/repos_github-api-test-org_github-api_stats_commit_activity-4-54ebe0.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCommitActivity/mappings/repos_github-api-test-org_github-api_stats_commit_activity-4-54ebe0.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_stats_commit_activity",
   "request": {
     "url": "/repos/github-api-test-org/github-api/stats/commit_activity",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCommitActivity/mappings/user-1-68a31e.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testCommitActivity/mappings/user-1-68a31e.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testContributorStats/mappings/orgs_github-api-test-org-2-4da8ec.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testContributorStats/mappings/orgs_github-api-test-org-2-4da8ec.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testContributorStats/mappings/repos_github-api-test-org_github-api-3-6d11bb.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testContributorStats/mappings/repos_github-api-test-org_github-api-3-6d11bb.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testContributorStats/mappings/repos_github-api-test-org_github-api_stats_contributors-4-722ef7.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testContributorStats/mappings/repos_github-api-test-org_github-api_stats_contributors-4-722ef7.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_stats_contributors",
   "request": {
     "url": "/repos/github-api-test-org/github-api/stats/contributors",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testContributorStats/mappings/user-1-8442a6.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testContributorStats/mappings/user-1-8442a6.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testParticipation/mappings/orgs_github-api-test-org-2-bc8f8b.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testParticipation/mappings/orgs_github-api-test-org-2-bc8f8b.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testParticipation/mappings/repos_github-api-test-org_github-api-3-7631fa.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testParticipation/mappings/repos_github-api-test-org_github-api-3-7631fa.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testParticipation/mappings/repos_github-api-test-org_github-api_stats_participation-4-9ae337.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testParticipation/mappings/repos_github-api-test-org_github-api_stats_participation-4-9ae337.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_stats_participation",
   "request": {
     "url": "/repos/github-api-test-org/github-api/stats/participation",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testParticipation/mappings/user-1-a809af.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testParticipation/mappings/user-1-a809af.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testPunchCard/mappings/orgs_github-api-test-org-2-754abf.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testPunchCard/mappings/orgs_github-api-test-org-2-754abf.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testPunchCard/mappings/repos_github-api-test-org_github-api-3-b2ea09.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testPunchCard/mappings/repos_github-api-test-org_github-api-3-b2ea09.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testPunchCard/mappings/repos_github-api-test-org_github-api_stats_punch_card-4-e401c5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testPunchCard/mappings/repos_github-api-test-org_github-api_stats_punch_card-4-e401c5.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_stats_punch_card",
   "request": {
     "url": "/repos/github-api-test-org/github-api/stats/punch_card",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testPunchCard/mappings/user-1-49e5cd.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryStatisticsTest/wiremock/testPunchCard/mappings/user-1-49e5cd.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryExist/mappings/repos_kamontat_checkidnumber-2-572d41.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryExist/mappings/repos_kamontat_checkidnumber-2-572d41.json
@@ -3,7 +3,12 @@
   "name": "repos_kamontat_checkidnumber",
   "request": {
     "url": "/repos/kamontat/CheckIDNumber",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryExist/mappings/repos_kamontat_checkidnumber_releases_latest-3-d2547b.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryExist/mappings/repos_kamontat_checkidnumber_releases_latest-3-d2547b.json
@@ -3,7 +3,12 @@
   "name": "repos_kamontat_checkidnumber_releases_latest",
   "request": {
     "url": "/repos/kamontat/CheckIDNumber/releases/latest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryExist/mappings/user-1-b9c99a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryExist/mappings/user-1-b9c99a.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryNotExist/mappings/repos_kamontat_java8example-2-7752c1.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryNotExist/mappings/repos_kamontat_java8example-2-7752c1.json
@@ -3,7 +3,12 @@
   "name": "repos_kamontat_java8example",
   "request": {
     "url": "/repos/kamontat/Java8Example",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryNotExist/mappings/repos_kamontat_java8example_releases_latest-3-838e4d.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryNotExist/mappings/repos_kamontat_java8example_releases_latest-3-838e4d.json
@@ -3,7 +3,12 @@
   "name": "repos_kamontat_java8example_releases_latest",
   "request": {
     "url": "/repos/kamontat/Java8Example/releases/latest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryNotExist/mappings/user-1-53c446.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/LatestRepositoryNotExist/mappings/user-1-53c446.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/orgs_github-api-test-org-2-cb173a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/orgs_github-api-test-org-2-cb173a.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/repos_github-api-test-org_github-api-3-0a4d7a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/repos_github-api-test-org_github-api-3-0a4d7a.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/repos_github-api-test-org_github-api-4-2c69d5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/repos_github-api-test-org_github-api-4-2c69d5.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/repos_github-api-test-org_github-api-5-1c529d.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/repos_github-api-test-org_github-api-5-1c529d.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/user-1-7f6e9a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/archive/mappings/user-1-7f6e9a.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranchNonExistentBut200Status/mappings/orgs_github-api-test-org-2-cadf65.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranchNonExistentBut200Status/mappings/orgs_github-api-test-org-2-cadf65.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranchNonExistentBut200Status/mappings/repos_github-api-test-org_github-api-3-228f03.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranchNonExistentBut200Status/mappings/repos_github-api-test-org_github-api-3-228f03.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranchNonExistentBut200Status/mappings/repos_github-api-test-org_github-api_branches_test_nonexistent-4-b14df6.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranchNonExistentBut200Status/mappings/repos_github-api-test-org_github-api_branches_test_nonexistent-4-b14df6.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_branches_test_nonexistent",
   "request": {
     "url": "/repos/github-api-test-org/github-api/branches/test/NonExistent",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranchNonExistentBut200Status/mappings/user-1-87afc7.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranchNonExistentBut200Status/mappings/user-1-87afc7.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranch_URLEncoded/mappings/orgs_github-api-test-org-2-5e8ae8.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranch_URLEncoded/mappings/orgs_github-api-test-org-2-5e8ae8.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranch_URLEncoded/mappings/repos_github-api-test-org_github-api-3-30364e.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranch_URLEncoded/mappings/repos_github-api-test-org_github-api-3-30364e.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranch_URLEncoded/mappings/repos_github-api-test-org_github-api_branches_test_urlencode-4-ed8bf5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranch_URLEncoded/mappings/repos_github-api-test-org_github-api_branches_test_urlencode-4-ed8bf5.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_branches_test_urlencode",
   "request": {
     "url": "/repos/github-api-test-org/github-api/branches/test/%23UrlEncode",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranch_URLEncoded/mappings/user-1-c92cdb.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getBranch_URLEncoded/mappings/user-1-c92cdb.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getCollaborators/mappings/orgs_github-api-test-org-2-d319a1.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getCollaborators/mappings/orgs_github-api-test-org-2-d319a1.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getCollaborators/mappings/repos_github-api-test-org_github-api-3-4c1e8c.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getCollaborators/mappings/repos_github-api-test-org_github-api-3-4c1e8c.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getCollaborators/mappings/repos_github-api-test-org_github-api_collaborators-4-2b8bad.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getCollaborators/mappings/repos_github-api-test-org_github-api_collaborators-4-2b8bad.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_collaborators",
   "request": {
     "url": "/repos/github-api-test-org/github-api/collaborators",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getCollaborators/mappings/user-1-1fc40d.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getCollaborators/mappings/user-1-1fc40d.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getMergeOptions/mappings/repos_github-api-test-org_temp-getmergeoptions-2-cb893c.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getMergeOptions/mappings/repos_github-api-test-org_temp-getmergeoptions-2-cb893c.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-getmergeoptions",
   "request": {
     "url": "/repos/github-api-test-org/temp-getMergeOptions",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getMergeOptions/mappings/user-1-5d8fe2.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getMergeOptions/mappings/user-1-5d8fe2.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/orgs_apache-5-f737f0.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/orgs_apache-5-f737f0.json
@@ -3,7 +3,12 @@
   "name": "orgs_apache",
   "request": {
     "url": "/orgs/apache",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_apache_groovy-6-cc8d85.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_apache_groovy-6-cc8d85.json
@@ -3,7 +3,12 @@
   "name": "repos_apache_groovy",
   "request": {
     "url": "/repos/apache/groovy",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_apache_groovy_collaborators_jglick_permission-7-61ff8c.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_apache_groovy_collaborators_jglick_permission-7-61ff8c.json
@@ -3,7 +3,12 @@
   "name": "repos_apache_groovy_collaborators_jglick_permission",
   "request": {
     "url": "/repos/apache/groovy/collaborators/jglick/permission",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 403,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_github-api-test-org_test-permission-2-4976af.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_github-api-test-org_test-permission-2-4976af.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-permission",
   "request": {
     "url": "/repos/github-api-test-org/test-permission",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_github-api-test-org_test-permission_collaborators_dude_permission-4-665c40.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_github-api-test-org_test-permission_collaborators_dude_permission-4-665c40.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-permission_collaborators_dude_permission",
   "request": {
     "url": "/repos/github-api-test-org/test-permission/collaborators/dude/permission",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_github-api-test-org_test-permission_collaborators_kohsuke_permission-3-8dd9fa.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/repos_github-api-test-org_test-permission_collaborators_kohsuke_permission-3-8dd9fa.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_test-permission_collaborators_kohsuke_permission",
   "request": {
     "url": "/repos/github-api-test-org/test-permission/collaborators/kohsuke/permission",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/user-1-01e35a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPermission/mappings/user-1-01e35a.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPostCommitHooks/mappings/orgs_github-api-test-org-2-4d7df9.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPostCommitHooks/mappings/orgs_github-api-test-org-2-4d7df9.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPostCommitHooks/mappings/repos_github-api-test-org_github-api-3-14b99b.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPostCommitHooks/mappings/repos_github-api-test-org_github-api-3-14b99b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPostCommitHooks/mappings/repos_github-api-test-org_github-api_hooks-4-2b78cc.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPostCommitHooks/mappings/repos_github-api-test-org_github-api_hooks-4-2b78cc.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_hooks",
   "request": {
     "url": "/repos/github-api-test-org/github-api/hooks",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPostCommitHooks/mappings/user-1-bd5a7a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getPostCommitHooks/mappings/user-1-bd5a7a.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameDoesNotExist/mappings/orgs_github-api-test-org-2-f2bd68.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameDoesNotExist/mappings/orgs_github-api-test-org-2-f2bd68.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameDoesNotExist/mappings/repos_github-api-test-org_github-api-3-c19ba5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameDoesNotExist/mappings/repos_github-api-test-org_github-api-3-c19ba5.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameDoesNotExist/mappings/repos_github-api-test-org_github-api_releases_tags_foo-bar-baz-4-3ac213.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameDoesNotExist/mappings/repos_github-api-test-org_github-api_releases_tags_foo-bar-baz-4-3ac213.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_releases_tags_foo-bar-baz",
   "request": {
     "url": "/repos/github-api-test-org/github-api/releases/tags/foo-bar-baz",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameDoesNotExist/mappings/user-1-c36cc5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameDoesNotExist/mappings/user-1-c36cc5.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameExists/mappings/orgs_github-2-8cbc3a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameExists/mappings/orgs_github-2-8cbc3a.json
@@ -3,7 +3,12 @@
   "name": "orgs_github",
   "request": {
     "url": "/orgs/github",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameExists/mappings/repos_github_hub-3-fc5211.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameExists/mappings/repos_github_hub-3-fc5211.json
@@ -3,7 +3,12 @@
   "name": "repos_github_hub",
   "request": {
     "url": "/repos/github/hub",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameExists/mappings/repos_github_hub_releases_tags_v230-pre10-4-dcb217.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameExists/mappings/repos_github_hub_releases_tags_v230-pre10-4-dcb217.json
@@ -3,7 +3,12 @@
   "name": "repos_github_hub_releases_tags_v230-pre10",
   "request": {
     "url": "/repos/github/hub/releases/tags/v2.3.0-pre10",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameExists/mappings/user-1-87c44e.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseByTagNameExists/mappings/user-1-87c44e.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseDoesNotExist/mappings/orgs_github-2-18ee08.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseDoesNotExist/mappings/orgs_github-2-18ee08.json
@@ -3,7 +3,12 @@
   "name": "orgs_github",
   "request": {
     "url": "/orgs/github",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseDoesNotExist/mappings/repos_github_hub-3-e0a029.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseDoesNotExist/mappings/repos_github_hub-3-e0a029.json
@@ -3,7 +3,12 @@
   "name": "repos_github_hub",
   "request": {
     "url": "/repos/github/hub",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseDoesNotExist/mappings/repos_github_hub_releases_9223372036854775807-4-b82be5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseDoesNotExist/mappings/repos_github_hub_releases_9223372036854775807-4-b82be5.json
@@ -3,7 +3,12 @@
   "name": "repos_github_hub_releases_9223372036854775807",
   "request": {
     "url": "/repos/github/hub/releases/9223372036854775807",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseDoesNotExist/mappings/user-1-f64c26.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseDoesNotExist/mappings/user-1-f64c26.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseExists/mappings/orgs_github-2-f8d704.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseExists/mappings/orgs_github-2-f8d704.json
@@ -3,7 +3,12 @@
   "name": "orgs_github",
   "request": {
     "url": "/orgs/github",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseExists/mappings/repos_github_hub-3-f5ba6b.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseExists/mappings/repos_github_hub-3-f5ba6b.json
@@ -3,7 +3,12 @@
   "name": "repos_github_hub",
   "request": {
     "url": "/repos/github/hub",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseExists/mappings/repos_github_hub_releases_6839710-4-2959bf.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseExists/mappings/repos_github_hub_releases_6839710-4-2959bf.json
@@ -3,7 +3,12 @@
   "name": "repos_github_hub_releases_6839710",
   "request": {
     "url": "/repos/github/hub/releases/6839710",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseExists/mappings/user-1-37773e.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/getReleaseExists/mappings/user-1-37773e.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listContributors/mappings/orgs_github-api-2-7c4b2a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listContributors/mappings/orgs_github-api-2-7c4b2a.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api",
   "request": {
     "url": "/orgs/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listContributors/mappings/repos_github-api_github-api-3-d87d95.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listContributors/mappings/repos_github-api_github-api-3-d87d95.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listContributors/mappings/repos_github-api_github-api_contributors-4-cd6221.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listContributors/mappings/repos_github-api_github-api_contributors-4-cd6221.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contributors",
   "request": {
     "url": "/repos/github-api/github-api/contributors",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listContributors/mappings/user-1-5705a1.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listContributors/mappings/user-1-5705a1.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listEmptyContributors/mappings/repos_github-api-test-org_empty-2-af73e2.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listEmptyContributors/mappings/repos_github-api-test-org_empty-2-af73e2.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_empty",
   "request": {
     "url": "/repos/github-api-test-org/empty",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listEmptyContributors/mappings/repos_github-api-test-org_empty_contributors-3-dae0e3.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listEmptyContributors/mappings/repos_github-api-test-org_empty_contributors-3-dae0e3.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_empty_contributors",
   "request": {
     "url": "/repos/github-api-test-org/empty/contributors",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listEmptyContributors/mappings/user-1-8d2ebb.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listEmptyContributors/mappings/user-1-8d2ebb.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listLanguages/mappings/repos_github-api_github-api-2-1852eb.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listLanguages/mappings/repos_github-api_github-api-2-1852eb.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listLanguages/mappings/repos_github-api_github-api_languages-3-acab46.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listLanguages/mappings/repos_github-api_github-api_languages-3-acab46.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_languages",
   "request": {
     "url": "/repos/github-api/github-api/languages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listLanguages/mappings/user-1-aab4cb.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listLanguages/mappings/user-1-aab4cb.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listReleases/mappings/orgs_github-2-c4db4d.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listReleases/mappings/orgs_github-2-c4db4d.json
@@ -3,7 +3,12 @@
   "name": "orgs_github",
   "request": {
     "url": "/orgs/github",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listReleases/mappings/repos_github_hub-3-833860.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listReleases/mappings/repos_github_hub-3-833860.json
@@ -3,7 +3,12 @@
   "name": "repos_github_hub",
   "request": {
     "url": "/repos/github/hub",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listReleases/mappings/repos_github_hub_releases-4-5c5da4.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listReleases/mappings/repos_github_hub_releases-4-5c5da4.json
@@ -3,7 +3,12 @@
   "name": "repos_github_hub_releases",
   "request": {
     "url": "/repos/github/hub/releases",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listReleases/mappings/user-1-95be22.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/listReleases/mappings/user-1-95be22.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/markDown/mappings/markdown-4-82013a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/markDown/mappings/markdown-4-82013a.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/markDown/mappings/markdown_raw-2-44dcd2.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/markDown/mappings/markdown_raw-2-44dcd2.json
@@ -9,7 +9,12 @@
         "equalTo": "**Test日本語**",
         "caseInsensitive": false
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/markDown/mappings/repos_github-api_github-api-3-b97d0b.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/markDown/mappings/repos_github-api_github-api-3-b97d0b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/markDown/mappings/user-1-d7cf6a.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/markDown/mappings/user-1-d7cf6a.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/searchRepositories/mappings/search_repositories-2-03ff4b.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/searchRepositories/mappings/search_repositories-2-03ff4b.json
@@ -3,7 +3,12 @@
   "name": "search_repositories",
   "request": {
     "url": "/search/repositories?sort=stars&q=tetris+language%3Aassembly",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/searchRepositories/mappings/user-1-3b3417.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/searchRepositories/mappings/user-1-3b3417.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-10-3c8120.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-10-3c8120.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-setmergeoptions",
   "request": {
     "url": "/repos/github-api-test-org/temp-setMergeOptions",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-2-0d8d7e.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-2-0d8d7e.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-setmergeoptions",
   "request": {
     "url": "/repos/github-api-test-org/temp-setMergeOptions",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-3-3e3a54.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-3-3e3a54.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-4-200ab5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-4-200ab5.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-5-036019.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-5-036019.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-6-4de721.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-6-4de721.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-setmergeoptions",
   "request": {
     "url": "/repos/github-api-test-org/temp-setMergeOptions",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-7-265263.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-7-265263.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-8-d82ad1.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-8-d82ad1.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-9-6224e0.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/repos_github-api-test-org_temp-setmergeoptions-9-6224e0.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/user-1-b42d20.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/setMergeOptions/mappings/user-1-b42d20.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/orgs_github-api-test-org-2-564bce.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/orgs_github-api-test-org-2-564bce.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api-3-5861f3.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api-3-5861f3.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api_subscription-4-d888ea.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api_subscription-4-d888ea.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_subscription",
   "request": {
     "url": "/repos/github-api-test-org/github-api/subscription",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api_subscription-5-b8ab91.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api_subscription-5-b8ab91.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api_subscription-6-7de879.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api_subscription-6-7de879.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_subscription",
   "request": {
     "url": "/repos/github-api-test-org/github-api/subscription",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api_subscription-7-50d81d.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/repos_github-api-test-org_github-api_subscription-7-50d81d.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_subscription",
   "request": {
     "url": "/repos/github-api-test-org/github-api/subscription",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 404,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/user-1-77d1bd.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/subscription/mappings/user-1-77d1bd.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api-2-159ce7.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api-2-159ce7.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api",
   "request": {
     "url": "/repos/github-api/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents-3-07f37d.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents-3-07f37d.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents",
   "request": {
     "url": "/repos/github-api/github-api/contents/?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_cname-4-7ccd6f.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_cname-4-7ccd6f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_cname",
   "request": {
     "url": "/repos/github-api/github-api/contents/CNAME?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_dependencieshtml-5-e65843.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_dependencieshtml-5-e65843.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_dependencieshtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/dependencies.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_dependency-convergencehtml-6-2711f4.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_dependency-convergencehtml-6-2711f4.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_dependency-convergencehtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/dependency-convergence.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_dependency-infohtml-7-b87956.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_dependency-infohtml-7-b87956.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_dependency-infohtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/dependency-info.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_distribution-managementhtml-8-8aba06.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_distribution-managementhtml-8-8aba06.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_distribution-managementhtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/distribution-management.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_indexhtml-9-699687.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_indexhtml-9-699687.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_indexhtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/index.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_integrationhtml-10-f6bbfa.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_integrationhtml-10-f6bbfa.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_integrationhtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/integration.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_issue-trackinghtml-11-5be48b.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_issue-trackinghtml-11-5be48b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_issue-trackinghtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/issue-tracking.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_licensehtml-12-e6c4a5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_licensehtml-12-e6c4a5.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_licensehtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/license.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_mail-listshtml-13-9fa1b5.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_mail-listshtml-13-9fa1b5.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_mail-listshtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/mail-lists.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_plugin-managementhtml-14-933e02.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_plugin-managementhtml-14-933e02.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_plugin-managementhtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/plugin-management.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_pluginshtml-15-ee7e46.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_pluginshtml-15-ee7e46.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_pluginshtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/plugins.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_project-infohtml-16-eed0ad.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_project-infohtml-16-eed0ad.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_project-infohtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/project-info.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_project-reportshtml-17-64d11c.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_project-reportshtml-17-64d11c.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_project-reportshtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/project-reports.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_project-summaryhtml-18-c278dd.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_project-summaryhtml-18-c278dd.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_project-summaryhtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/project-summary.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_source-repositoryhtml-19-dfae60.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_source-repositoryhtml-19-dfae60.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_source-repositoryhtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/source-repository.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_team-listhtml-20-692982.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/repos_github-api_github-api_contents_team-listhtml-20-692982.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api_github-api_contents_team-listhtml",
   "request": {
     "url": "/repos/github-api/github-api/contents/team-list.html?ref=gh-pages",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/user-1-656249.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162/mappings/user-1-656249.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_cname-1-b36b55.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_cname-1-b36b55.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_cname",
   "request": {
     "url": "/github-api/github-api/gh-pages/CNAME",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_dependencieshtml-2-d0c5eb.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_dependencieshtml-2-d0c5eb.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_dependencieshtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/dependencies.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_dependency-convergencehtml-3-9eeed3.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_dependency-convergencehtml-3-9eeed3.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_dependency-convergencehtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/dependency-convergence.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_dependency-infohtml-4-3ca718.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_dependency-infohtml-4-3ca718.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_dependency-infohtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/dependency-info.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_distribution-managementhtml-5-445a75.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_distribution-managementhtml-5-445a75.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_distribution-managementhtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/distribution-management.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_indexhtml-6-462283.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_indexhtml-6-462283.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_indexhtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/index.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_integrationhtml-7-92a899.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_integrationhtml-7-92a899.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_integrationhtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/integration.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_issue-trackinghtml-8-77d917.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_issue-trackinghtml-8-77d917.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_issue-trackinghtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/issue-tracking.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_licensehtml-9-833a65.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_licensehtml-9-833a65.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_licensehtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/license.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_mail-listshtml-10-497d36.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_mail-listshtml-10-497d36.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_mail-listshtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/mail-lists.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_plugin-managementhtml-11-ee1451.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_plugin-managementhtml-11-ee1451.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_plugin-managementhtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/plugin-management.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_pluginshtml-12-80c8a1.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_pluginshtml-12-80c8a1.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_pluginshtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/plugins.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_project-infohtml-13-c17c46.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_project-infohtml-13-c17c46.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_project-infohtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/project-info.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_project-reportshtml-14-5367f0.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_project-reportshtml-14-5367f0.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_project-reportshtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/project-reports.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_project-summaryhtml-15-604826.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_project-summaryhtml-15-604826.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_project-summaryhtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/project-summary.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_source-repositoryhtml-16-1548ed.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_source-repositoryhtml-16-1548ed.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_source-repositoryhtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/source-repository.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_team-listhtml-17-15e841.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testIssue162_raw/mappings/github-api_github-api_gh-pages_team-listhtml-17-15e841.json
@@ -3,7 +3,12 @@
   "name": "github-api_github-api_gh-pages_team-listhtml",
   "request": {
     "url": "/github-api/github-api/gh-pages/team-list.html",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testListTopics/mappings/orgs_github-api-test-org-1-e69611.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testListTopics/mappings/orgs_github-api-test-org-1-e69611.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testListTopics/mappings/repos_github-api-test-org_github-api-2-505872.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testListTopics/mappings/repos_github-api-test-org_github-api-2-505872.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testListTopics/mappings/repos_github-api-test-org_github-api_topics-3-66254b.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testListTopics/mappings/repos_github-api-test-org_github-api_topics-3-66254b.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_topics",
   "request": {
     "url": "/repos/github-api-test-org/github-api/topics",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.mercy-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-3-1c10db.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-3-1c10db.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-4-a50794.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-4-a50794.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_test-repo-public",
   "request": {
     "url": "/repos/bitwiseman/test-repo-public",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-5-745213.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-5-745213.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-6-5f1779.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-6-5f1779.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_test-repo-public",
   "request": {
     "url": "/repos/bitwiseman/test-repo-public",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-7-f9f729.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/repos_bitwiseman_test-repo-public-7-f9f729.json
@@ -3,7 +3,12 @@
   "name": "repos_bitwiseman_test-repo-public",
   "request": {
     "url": "/repos/bitwiseman/test-repo-public",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/user-1-e09de7.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/user-1-e09de7.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/user_repos-2-d25ff0.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetPublic/mappings/user_repos-2-d25ff0.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/orgs_github-api-test-org-2-077497.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/orgs_github-api-test-org-2-077497.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api-3-6396d3.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api-3-6396d3.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-10-d74974.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-10-d74974.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.mercy-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-11-57a970.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-11-57a970.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_topics",
   "request": {
     "url": "/repos/github-api-test-org/github-api/topics",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.mercy-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-4-e6442e.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-4-e6442e.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.mercy-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-5-2dc36e.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-5-2dc36e.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_topics",
   "request": {
     "url": "/repos/github-api-test-org/github-api/topics",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.mercy-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-6-83a58f.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-6-83a58f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.mercy-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-7-eed846.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-7-eed846.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_topics",
   "request": {
     "url": "/repos/github-api-test-org/github-api/topics",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.mercy-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-8-df3c07.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-8-df3c07.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.mercy-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-9-6159ab.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/repos_github-api-test-org_github-api_topics-9-6159ab.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_topics",
   "request": {
     "url": "/repos/github-api-test-org/github-api/topics",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "application/vnd.github.mercy-preview+json"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/user-1-489e21.json
+++ b/src/test/resources/org/kohsuke/github/GHRepositoryTest/wiremock/testSetTopics/mappings/user-1-489e21.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/orgs_github-api-test-org-2-37477e.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/orgs_github-api-test-org-2-37477e.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/orgs_github-api-test-org_teams-3-a484e2.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/orgs_github-api-test-org_teams-3-a484e2.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/orgs_github-api-test-org_teams-5-68c43a.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/orgs_github-api-test-org_teams-5-68c43a.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/orgs_github-api-test-org_teams-7-0bdd94.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/orgs_github-api-test-org_teams-7-0bdd94.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org_teams",
   "request": {
     "url": "/orgs/github-api-test-org/teams",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/teams_3451996-4-f0db29.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/teams_3451996-4-f0db29.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/teams_3451996-6-5ffee5.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/teams_3451996-6-5ffee5.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/user-1-74e41f.json
+++ b/src/test/resources/org/kohsuke/github/GHTeamTest/wiremock/testSetDescription/mappings/user-1-74e41f.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest-2-3141cd.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest-2-3141cd.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_contents_app_runsh-12-b4be45.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_contents_app_runsh-12-b4be45.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_contents_app_runsh",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/contents/app/run.sh",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_contents_data_val1dat-14-28e824.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_contents_data_val1dat-14-28e824.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_contents_data_val1dat",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/contents/data/val1.dat",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_contents_data_val2dat-15-3f3623.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_contents_data_val2dat-15-3f3623.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_contents_data_val2dat",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/contents/data/val2.dat",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_contents_doc_readmetxt-13-dccdb6.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_contents_doc_readmetxt-13-dccdb6.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_contents_doc_readmetxt",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/contents/doc/readme.txt",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-5-ea9e4f.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-5-ea9e4f.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-6-2c952c.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-6-2c952c.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-7-8650c5.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-7-8650c5.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-8-91c550.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-8-91c550.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_commits-10-8bc638.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_commits-10-8bc638.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_refs_heads_master-11-942357.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_refs_heads_master-11-942357.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_refs_heads_master-3-b289fa.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_refs_heads_master-3-b289fa.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_git_refs_heads_master",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/git/refs/heads/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_trees-9-ca5764.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_trees-9-ca5764.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_trees_master-4-f5388f.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/repos_sandboxx_ghtreebuildertest_git_trees_master-4-f5388f.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_git_trees_master",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/git/trees/master?recursive=1",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/user-1-b27491.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testAdd/mappings/user-1-b27491.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest-2-c4c87c.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest-2-c4c87c.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_contents_data_val1dat-10-fce516.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_contents_data_val1dat-10-fce516.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_contents_data_val1dat",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/contents/data/val1.dat",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_contents_data_val2dat-11-1c94ff.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_contents_data_val2dat-11-1c94ff.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_contents_data_val2dat",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/contents/data/val2.dat",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-5-319a22.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-5-319a22.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-6-3b8b1b.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_blobs-6-3b8b1b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_commits-8-29661c.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_commits-8-29661c.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_refs_heads_master-3-6d634a.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_refs_heads_master-3-6d634a.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_git_refs_heads_master",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/git/refs/heads/master",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_refs_heads_master-9-9f6c9b.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_refs_heads_master-9-9f6c9b.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_trees-7-1c90d0.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_trees-7-1c90d0.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_trees_master-4-945055.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/repos_sandboxx_ghtreebuildertest_git_trees_master-4-945055.json
@@ -3,7 +3,12 @@
   "name": "repos_sandboxx_ghtreebuildertest_git_trees_master",
   "request": {
     "url": "/repos/sandboxx/GHTreeBuilderTest/git/trees/master?recursive=1",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/user-1-1c3512.json
+++ b/src/test/resources/org/kohsuke/github/GHTreeBuilderTest/wiremock/testShaEntry/mappings/user-1-1c3512.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/getKeys/mappings/users_rtyler-1-11f423.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/getKeys/mappings/users_rtyler-1-11f423.json
@@ -3,7 +3,12 @@
   "name": "users_rtyler",
   "request": {
     "url": "/users/rtyler",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/getKeys/mappings/users_rtyler_keys-2-395dc0.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/getKeys/mappings/users_rtyler_keys-2-395dc0.json
@@ -3,7 +3,12 @@
   "name": "users_rtyler_keys",
   "request": {
     "url": "/users/rtyler/keys",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listFollowsAndFollowers/mappings/user-1-ca1c86.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listFollowsAndFollowers/mappings/user-1-ca1c86.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listFollowsAndFollowers/mappings/users_rtyler-2-b56699.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listFollowsAndFollowers/mappings/users_rtyler-2-b56699.json
@@ -3,7 +3,12 @@
   "name": "users_rtyler",
   "request": {
     "url": "/users/rtyler",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listFollowsAndFollowers/mappings/users_rtyler_followers-3-5d12f1.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listFollowsAndFollowers/mappings/users_rtyler_followers-3-5d12f1.json
@@ -3,7 +3,12 @@
   "name": "users_rtyler_followers",
   "request": {
     "url": "/users/rtyler/followers",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listFollowsAndFollowers/mappings/users_rtyler_following-4-51f792.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listFollowsAndFollowers/mappings/users_rtyler_following-4-51f792.json
@@ -3,7 +3,12 @@
   "name": "users_rtyler_following",
   "request": {
     "url": "/users/rtyler/following",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/user-1-905609.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/user-1-905609.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/user_50003_repos-4-1eeb7b.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/user_50003_repos-4-1eeb7b.json
@@ -3,7 +3,12 @@
   "name": "user_50003_repos",
   "request": {
     "url": "/user/50003/repos?per_page=30&page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/user_50003_repos-5-d1c08a.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/user_50003_repos-5-d1c08a.json
@@ -3,7 +3,12 @@
   "name": "user_50003_repos",
   "request": {
     "url": "/user/50003/repos?per_page=30&page=3",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/user_50003_repos-6-1e91f1.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/user_50003_repos-6-1e91f1.json
@@ -3,7 +3,12 @@
   "name": "user_50003_repos",
   "request": {
     "url": "/user/50003/repos?per_page=30&page=4",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/users_kohsuke-2-da994e.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/users_kohsuke-2-da994e.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke",
   "request": {
     "url": "/users/kohsuke",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/users_kohsuke_repos-3-9f7b75.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositories/mappings/users_kohsuke_repos-3-9f7b75.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke_repos",
   "request": {
     "url": "/users/kohsuke/repos?per_page=30",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositoriesPageSize62/mappings/user-1-e80779.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositoriesPageSize62/mappings/user-1-e80779.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositoriesPageSize62/mappings/user_50003_repos-4-c1c1b7.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositoriesPageSize62/mappings/user_50003_repos-4-c1c1b7.json
@@ -3,7 +3,12 @@
   "name": "user_50003_repos",
   "request": {
     "url": "/user/50003/repos?per_page=62&page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositoriesPageSize62/mappings/users_kohsuke-2-f1828d.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositoriesPageSize62/mappings/users_kohsuke-2-f1828d.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke",
   "request": {
     "url": "/users/kohsuke",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositoriesPageSize62/mappings/users_kohsuke_repos-3-24db0a.json
+++ b/src/test/resources/org/kohsuke/github/GHUserTest/wiremock/listPublicRepositoriesPageSize62/mappings/users_kohsuke_repos-3-24db0a.json
@@ -3,7 +3,12 @@
   "name": "users_kohsuke_repos",
   "request": {
     "url": "/users/kohsuke/repos?per_page=62",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getMeta/mappings/meta-1-d75466.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getMeta/mappings/meta-1-d75466.json
@@ -3,7 +3,12 @@
   "name": "meta",
   "request": {
     "url": "/meta",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-11-0fccda.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-11-0fccda.json
@@ -3,7 +3,12 @@
   "name": "organizations",
   "request": {
     "url": "/organizations?per_page=2&since=150",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-14-003deb.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-14-003deb.json
@@ -3,7 +3,12 @@
   "name": "organizations",
   "request": {
     "url": "/organizations?per_page=2&since=264",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-2-025896.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-2-025896.json
@@ -3,7 +3,12 @@
   "name": "organizations",
   "request": {
     "url": "/organizations?per_page=2",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-5-4ef810.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-5-4ef810.json
@@ -3,7 +3,12 @@
   "name": "organizations",
   "request": {
     "url": "/organizations?per_page=2&since=81",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-8-19d13a.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/organizations-8-19d13a.json
@@ -3,7 +3,12 @@
   "name": "organizations",
   "request": {
     "url": "/organizations?per_page=2&since=128",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_collectiveidea-7-4bbf97.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_collectiveidea-7-4bbf97.json
@@ -3,7 +3,12 @@
   "name": "orgs_collectiveidea",
   "request": {
     "url": "/orgs/collectiveidea",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_engineyard-4-643eb5.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_engineyard-4-643eb5.json
@@ -3,7 +3,12 @@
   "name": "orgs_engineyard",
   "request": {
     "url": "/orgs/engineyard",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_entryway-12-e1bd91.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_entryway-12-e1bd91.json
@@ -3,7 +3,12 @@
   "name": "orgs_entryway",
   "request": {
     "url": "/orgs/entryway",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_errfree-3-63eb86.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_errfree-3-63eb86.json
@@ -3,7 +3,12 @@
   "name": "orgs_errfree",
   "request": {
     "url": "/orgs/errfree",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_merb-13-df20cc.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_merb-13-df20cc.json
@@ -3,7 +3,12 @@
   "name": "orgs_merb",
   "request": {
     "url": "/orgs/merb",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_ministrycentered-6-40a544.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_ministrycentered-6-40a544.json
@@ -3,7 +3,12 @@
   "name": "orgs_ministrycentered",
   "request": {
     "url": "/orgs/ministrycentered",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_moneyspyder-15-859aaf.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_moneyspyder-15-859aaf.json
@@ -3,7 +3,12 @@
   "name": "orgs_moneyspyder",
   "request": {
     "url": "/orgs/moneyspyder",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_ogc-9-7ba44d.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_ogc-9-7ba44d.json
@@ -3,7 +3,12 @@
   "name": "orgs_ogc",
   "request": {
     "url": "/orgs/ogc",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_sevenwire-10-2a01f6.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_sevenwire-10-2a01f6.json
@@ -3,7 +3,12 @@
   "name": "orgs_sevenwire",
   "request": {
     "url": "/orgs/sevenwire",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_sproutit-16-a165de.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/orgs_sproutit-16-a165de.json
@@ -3,7 +3,12 @@
   "name": "orgs_sproutit",
   "request": {
     "url": "/orgs/sproutit",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/user-1-d7829e.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/getOrgs/mappings/user-1-d7829e.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/user-1-83656a.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/user-1-83656a.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users-2-c2940d.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users-2-c2940d.json
@@ -3,7 +3,12 @@
   "name": "users",
   "request": {
     "url": "/users",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_brynary-12-87de93.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_brynary-12-87de93.json
@@ -3,7 +3,12 @@
   "name": "users_brynary",
   "request": {
     "url": "/users/brynary",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_defunkt-4-14f04e.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_defunkt-4-14f04e.json
@@ -3,7 +3,12 @@
   "name": "users_defunkt",
   "request": {
     "url": "/users/defunkt",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_evanphx-9-bb2fea.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_evanphx-9-bb2fea.json
@@ -3,7 +3,12 @@
   "name": "users_evanphx",
   "request": {
     "url": "/users/evanphx",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_ezmobius-7-2e9ea7.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_ezmobius-7-2e9ea7.json
@@ -3,7 +3,12 @@
   "name": "users_ezmobius",
   "request": {
     "url": "/users/ezmobius",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_ivey-8-2220ec.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_ivey-8-2220ec.json
@@ -3,7 +3,12 @@
   "name": "users_ivey",
   "request": {
     "url": "/users/ivey",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_mojombo-3-41ed06.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_mojombo-3-41ed06.json
@@ -3,7 +3,12 @@
   "name": "users_mojombo",
   "request": {
     "url": "/users/mojombo",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_pjhyett-5-41b461.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_pjhyett-5-41b461.json
@@ -3,7 +3,12 @@
   "name": "users_pjhyett",
   "request": {
     "url": "/users/pjhyett",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_vanpelt-10-900a0e.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_vanpelt-10-900a0e.json
@@ -3,7 +3,12 @@
   "name": "users_vanpelt",
   "request": {
     "url": "/users/vanpelt",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_wayneeseguin-11-3e6233.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_wayneeseguin-11-3e6233.json
@@ -3,7 +3,12 @@
   "name": "users_wayneeseguin",
   "request": {
     "url": "/users/wayneeseguin",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_wycats-6-b5f8d0.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/listUsers/mappings/users_wycats-6-b5f8d0.json
@@ -3,7 +3,12 @@
   "name": "users_wycats",
   "request": {
     "url": "/users/wycats",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchContent/mappings/repositories_167174_contents_src_attributes_classesjs-3-d7ab2e.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchContent/mappings/repositories_167174_contents_src_attributes_classesjs-3-d7ab2e.json
@@ -3,7 +3,12 @@
   "name": "repositories_167174_contents_src_attributes_classesjs",
   "request": {
     "url": "/repositories/167174/contents/src/attributes/classes.js?ref=cf84696fd1d7fe314a11492606529b5a658ee9e3",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchContent/mappings/search_code-2-8ebadd.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchContent/mappings/search_code-2-8ebadd.json
@@ -3,7 +3,12 @@
   "name": "search_code",
   "request": {
     "url": "/search/code?q=addClass+in%3Afile+language%3Ajs+repo%3Ajquery%2Fjquery",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchContent/mappings/user-1-d3b1f3.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchContent/mappings/user-1-d3b1f3.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchUsers/mappings/search_users-2-0ca094.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchUsers/mappings/search_users-2-0ca094.json
@@ -3,7 +3,12 @@
   "name": "search_users",
   "request": {
     "url": "/search/users?q=tom+repos%3A%3E42+followers%3A%3E1000",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchUsers/mappings/user-1-76f627.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchUsers/mappings/user-1-76f627.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchUsers/mappings/users_mojombo-3-6e29c6.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/searchUsers/mappings/users_mojombo-3-6e29c6.json
@@ -3,7 +3,12 @@
   "name": "users_mojombo",
   "request": {
     "url": "/users/mojombo",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/testListAllRepositories/mappings/repositories-2-7bda3d.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/testListAllRepositories/mappings/repositories-2-7bda3d.json
@@ -3,7 +3,12 @@
   "name": "repositories",
   "request": {
     "url": "/repositories",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/testListAllRepositories/mappings/repositories-3-85ebe3.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/testListAllRepositories/mappings/repositories-3-85ebe3.json
@@ -3,7 +3,12 @@
   "name": "repositories",
   "request": {
     "url": "/repositories?since=369",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/testListAllRepositories/mappings/user-1-9eed57.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/testListAllRepositories/mappings/user-1-9eed57.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/testListMyAuthorizations/mappings/authorizations-1-4b8125.json
+++ b/src/test/resources/org/kohsuke/github/GitHubTest/wiremock/testListMyAuthorizations/mappings/authorizations-1-4b8125.json
@@ -3,7 +3,12 @@
   "name": "authorizations",
   "request": {
     "url": "/authorizations",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/Github2faTest/wiremock/test2faToken/mappings/authorizations-1-cdda4d.json
+++ b/src/test/resources/org/kohsuke/github/Github2faTest/wiremock/test2faToken/mappings/authorizations-1-cdda4d.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 401,

--- a/src/test/resources/org/kohsuke/github/Github2faTest/wiremock/test2faToken/mappings/authorizations-2-3f50c6.json
+++ b/src/test/resources/org/kohsuke/github/Github2faTest/wiremock/test2faToken/mappings/authorizations-2-3f50c6.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository-2-7e3d08.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository-2-7e3d08.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testcreaterepository",
   "request": {
     "url": "/repos/github-api-test-org/temp-testCreateRepository",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_issues-5-606626.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_issues-5-606626.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_milestones-4-c1bb69.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_milestones-4-c1bb69.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases-3-16498f.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases-3-16498f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testcreaterepository_releases",
   "request": {
     "url": "/repos/github-api-test-org/temp-testCreateRepository/releases",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases-6-dc00c2.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases-6-dc00c2.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases-7-dc82f3.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases-7-dc82f3.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testcreaterepository_releases",
   "request": {
     "url": "/repos/github-api-test-org/temp-testCreateRepository/releases",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets-10-ed473c.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets-10-ed473c.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets",
   "request": {
     "url": "/repos/github-api-test-org/temp-testCreateRepository/releases/21786739/assets",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets-12-383e6f.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets-12-383e6f.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets",
   "request": {
     "url": "/repos/github-api-test-org/temp-testCreateRepository/releases/21786739/assets",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets-8-42bb60.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets-8-42bb60.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets",
   "request": {
     "url": "/repos/github-api-test-org/temp-testCreateRepository/releases/21786739/assets",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_assets_16422841-11-864573.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_assets_16422841-11-864573.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_temp-testcreaterepository_releases_assets_16422841",
   "request": {
     "url": "/repos/github-api-test-org/temp-testCreateRepository/releases/assets/16422841",
-    "method": "DELETE"
+    "method": "DELETE",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 204,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_assets_16422841-9-7f61d0.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_assets_16422841-9-7f61d0.json
@@ -10,7 +10,12 @@
         "ignoreArrayOrder": true,
         "ignoreExtraElements": true
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/user-1-864ebe.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository/mappings/user-1-864ebe.json
@@ -3,7 +3,12 @@
   "name": "user",
   "request": {
     "url": "/user",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository_uploads/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets-1-3069f0.json
+++ b/src/test/resources/org/kohsuke/github/LifecycleTest/wiremock/testCreateRepository_uploads/mappings/repos_github-api-test-org_temp-testcreaterepository_releases_21786739_assets-1-3069f0.json
@@ -9,7 +9,12 @@
         "equalTo": " Copyright (c) 2011- Kohsuke Kawaguchi and other contributors\n\n Permission is hereby granted, free of charge, to any person\n obtaining a copy of this software and associated documentation\n files (the \"Software\"), to deal in the Software without\n restriction, including without limitation the rights to use,\n copy, modify, merge, publish, distribute, sublicense, and/or sell\n copies of the Software, and to permit persons to whom the\n Software is furnished to do so, subject to the following\n conditions:\n\n The above copyright notice and this permission notice shall be\n included in all copies or substantial portions of the Software.\n\n THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,\n EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES\n OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND\n NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT\n HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,\n WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING\n FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR\n OTHER DEALINGS IN THE SOFTWARE.\n",
         "caseInsensitive": false
       }
-    ]
+    ],
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 201,

--- a/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetClones/mappings/orgs_github-api-test-org-1-c83bc7.json
+++ b/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetClones/mappings/orgs_github-api-test-org-1-c83bc7.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetClones/mappings/repos_github-api-test-org_github-api-2-f2527a.json
+++ b/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetClones/mappings/repos_github-api-test-org_github-api-2-f2527a.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetTrafficStatsAccessFailureDueToInsufficientPermissions/mappings/orgs_github-api-test-org-1-cc28e4.json
+++ b/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetTrafficStatsAccessFailureDueToInsufficientPermissions/mappings/orgs_github-api-test-org-1-cc28e4.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetTrafficStatsAccessFailureDueToInsufficientPermissions/mappings/repos_github-api-test-org_github-api-2-3e1a60.json
+++ b/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetTrafficStatsAccessFailureDueToInsufficientPermissions/mappings/repos_github-api-test-org_github-api-2-3e1a60.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetTrafficStatsAccessFailureDueToInsufficientPermissions/mappings/repos_github-api-test-org_github-api_traffic_clones-4-8036aa.json
+++ b/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetTrafficStatsAccessFailureDueToInsufficientPermissions/mappings/repos_github-api-test-org_github-api_traffic_clones-4-8036aa.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_traffic_clones",
   "request": {
     "url": "/repos/github-api-test-org/github-api/traffic/clones",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 403,

--- a/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetTrafficStatsAccessFailureDueToInsufficientPermissions/mappings/repos_github-api-test-org_github-api_traffic_views-3-fe2649.json
+++ b/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetTrafficStatsAccessFailureDueToInsufficientPermissions/mappings/repos_github-api-test-org_github-api_traffic_views-3-fe2649.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api_traffic_views",
   "request": {
     "url": "/repos/github-api-test-org/github-api/traffic/views",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 403,

--- a/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetViews/mappings/orgs_github-api-test-org-1-8dd3c6.json
+++ b/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetViews/mappings/orgs_github-api-test-org-1-8dd3c6.json
@@ -3,7 +3,12 @@
   "name": "orgs_github-api-test-org",
   "request": {
     "url": "/orgs/github-api-test-org",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,

--- a/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetViews/mappings/repos_github-api-test-org_github-api-2-3adb69.json
+++ b/src/test/resources/org/kohsuke/github/RepositoryTrafficTest/wiremock/testGetViews/mappings/repos_github-api-test-org_github-api-2-3adb69.json
@@ -3,7 +3,12 @@
   "name": "repos_github-api-test-org_github-api",
   "request": {
     "url": "/repos/github-api-test-org/github-api",
-    "method": "GET"
+    "method": "GET",
+    "headers": {
+      "Accept": {
+        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+      }
+    }
   },
   "response": {
     "status": 200,


### PR DESCRIPTION
# Description
The 'Accept' header on requests can change what data is returned, so we need to
only match requests with the correct value.

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn -P ci install site ` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.
