### PR TITLE
Use InjectableValue to provide response info

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -142,7 +142,7 @@ public class GHEventInfo {
      *             if payload cannot be parsed
      */
     public <T extends GHEventPayload> T getPayload(Class<T> type) throws IOException {
-        T v = GitHubClient.MAPPER.readValue(payload.traverse(), type);
+        T v = GitHubClient.getMappingObjectReader().readValue(payload.traverse(), type);
         v.wrapUp(root);
         return v;
     }

--- a/src/main/java/org/kohsuke/github/GHObject.java
+++ b/src/main/java/org/kohsuke/github/GHObject.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.annotation.JacksonInject;
 import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
@@ -31,6 +32,19 @@ public abstract class GHObject {
     protected String updated_at;
 
     GHObject() {
+    }
+
+    /**
+     * Called by Jackson
+     * 
+     * @param responseInfo
+     *            the {@link GitHubResponse.ResponseInfo} to get headers from.
+     */
+    @JacksonInject
+    protected void setResponseHeaderFields(@CheckForNull GitHubResponse.ResponseInfo responseInfo) {
+        if (responseInfo != null) {
+            responseHeaderFields = responseInfo.headers();
+        }
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -772,7 +772,7 @@ public class GitHub {
      *             the io exception
      */
     public <T extends GHEventPayload> T parseEventPayload(Reader r, Class<T> type) throws IOException {
-        T t = GitHubClient.MAPPER.readValue(r, type);
+        T t = GitHubClient.getMappingObjectReader().forType(type).readValue(r);
         t.wrapUp(this);
         return t;
     }

--- a/src/main/java/org/kohsuke/github/GitHubHttpUrlConnectionClient.java
+++ b/src/main/java/org/kohsuke/github/GitHubHttpUrlConnectionClient.java
@@ -153,7 +153,7 @@ class GitHubHttpUrlConnectionClient extends GitHubClient {
                         for (GitHubRequest.Entry e : request.args()) {
                             json.put(e.key, e.value);
                         }
-                        MAPPER.writeValue(connection.getOutputStream(), json);
+                        getMappingObjectWriter().writeValue(connection.getOutputStream(), json);
                     }
                 }
             }
@@ -235,4 +235,5 @@ class GitHubHttpUrlConnectionClient extends GitHubClient {
         private static final Logger LOGGER = Logger.getLogger(GitHubClient.class.getName());
 
     }
+
 }

--- a/src/main/java/org/kohsuke/github/GitHubResponse.java
+++ b/src/main/java/org/kohsuke/github/GitHubResponse.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import org.apache.commons.io.IOUtils;
 
@@ -77,7 +78,10 @@ class GitHubResponse<T> {
 
         String data = responseInfo.getBodyAsString();
         try {
-            return GitHubClient.MAPPER.readValue(data, type);
+            InjectableValues.Std inject = new InjectableValues.Std();
+            inject.addValue(ResponseInfo.class, responseInfo);
+
+            return GitHubClient.getMappingObjectReader(responseInfo).forType(type).readValue(data);
         } catch (JsonMappingException e) {
             String message = "Failed to deserialize " + data;
             throw new IOException(message, e);
@@ -102,7 +106,7 @@ class GitHubResponse<T> {
 
         String data = responseInfo.getBodyAsString();
         try {
-            return GitHubClient.MAPPER.readerForUpdating(instance).<T>readValue(data);
+            return GitHubClient.getMappingObjectReader(responseInfo).withValueToUpdate(instance).readValue(data);
         } catch (JsonMappingException e) {
             String message = "Failed to deserialize " + data;
             throw new IOException(message, e);

--- a/src/test/java/org/kohsuke/github/GHObjectTest.java
+++ b/src/test/java/org/kohsuke/github/GHObjectTest.java
@@ -12,5 +12,9 @@ public class GHObjectTest extends org.kohsuke.github.AbstractGitHubWireMockTest 
         assertThat(org.toString(),
                 containsString(
                         "login=github-api-test-org,location=<null>,blog=<null>,email=<null>,name=<null>,company=<null>,type=Organization,followers=0,following=0"));
+
+        // getResponseHeaderFields is deprecated but we should not break it.
+        assertThat(org.getResponseHeaderFields(), notNullValue());
+        assertThat(org.getResponseHeaderFields().get("Cache-Control").get(0), is("private, max-age=60, s-maxage=60"));
     }
 }


### PR DESCRIPTION
# Description 
Jackson can do binding of injected values for us rather than needing to special case them.  

A continuation of this change would be to remove most of the initialization `wrapUp(root)` methods and add a binding for `GitHub` member. 

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn -D enable-ci clean install site` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.
