### PR TITLE
Fix scm.url in pom.xml so that Dependabot can pick up changelogs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <scm>
     <connection>scm:git:git@github.com/github-api/${project.artifactId}.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/github-api/${project.artifactId}.git</developerConnection>
-    <url>https://${project.artifactId}.kohsuke.org/</url>
+    <url>https://github.com/github-api/github-api/</url>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
# Description 

SCM URL points to the project website instead of SCM. It prevents Dependabot from automatically discovering changelogs for this component. E.g. see https://github.com/jenkinsci/github-api-plugin/pull/38

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
~- [ ] Add JavaDocs and other comments~
~- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.~
~- [ ] Run `mvn -D enable-ci clean install site` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.~
