### PR TITLE
Make PagedSearchIterable non-abstract

### DIFF
--- a/src/main/java/org/kohsuke/github/GitHubPageContentsIterator.java
+++ b/src/main/java/org/kohsuke/github/GitHubPageContentsIterator.java
@@ -1,0 +1,39 @@
+package org.kohsuke.github;
+
+import java.util.Iterator;
+import java.util.function.Consumer;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
+/**
+ * This class is not thread-safe. Any one instance should only be called from a single thread.
+ */
+class GitHubPageContentsIterator<T> extends PagedIterator<T> {
+
+    @CheckForNull
+    private final Consumer<T> itemInitializer;
+
+    public GitHubPageContentsIterator(@Nonnull Iterator<T[]> iterator, @CheckForNull Consumer<T> itemInitializer) {
+        super(iterator);
+        this.itemInitializer = itemInitializer;
+    }
+
+    @Override
+    protected void wrapUp(T[] page) {
+        if (itemInitializer != null) {
+            for (T item : page) {
+                itemInitializer.accept(item);
+            }
+        }
+    }
+
+    /**
+     * Gets the {@link GitHubResponse} for the last page received.
+     *
+     * @return the {@link GitHubResponse} for the last page received.
+     */
+    GitHubResponse<T[]> lastResponse() {
+        return ((GitHubPageIterator<T[]>) base).finalResponse();
+    }
+}


### PR DESCRIPTION
# Description 
As a follow on to #709, I noticed that `PagedSearchIterable` does not need to be an abstract class that is dynamically extended anymore.  With some minor changes it can be instantiated directly and be more understandable.  It now looks almost the same as `GitHubPageContentsIterable`.

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn -D enable-ci clean install site` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.
