### PR TITLE
Deprecate PagedIterable.asList() and PagedIterable.asSet()

### DIFF
--- a/src/main/java/org/kohsuke/github/GHContent.java
+++ b/src/main/java/org/kohsuke/github/GHContent.java
@@ -388,22 +388,6 @@ public class GHContent implements Refreshable {
     }
 
     /**
-     * Wrap gh content [ ].
-     *
-     * @param contents
-     *            the contents
-     * @param repository
-     *            the repository
-     * @return the gh content [ ]
-     */
-    public static GHContent[] wrap(GHContent[] contents, GHRepository repository) {
-        for (GHContent unwrappedContent : contents) {
-            unwrappedContent.wrap(repository);
-        }
-        return contents;
-    }
-
-    /**
      * Fully populate the data by retrieving missing data.
      *
      * Depending on the original API call where this object is created, it may not contain everything.

--- a/src/main/java/org/kohsuke/github/GHIssue.java
+++ b/src/main/java/org/kohsuke/github/GHIssue.java
@@ -100,12 +100,6 @@ public class GHIssue extends GHObject implements Reactable {
         return this;
     }
 
-    static GHIssue[] wrap(GHIssue[] issues, GHRepository owner) {
-        for (GHIssue i : issues)
-            i.wrap(owner);
-        return issues;
-    }
-
     /**
      * Repository to which the issue belongs.
      *
@@ -434,7 +428,7 @@ public class GHIssue extends GHObject implements Reactable {
      * @see #listComments() #listComments()
      */
     public List<GHIssueComment> getComments() throws IOException {
-        return listComments().asList();
+        return listComments().toList();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHMembership.java
+++ b/src/main/java/org/kohsuke/github/GHMembership.java
@@ -83,11 +83,6 @@ public class GHMembership /* extends GHObject --- but it doesn't have id, create
         return this;
     }
 
-    static void wrap(GHMembership[] page, GitHub root) {
-        for (GHMembership m : page)
-            m.wrap(root);
-    }
-
     /**
      * Role of a user in an organization.
      */

--- a/src/main/java/org/kohsuke/github/GHMyself.java
+++ b/src/main/java/org/kohsuke/github/GHMyself.java
@@ -69,7 +69,10 @@ public class GHMyself extends GHUser {
      *             the io exception
      */
     public List<GHEmail> getEmails2() throws IOException {
-        GHEmail[] addresses = root.createRequest().withUrlPath("/user/emails").fetchArray(GHEmail[].class);
+        GHEmail[] addresses = root.createRequest()
+                .withUrlPath("/user/emails")
+                .toIterable(GHEmail[].class, null)
+                .toArray();
         return Collections.unmodifiableList(Arrays.asList(addresses));
     }
 
@@ -84,8 +87,8 @@ public class GHMyself extends GHUser {
      *             the io exception
      */
     public List<GHKey> getPublicKeys() throws IOException {
-        return Collections.unmodifiableList(
-                Arrays.asList(root.createRequest().withUrlPath("/user/keys").fetchArray(GHKey[].class)));
+        return Collections.unmodifiableList(Arrays
+                .asList(root.createRequest().withUrlPath("/user/keys").toIterable(GHKey[].class, null).toArray()));
     }
 
     /**
@@ -99,8 +102,10 @@ public class GHMyself extends GHUser {
      *             the io exception
      */
     public List<GHVerifiedKey> getPublicVerifiedKeys() throws IOException {
-        return Collections.unmodifiableList(Arrays.asList(
-                root.createRequest().withUrlPath("/users/" + getLogin() + "/keys").fetchArray(GHVerifiedKey[].class)));
+        return Collections.unmodifiableList(Arrays.asList(root.createRequest()
+                .withUrlPath("/users/" + getLogin() + "/keys")
+                .toIterable(GHVerifiedKey[].class, null)
+                .toArray()));
     }
 
     /**
@@ -113,7 +118,10 @@ public class GHMyself extends GHUser {
     public GHPersonSet<GHOrganization> getAllOrganizations() throws IOException {
         GHPersonSet<GHOrganization> orgs = new GHPersonSet<GHOrganization>();
         Set<String> names = new HashSet<String>();
-        for (GHOrganization o : root.createRequest().withUrlPath("/user/orgs").fetchArray(GHOrganization[].class)) {
+        for (GHOrganization o : root.createRequest()
+                .withUrlPath("/user/orgs")
+                .toIterable(GHOrganization[].class, null)
+                .toArray()) {
             if (names.add(o.getLogin())) // in case of rumoured duplicates in the data
                 orgs.add(root.getOrganization(o.getLogin()));
         }

--- a/src/main/java/org/kohsuke/github/GHMyself.java
+++ b/src/main/java/org/kohsuke/github/GHMyself.java
@@ -2,7 +2,6 @@ package org.kohsuke.github;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -69,11 +68,7 @@ public class GHMyself extends GHUser {
      *             the io exception
      */
     public List<GHEmail> getEmails2() throws IOException {
-        GHEmail[] addresses = root.createRequest()
-                .withUrlPath("/user/emails")
-                .toIterable(GHEmail[].class, null)
-                .toArray();
-        return Collections.unmodifiableList(Arrays.asList(addresses));
+        return root.createRequest().withUrlPath("/user/emails").toIterable(GHEmail[].class, null).toList();
     }
 
     /**
@@ -87,8 +82,7 @@ public class GHMyself extends GHUser {
      *             the io exception
      */
     public List<GHKey> getPublicKeys() throws IOException {
-        return Collections.unmodifiableList(Arrays
-                .asList(root.createRequest().withUrlPath("/user/keys").toIterable(GHKey[].class, null).toArray()));
+        return root.createRequest().withUrlPath("/user/keys").toIterable(GHKey[].class, null).toList();
     }
 
     /**
@@ -102,10 +96,10 @@ public class GHMyself extends GHUser {
      *             the io exception
      */
     public List<GHVerifiedKey> getPublicVerifiedKeys() throws IOException {
-        return Collections.unmodifiableList(Arrays.asList(root.createRequest()
+        return root.createRequest()
                 .withUrlPath("/users/" + getLogin() + "/keys")
                 .toIterable(GHVerifiedKey[].class, null)
-                .toArray()));
+                .toList();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHNotificationStream.java
+++ b/src/main/java/org/kohsuke/github/GHNotificationStream.java
@@ -181,7 +181,7 @@ public class GHNotificationStream implements Iterable<GHThread> {
 
                         Requester requester = req.withUrlPath(apiUrl);
                         GitHubResponse<GHThread[]> response = ((GitHubPageContentsIterable<GHThread>) requester
-                                .toIterable(requester.client, GHThread[].class, null)).toResponse();
+                                .toIterable(GHThread[].class, null)).toResponse();
                         threads = response.body();
 
                         if (threads == null) {

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -253,7 +253,7 @@ public class GHOrganization extends GHPerson {
      * @deprecated use {@link #listMembers()}
      */
     public List<GHUser> getMembers() throws IOException {
-        return listMembers().asList();
+        return listMembers().toList();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHPerson.java
+++ b/src/main/java/org/kohsuke/github/GHPerson.java
@@ -2,6 +2,7 @@ package org.kohsuke.github;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
@@ -116,9 +117,15 @@ public abstract class GHPerson extends GHObject {
     public synchronized Iterable<List<GHRepository>> iterateRepositories(final int pageSize) {
         return new Iterable<List<GHRepository>>() {
             public Iterator<List<GHRepository>> iterator() {
-                final Iterator<GHRepository[]> pager = GitHubPageIterator.create(root.getClient(),
-                        GHRepository[].class,
-                        root.createRequest().withUrlPath("users", login, "repos").withPageSize(pageSize));
+                final Iterator<GHRepository[]> pager;
+                try {
+                    pager = GitHubPageIterator.create(root.getClient(),
+                            GHRepository[].class,
+                            root.createRequest().withUrlPath("users", login, "repos").build(),
+                            pageSize);
+                } catch (MalformedURLException e) {
+                    throw new GHException("Unable to build GitHub API URL", e);
+                }
 
                 return new Iterator<List<GHRepository>>() {
                     public boolean hasNext() {

--- a/src/main/java/org/kohsuke/github/GHRef.java
+++ b/src/main/java/org/kohsuke/github/GHRef.java
@@ -88,13 +88,6 @@ public class GHRef {
         return this;
     }
 
-    static GHRef[] wrap(GHRef[] in, GitHub root) {
-        for (GHRef r : in) {
-            r.wrap(root);
-        }
-        return in;
-    }
-
     /**
      * The type GHObject.
      */

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
@@ -258,8 +257,9 @@ public class GHRelease extends GHObject {
     public List<GHAsset> getAssets() throws IOException {
         Requester builder = owner.root.createRequest();
 
-        GHAsset[] assets = builder.withUrlPath(getApiTailUrl("assets")).toIterable(GHAsset[].class, null).toArray();
-        return Arrays.asList(GHAsset.wrap(assets, this));
+        return builder.withUrlPath(getApiTailUrl("assets"))
+                .toIterable(GHAsset[].class, item -> item.wrap(this))
+                .toList();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHRelease.java
+++ b/src/main/java/org/kohsuke/github/GHRelease.java
@@ -258,7 +258,7 @@ public class GHRelease extends GHObject {
     public List<GHAsset> getAssets() throws IOException {
         Requester builder = owner.root.createRequest();
 
-        GHAsset[] assets = builder.withUrlPath(getApiTailUrl("assets")).fetchArray(GHAsset[].class);
+        GHAsset[] assets = builder.withUrlPath(getApiTailUrl("assets")).toIterable(GHAsset[].class, null).toArray();
         return Arrays.asList(GHAsset.wrap(assets, this));
     }
 

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -376,8 +376,9 @@ public class GHRepository extends GHObject {
         Requester requester = root.createRequest()
                 .with("state", state)
                 .with("milestone", milestone == null ? "none" : "" + milestone.getNumber());
-        return Arrays
-                .asList(GHIssue.wrap(requester.withUrlPath(getApiTailUrl("issues")).fetchArray(GHIssue[].class), this));
+        return Arrays.asList(
+                GHIssue.wrap(requester.withUrlPath(getApiTailUrl("issues")).toIterable(GHIssue[].class, null).toArray(),
+                        this));
     }
 
     /**
@@ -785,9 +786,10 @@ public class GHRepository extends GHObject {
      */
     public Set<String> getCollaboratorNames() throws IOException {
         Set<String> r = new HashSet<String>();
-        for (GHUser u : GHUser.wrap(
-                root.createRequest().withUrlPath(getApiTailUrl("collaborators")).fetchArray(GHUser[].class),
-                root))
+        for (GHUser u : GHUser.wrap(root.createRequest()
+                .withUrlPath(getApiTailUrl("collaborators"))
+                .toIterable(GHUser[].class, null)
+                .toArray(), root))
             r.add(u.login);
         return r;
     }
@@ -830,9 +832,9 @@ public class GHRepository extends GHObject {
      *             the io exception
      */
     public Set<GHTeam> getTeams() throws IOException {
-        return Collections.unmodifiableSet(new HashSet<GHTeam>(Arrays.asList(
-                GHTeam.wrapUp(root.createRequest().withUrlPath(getApiTailUrl("teams")).fetchArray(GHTeam[].class),
-                        root.getOrganization(getOwnerName())))));
+        return Collections.unmodifiableSet(new HashSet<GHTeam>(Arrays.asList(GHTeam.wrapUp(
+                root.createRequest().withUrlPath(getApiTailUrl("teams")).toIterable(GHTeam[].class, null).toArray(),
+                root.getOrganization(getOwnerName())))));
     }
 
     /**
@@ -1451,7 +1453,8 @@ public class GHRepository extends GHObject {
     public GHRef[] getRefs() throws IOException {
         return GHRef.wrap(root.createRequest()
                 .withUrlPath(String.format("/repos/%s/%s/git/refs", getOwnerName(), name))
-                .fetchArray(GHRef[].class), root);
+                .toIterable(GHRef[].class, null)
+                .toArray(), root);
     }
 
     /**
@@ -1478,7 +1481,8 @@ public class GHRepository extends GHObject {
     public GHRef[] getRefs(String refType) throws IOException {
         return GHRef.wrap(root.createRequest()
                 .withUrlPath(String.format("/repos/%s/%s/git/refs/%s", getOwnerName(), name, refType))
-                .fetchArray(GHRef[].class), root);
+                .toIterable(GHRef[].class, null)
+                .toArray(), root);
     }
 
     /**
@@ -2071,7 +2075,10 @@ public class GHRepository extends GHObject {
      */
     public Map<String, GHBranch> getBranches() throws IOException {
         Map<String, GHBranch> r = new TreeMap<String, GHBranch>();
-        for (GHBranch p : root.createRequest().withUrlPath(getApiTailUrl("branches")).fetchArray(GHBranch[].class)) {
+        for (GHBranch p : root.createRequest()
+                .withUrlPath(getApiTailUrl("branches"))
+                .toIterable(GHBranch[].class, null)
+                .toArray()) {
             p.wrap(this);
             r.put(p.getName(), p);
         }
@@ -2203,7 +2210,10 @@ public class GHRepository extends GHObject {
         }
         String target = getApiTailUrl("contents/" + path);
 
-        GHContent[] files = requester.with("ref", ref).withUrlPath(target).fetchArray(GHContent[].class);
+        GHContent[] files = requester.with("ref", ref)
+                .withUrlPath(target)
+                .toIterable(GHContent[].class, null)
+                .toArray();
 
         GHContent.wrap(files, this);
 
@@ -2361,8 +2371,10 @@ public class GHRepository extends GHObject {
      *             the io exception
      */
     public List<GHDeployKey> getDeployKeys() throws IOException {
-        List<GHDeployKey> list = new ArrayList<GHDeployKey>(
-                Arrays.asList(root.createRequest().withUrlPath(getApiTailUrl("keys")).fetchArray(GHDeployKey[].class)));
+        List<GHDeployKey> list = new ArrayList<GHDeployKey>(Arrays.asList(root.createRequest()
+                .withUrlPath(getApiTailUrl("keys"))
+                .toIterable(GHDeployKey[].class, null)
+                .toArray()));
         for (GHDeployKey h : list)
             h.wrap(this);
         return list;

--- a/src/main/java/org/kohsuke/github/GHSearchBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHSearchBuilder.java
@@ -6,8 +6,6 @@ import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nonnull;
-
 /**
  * Base class for various search builders.
  *
@@ -25,6 +23,7 @@ public abstract class GHSearchBuilder<T> extends GHQueryBuilder<T> {
     GHSearchBuilder(GitHub root, Class<? extends SearchResult<T>> receiverType) {
         super(root);
         this.receiverType = receiverType;
+        req.withUrlPath(getApiUrl());
     }
 
     /**
@@ -47,20 +46,7 @@ public abstract class GHSearchBuilder<T> extends GHQueryBuilder<T> {
 
         req.set("q", StringUtils.join(terms, " "));
         try {
-            final GitHubRequest baseRequest = req.build();
-            return new PagedSearchIterable<T>(root) {
-                @Nonnull
-                public PagedIterator<T> _iterator(int pageSize) {
-                    return new PagedIterator<T>(adapt(GitHubPageIterator.create(root.getClient(),
-                            receiverType,
-                            baseRequest.toBuilder().withUrlPath(getApiUrl()).withPageSize(pageSize)))) {
-                        protected void wrapUp(T[] page) {
-                            // PagedSearchIterable
-                            // SearchResult.getItems() should do it
-                        }
-                    };
-                }
-            };
+            return new PagedSearchIterable<>(root, req.build(), receiverType);
         } catch (MalformedURLException e) {
             throw new GHException("", e);
         }

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -1,7 +1,6 @@
 package org.kohsuke.github;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -50,13 +49,6 @@ public class GHTeam implements Refreshable {
     GHTeam wrapUp(GitHub root) { // auto-wrapUp when organization is known from GET /user/teams
         this.organization.wrapUp(root);
         return wrapUp(organization);
-    }
-
-    static GHTeam[] wrapUp(GHTeam[] teams, GHOrganization owner) {
-        for (GHTeam t : teams) {
-            t.wrapUp(owner);
-        }
-        return teams;
     }
 
     static GHTeam[] wrapUp(GHTeam[] teams, GHPullRequest owner) {
@@ -163,7 +155,7 @@ public class GHTeam implements Refreshable {
      *             the io exception
      */
     public Set<GHUser> getMembers() throws IOException {
-        return Collections.unmodifiableSet(listMembers().asSet());
+        return listMembers().toSet();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -41,8 +41,7 @@ public class GHUser extends GHPerson {
      *             the io exception
      */
     public List<GHKey> getKeys() throws IOException {
-        return Collections.unmodifiableList(Arrays.asList(
-                root.createRequest().withUrlPath(getApiTailUrl("keys")).toIterable(GHKey[].class, null).toArray()));
+        return root.createRequest().withUrlPath(getApiTailUrl("keys")).toIterable(GHKey[].class, null).toList();
     }
 
     /**
@@ -74,7 +73,7 @@ public class GHUser extends GHPerson {
      */
     @WithBridgeMethods(Set.class)
     public GHPersonSet<GHUser> getFollows() throws IOException {
-        return new GHPersonSet<GHUser>(listFollows().asList());
+        return new GHPersonSet<GHUser>(listFollows().toList());
     }
 
     /**
@@ -95,7 +94,7 @@ public class GHUser extends GHPerson {
      */
     @WithBridgeMethods(Set.class)
     public GHPersonSet<GHUser> getFollowers() throws IOException {
-        return new GHPersonSet<GHUser>(listFollowers().asList());
+        return new GHPersonSet<GHUser>(listFollowers().toList());
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -41,8 +41,8 @@ public class GHUser extends GHPerson {
      *             the io exception
      */
     public List<GHKey> getKeys() throws IOException {
-        return Collections.unmodifiableList(
-                Arrays.asList(root.createRequest().withUrlPath(getApiTailUrl("keys")).fetchArray(GHKey[].class)));
+        return Collections.unmodifiableList(Arrays.asList(
+                root.createRequest().withUrlPath(getApiTailUrl("keys")).toIterable(GHKey[].class, null).toArray()));
     }
 
     /**
@@ -191,7 +191,8 @@ public class GHUser extends GHPerson {
         Set<String> names = new HashSet<String>();
         for (GHOrganization o : root.createRequest()
                 .withUrlPath("/users/" + login + "/orgs")
-                .fetchArray(GHOrganization[].class)) {
+                .toIterable(GHOrganization[].class, null)
+                .toArray()) {
             if (names.add(o.getLogin())) // I've seen some duplicates in the data
                 orgs.add(root.getOrganization(o.getLogin()));
         }

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -600,7 +600,8 @@ public class GitHub {
      */
     public List<GHInvitation> getMyInvitations() throws IOException {
         GHInvitation[] invitations = createRequest().withUrlPath("/user/repository_invitations")
-                .fetchArray(GHInvitation[].class);
+                .toIterable(GHInvitation[].class, null)
+                .toArray();
         for (GHInvitation i : invitations) {
             i.wrapUp(this);
         }
@@ -618,7 +619,9 @@ public class GitHub {
      *             the io exception
      */
     public Map<String, GHOrganization> getMyOrganizations() throws IOException {
-        GHOrganization[] orgs = createRequest().withUrlPath("/user/orgs").fetchArray(GHOrganization[].class);
+        GHOrganization[] orgs = createRequest().withUrlPath("/user/orgs")
+                .toIterable(GHOrganization[].class, null)
+                .toArray();
         Map<String, GHOrganization> r = new HashMap<String, GHOrganization>();
         for (GHOrganization o : orgs) {
             // don't put 'o' into orgs because they are shallow
@@ -672,7 +675,8 @@ public class GitHub {
      */
     public Map<String, GHOrganization> getUserPublicOrganizations(String login) throws IOException {
         GHOrganization[] orgs = createRequest().withUrlPath("/users/" + login + "/orgs")
-                .fetchArray(GHOrganization[].class);
+                .toIterable(GHOrganization[].class, null)
+                .toArray();
         Map<String, GHOrganization> r = new HashMap<String, GHOrganization>();
         for (GHOrganization o : orgs) {
             // don't put 'o' into orgs because they are shallow
@@ -693,7 +697,7 @@ public class GitHub {
      */
     public Map<String, Set<GHTeam>> getMyTeams() throws IOException {
         Map<String, Set<GHTeam>> allMyTeams = new HashMap<String, Set<GHTeam>>();
-        for (GHTeam team : createRequest().withUrlPath("/user/teams").fetchArray(GHTeam[].class)) {
+        for (GHTeam team : createRequest().withUrlPath("/user/teams").toIterable(GHTeam[].class, null).toArray()) {
             team.wrapUp(this);
             String orgLogin = team.getOrganization().getLogin();
             Set<GHTeam> teamsPerOrg = allMyTeams.get(orgLogin);
@@ -727,7 +731,7 @@ public class GitHub {
      *             the io exception
      */
     public List<GHEventInfo> getEvents() throws IOException {
-        GHEventInfo[] events = createRequest().withUrlPath("/events").fetchArray(GHEventInfo[].class);
+        GHEventInfo[] events = createRequest().withUrlPath("/events").toIterable(GHEventInfo[].class, null).toArray();
         for (GHEventInfo e : events)
             e.wrapUp(this);
         return Arrays.asList(events);

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -599,13 +599,9 @@ public class GitHub {
      *             the io exception
      */
     public List<GHInvitation> getMyInvitations() throws IOException {
-        GHInvitation[] invitations = createRequest().withUrlPath("/user/repository_invitations")
-                .toIterable(GHInvitation[].class, null)
-                .toArray();
-        for (GHInvitation i : invitations) {
-            i.wrapUp(this);
-        }
-        return Arrays.asList(invitations);
+        return createRequest().withUrlPath("/user/repository_invitations")
+                .toIterable(GHInvitation[].class, item -> item.wrapUp(this))
+                .toList();
     }
 
     /**
@@ -620,12 +616,12 @@ public class GitHub {
      */
     public Map<String, GHOrganization> getMyOrganizations() throws IOException {
         GHOrganization[] orgs = createRequest().withUrlPath("/user/orgs")
-                .toIterable(GHOrganization[].class, null)
+                .toIterable(GHOrganization[].class, item -> item.wrapUp(this))
                 .toArray();
-        Map<String, GHOrganization> r = new HashMap<String, GHOrganization>();
+        Map<String, GHOrganization> r = new HashMap<>();
         for (GHOrganization o : orgs) {
             // don't put 'o' into orgs because they are shallow
-            r.put(o.getLogin(), o.wrapUp(this));
+            r.put(o.getLogin(), o);
         }
         return r;
     }
@@ -675,12 +671,12 @@ public class GitHub {
      */
     public Map<String, GHOrganization> getUserPublicOrganizations(String login) throws IOException {
         GHOrganization[] orgs = createRequest().withUrlPath("/users/" + login + "/orgs")
-                .toIterable(GHOrganization[].class, null)
+                .toIterable(GHOrganization[].class, item -> item.wrapUp(this))
                 .toArray();
-        Map<String, GHOrganization> r = new HashMap<String, GHOrganization>();
+        Map<String, GHOrganization> r = new HashMap<>();
         for (GHOrganization o : orgs) {
-            // don't put 'o' into orgs because they are shallow
-            r.put(o.getLogin(), o.wrapUp(this));
+            // don't put 'o' into orgs cache because they are shallow records
+            r.put(o.getLogin(), o);
         }
         return r;
     }
@@ -696,13 +692,14 @@ public class GitHub {
      *             the io exception
      */
     public Map<String, Set<GHTeam>> getMyTeams() throws IOException {
-        Map<String, Set<GHTeam>> allMyTeams = new HashMap<String, Set<GHTeam>>();
-        for (GHTeam team : createRequest().withUrlPath("/user/teams").toIterable(GHTeam[].class, null).toArray()) {
-            team.wrapUp(this);
+        Map<String, Set<GHTeam>> allMyTeams = new HashMap<>();
+        for (GHTeam team : createRequest().withUrlPath("/user/teams")
+                .toIterable(GHTeam[].class, item -> item.wrapUp(this))
+                .toArray()) {
             String orgLogin = team.getOrganization().getLogin();
             Set<GHTeam> teamsPerOrg = allMyTeams.get(orgLogin);
             if (teamsPerOrg == null) {
-                teamsPerOrg = new HashSet<GHTeam>();
+                teamsPerOrg = new HashSet<>();
             }
             teamsPerOrg.add(team);
             allMyTeams.put(orgLogin, teamsPerOrg);
@@ -731,10 +728,9 @@ public class GitHub {
      *             the io exception
      */
     public List<GHEventInfo> getEvents() throws IOException {
-        GHEventInfo[] events = createRequest().withUrlPath("/events").toIterable(GHEventInfo[].class, null).toArray();
-        for (GHEventInfo e : events)
-            e.wrapUp(this);
-        return Arrays.asList(events);
+        return createRequest().withUrlPath("/events")
+                .toIterable(GHEventInfo[].class, item -> item.wrapUp(this))
+                .toList();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHubPageContentsIterable.java
+++ b/src/main/java/org/kohsuke/github/GitHubPageContentsIterable.java
@@ -19,16 +19,16 @@ class GitHubPageContentsIterable<T> extends PagedIterable<T> {
 
     private final GitHubClient client;
     private final GitHubRequest request;
-    private final Class<T[]> clazz;
+    private final Class<T[]> receiverType;
     private final Consumer<T> itemInitializer;
 
     GitHubPageContentsIterable(GitHubClient client,
             GitHubRequest request,
-            Class<T[]> clazz,
+            Class<T[]> receiverType,
             Consumer<T> itemInitializer) {
         this.client = client;
         this.request = request;
-        this.clazz = clazz;
+        this.receiverType = receiverType;
         this.itemInitializer = itemInitializer;
     }
 
@@ -38,9 +38,8 @@ class GitHubPageContentsIterable<T> extends PagedIterable<T> {
     @Override
     @Nonnull
     public PagedIterator<T> _iterator(int pageSize) {
-        final GitHubPageIterator<T[]> iterator = GitHubPageIterator
-                .create(client, clazz, request.toBuilder().withPageSize(pageSize));
-        return new GitHubPageContentsIterator(iterator);
+        final GitHubPageIterator<T[]> iterator = GitHubPageIterator.create(client, receiverType, request, pageSize);
+        return new GitHubPageContentsIterator(iterator, itemInitializer);
     }
 
     /**
@@ -64,17 +63,8 @@ class GitHubPageContentsIterable<T> extends PagedIterable<T> {
      */
     private class GitHubPageContentsIterator extends PagedIterator<T> {
 
-        public GitHubPageContentsIterator(GitHubPageIterator<T[]> iterator) {
-            super(iterator);
-        }
-
-        @Override
-        protected void wrapUp(T[] page) {
-            if (itemInitializer != null) {
-                for (T item : page) {
-                    itemInitializer.accept(item);
-                }
-            }
+        public GitHubPageContentsIterator(GitHubPageIterator<T[]> iterator, Consumer<T> itemInitializer) {
+            super(iterator, itemInitializer);
         }
 
         /**

--- a/src/main/java/org/kohsuke/github/GitHubPageIterator.java
+++ b/src/main/java/org/kohsuke/github/GitHubPageIterator.java
@@ -49,7 +49,7 @@ class GitHubPageIterator<T> implements Iterator<T> {
      */
     private GitHubResponse<T> finalResponse = null;
 
-    GitHubPageIterator(GitHubClient client, Class<T> type, GitHubRequest request) {
+    private GitHubPageIterator(GitHubClient client, Class<T> type, GitHubRequest request) {
         if (!"GET".equals(request.method())) {
             throw new IllegalStateException("Request method \"GET\" is required for page iterator.");
         }
@@ -70,9 +70,15 @@ class GitHubPageIterator<T> implements Iterator<T> {
      *            type of each page (not the items in the page).
      * @return iterator
      */
-    static <T> GitHubPageIterator<T> create(GitHubClient client, Class<T> type, GitHubRequest.Builder<?> builder) {
+    static <T> GitHubPageIterator<T> create(GitHubClient client, Class<T> type, GitHubRequest request, int pageSize) {
+
         try {
-            return new GitHubPageIterator<>(client, type, builder.build());
+            if (pageSize > 0) {
+                GitHubRequest.Builder<?> builder = request.toBuilder().with("per_page", pageSize);
+                request = builder.build();
+            }
+
+            return new GitHubPageIterator<>(client, type, request);
         } catch (MalformedURLException e) {
             throw new GHException("Unable to build GitHub API URL", e);
         }

--- a/src/main/java/org/kohsuke/github/GitHubRequest.java
+++ b/src/main/java/org/kohsuke/github/GitHubRequest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Consumer;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -297,29 +296,6 @@ class GitHubRequest {
          */
         public GitHubRequest build() throws MalformedURLException {
             return new GitHubRequest(args, headers, apiUrl, urlPath, method, body, forceBody);
-        }
-
-        /**
-         * Creates {@link PagedIterable <R>} from this builder using the provided {@link Consumer<R>}. This method and
-         * the {@link PagedIterable <R>} do not actually begin fetching data until {@link Iterator#next()} or
-         * {@link Iterator#hasNext()} are called.
-         *
-         * @param client
-         *            the {@link GitHubClient} to be used for this {@link PagedIterable<R>}
-         * @param type
-         *            the type of the pages to retrieve.
-         * @param itemInitializer
-         *            the consumer to execute on each paged item retrieved.
-         * @param <R>
-         *            the element type for the pages returned from
-         * @return the {@link PagedIterable} for this builder.
-         */
-        public <R> PagedIterable<R> toIterable(GitHubClient client, Class<R[]> type, Consumer<R> itemInitializer) {
-            try {
-                return new GitHubPageContentsIterable<>(client, build(), type, itemInitializer);
-            } catch (MalformedURLException e) {
-                throw new GHException(e.getMessage(), e);
-            }
         }
 
         /**
@@ -605,20 +581,6 @@ class GitHubRequest {
          */
         public B inBody() {
             forceBody = true;
-            return (B) this;
-        }
-
-        /**
-         * Set page size for to be used for {@link #toIterable(GitHubClient, Class, Consumer)}.
-         * 
-         * @param pageSize
-         *            the page size
-         * @return the request builder
-         */
-        public B withPageSize(int pageSize) {
-            if (pageSize > 0) {
-                this.with("per_page", pageSize);
-            }
             return (B) this;
         }
     }

--- a/src/main/java/org/kohsuke/github/PagedIterable.java
+++ b/src/main/java/org/kohsuke/github/PagedIterable.java
@@ -110,6 +110,8 @@ public abstract class PagedIterable<T> implements Iterable<T> {
      * Eagerly walk {@link Iterable} and return the result in a list.
      *
      * @return the list
+     * @throws IOException
+     *             if an I/O Exception occurs
      */
     @Nonnull
     public List<T> toList() throws IOException {
@@ -120,6 +122,8 @@ public abstract class PagedIterable<T> implements Iterable<T> {
      * Eagerly walk {@link Iterable} and return the result in a set.
      *
      * @return the set
+     * @throws IOException
+     *             if an I/O Exception occurs
      */
     @Nonnull
     public Set<T> toSet() throws IOException {

--- a/src/main/java/org/kohsuke/github/PagedIterable.java
+++ b/src/main/java/org/kohsuke/github/PagedIterable.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -111,9 +112,31 @@ public abstract class PagedIterable<T> implements Iterable<T> {
      * @return the list
      */
     @Nonnull
+    public List<T> toList() throws IOException {
+        return Collections.unmodifiableList(Arrays.asList(this.toArray()));
+    }
+
+    /**
+     * Eagerly walk {@link Iterable} and return the result in a set.
+     *
+     * @return the set
+     */
+    @Nonnull
+    public Set<T> toSet() throws IOException {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.asList(this.toArray())));
+    }
+
+    /**
+     * Eagerly walk {@link Iterable} and return the result in a list.
+     *
+     * @return the list
+     * @deprecated Use {@link #toList()} instead.
+     */
+    @Nonnull
+    @Deprecated
     public List<T> asList() {
         try {
-            return Arrays.asList(this.toArray());
+            return this.toList();
         } catch (IOException e) {
             throw new GHException("Failed to retrieve list: " + e.getMessage(), e);
         }
@@ -123,10 +146,16 @@ public abstract class PagedIterable<T> implements Iterable<T> {
      * Eagerly walk {@link Iterable} and return the result in a set.
      *
      * @return the set
+     * @deprecated Use {@link #toSet()} instead.
      */
     @Nonnull
+    @Deprecated
     public Set<T> asSet() {
-        return new LinkedHashSet<>(this.asList());
+        try {
+            return this.toSet();
+        } catch (IOException e) {
+            throw new GHException("Failed to retrieve list: " + e.getMessage(), e);
+        }
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/PagedIterator.java
+++ b/src/main/java/org/kohsuke/github/PagedIterator.java
@@ -5,7 +5,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.function.Consumer;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
@@ -20,8 +22,13 @@ import javax.annotation.Nonnull;
  * @param <T>
  *            the type parameter
  */
-public abstract class PagedIterator<T> implements Iterator<T> {
+public class PagedIterator<T> implements Iterator<T> {
+
+    @Nonnull
     protected final Iterator<T[]> base;
+
+    @CheckForNull
+    private final Consumer<T> itemInitializer;
 
     /**
      * Current batch of items. Each time {@link #next()} is called the next item in this array will be returned. After
@@ -39,8 +46,9 @@ public abstract class PagedIterator<T> implements Iterator<T> {
      */
     private int nextItemIndex;
 
-    PagedIterator(Iterator<T[]> base) {
+    PagedIterator(@Nonnull Iterator<T[]> base, @CheckForNull Consumer<T> itemInitializer) {
         this.base = base;
+        this.itemInitializer = itemInitializer;
     }
 
     /**
@@ -50,7 +58,13 @@ public abstract class PagedIterator<T> implements Iterator<T> {
      * @param page
      *            the page of items to be initialized
      */
-    protected abstract void wrapUp(T[] page);
+    protected void wrapUp(T[] page) {
+        if (itemInitializer != null) {
+            for (T item : page) {
+                itemInitializer.accept(item);
+            }
+        }
+    }
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/kohsuke/github/PagedSearchIterable.java
+++ b/src/main/java/org/kohsuke/github/PagedSearchIterable.java
@@ -4,6 +4,8 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.util.Iterator;
 
+import javax.annotation.Nonnull;
+
 /**
  * {@link PagedIterable} enhanced to report search result specific information.
  *
@@ -14,16 +16,22 @@ import java.util.Iterator;
         value = { "UWF_UNWRITTEN_PUBLIC_OR_PROTECTED_FIELD", "UWF_UNWRITTEN_FIELD",
                 "UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR" },
         justification = "Constructed by JSON API")
-public abstract class PagedSearchIterable<T> extends PagedIterable<T> {
+public class PagedSearchIterable<T> extends PagedIterable<T> {
     private final GitHub root;
+
+    private final GitHubRequest request;
+
+    private final Class<? extends SearchResult<T>> receiverType;
 
     /**
      * As soon as we have any result fetched, it's set here so that we can report the total count.
      */
     private SearchResult<T> result;
 
-    PagedSearchIterable(GitHub root) {
+    PagedSearchIterable(GitHub root, GitHubRequest request, Class<? extends SearchResult<T>> receiverType) {
         this.root = root;
+        this.request = request;
+        this.receiverType = receiverType;
     }
 
     @Override
@@ -54,6 +62,14 @@ public abstract class PagedSearchIterable<T> extends PagedIterable<T> {
     private void populate() {
         if (result == null)
             iterator().hasNext();
+    }
+
+    @Nonnull
+    @Override
+    public PagedIterator<T> _iterator(int pageSize) {
+        final Iterator<T[]> adapter = adapt(
+                GitHubPageIterator.create(root.getClient(), receiverType, request, pageSize));
+        return new PagedIterator<T>(adapter, null);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -69,21 +69,6 @@ class Requester extends GitHubRequest.Builder<Requester> {
     }
 
     /**
-     * Sends a request and parses the response into an array of the given type via databinding.
-     *
-     * @param <T>
-     *            the type parameter
-     * @param type
-     *            the type
-     * @return an array of {@link T} elements
-     * @throws IOException
-     *             if the server returns 4xx/5xx responses.
-     */
-    public <T> T[] fetchArray(@Nonnull Class<T[]> type) throws IOException {
-        return toIterable(client, type, null).toArray();
-    }
-
-    /**
      * Like {@link #fetch(Class)} but updates an existing object instead of creating a new instance.
      *
      * @param <T>

--- a/src/main/java/org/kohsuke/github/Requester.java
+++ b/src/main/java/org/kohsuke/github/Requester.java
@@ -25,6 +25,7 @@ package org.kohsuke.github;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.util.Iterator;
 import java.util.function.Consumer;
 
@@ -109,9 +110,11 @@ class Requester extends GitHubRequest.Builder<Requester> {
     }
 
     /**
-     * Creates {@link PagedIterable <R>} from this builder using the provided {@link Consumer<R>}. This method and the
-     * {@link PagedIterable <R>} do not actually begin fetching data until {@link Iterator#next()} or
-     * {@link Iterator#hasNext()} are called.
+     * Creates {@link PagedIterable <R>} from this builder using the provided {@link Consumer<R>}.
+     * <p>
+     * This method and the {@link PagedIterable <R>} do not actually begin fetching data until {@link Iterator#next()}
+     * or {@link Iterator#hasNext()} are called.
+     * </p>
      *
      * @param type
      *            the type of the pages to retrieve.
@@ -122,6 +125,11 @@ class Requester extends GitHubRequest.Builder<Requester> {
      * @return the {@link PagedIterable} for this builder.
      */
     public <R> PagedIterable<R> toIterable(Class<R[]> type, Consumer<R> itemInitializer) {
-        return toIterable(this.client, type, itemInitializer);
+        try {
+            return new GitHubPageContentsIterable<>(client, build(), type, itemInitializer);
+        } catch (MalformedURLException e) {
+            throw new GHException(e.getMessage(), e);
+        }
+
     }
 }

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -117,7 +117,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
                 .create();
         assertNotNull(deployment.getCreator());
         assertNotNull(deployment.getId());
-        List<GHDeployment> deployments = repository.listDeployments(null, "master", null, "unittest").asList();
+        List<GHDeployment> deployments = repository.listDeployments(null, "master", null, "unittest").toList();
         assertNotNull(deployments);
         assertFalse(Iterables.isEmpty(deployments));
         GHDeployment unitTestDeployment = deployments.get(0);
@@ -260,7 +260,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
         GHRepository r = gitHub.getRepository("github-api/github-api");
         assertEquals("master", r.getMasterBranch());
         PagedIterable<GHPullRequest> i = r.listPullRequests(GHIssueState.CLOSED);
-        List<GHPullRequest> prs = i.asList();
+        List<GHPullRequest> prs = i.toList();
         assertNotNull(prs);
         assertTrue(prs.size() > 0);
     }
@@ -570,7 +570,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
         // state = r.createCommitStatus("ecbfdd7315ef2cf04b2be7f11a072ce0bd00c396", GHCommitState.FAILURE,
         // "http://kohsuke.org/", "testing!");
 
-        List<GHCommitStatus> lst = r.listCommitStatuses("ecbfdd7315ef2cf04b2be7f11a072ce0bd00c396").asList();
+        List<GHCommitStatus> lst = r.listCommitStatuses("ecbfdd7315ef2cf04b2be7f11a072ce0bd00c396").toList();
         state = lst.get(0);
         // System.out.println(state);
         assertEquals("testing!", state.getDescription());
@@ -778,7 +778,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
         cleanupLabel("test2");
 
         GHRepository r = gitHub.getRepository("github-api-test-org/test-labels");
-        List<GHLabel> lst = r.listLabels().asList();
+        List<GHLabel> lst = r.listLabels().toList();
         for (GHLabel l : lst) {
             // System.out.println(l.getName());
         }
@@ -887,7 +887,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
 
         List<GHReaction> l;
         // retrieval
-        l = i.listReactions().asList();
+        l = i.listReactions().toList();
         assertThat(l.size(), equalTo(1));
 
         assertThat(l.get(0).getUser().getLogin(), is("kohsuke"));
@@ -900,7 +900,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
         assertThat(a.getContent(), is(ReactionContent.HOORAY));
         a.delete();
 
-        l = i.listReactions().asList();
+        l = i.listReactions().toList();
         assertThat(l.size(), equalTo(1));
 
         a = i.createReaction(ReactionContent.PLUS_ONE);
@@ -919,7 +919,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
         assertThat(a.getUser().getLogin(), is(gitHub.getMyself().getLogin()));
         assertThat(a.getContent(), is(ReactionContent.ROCKET));
 
-        l = i.listReactions().asList();
+        l = i.listReactions().toList();
         assertThat(l.size(), equalTo(5));
         assertThat(l.get(0).getUser().getLogin(), is("kohsuke"));
         assertThat(l.get(0).getContent(), is(ReactionContent.HEART));
@@ -937,7 +937,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
         l.get(3).delete();
         l.get(4).delete();
 
-        l = i.listReactions().asList();
+        l = i.listReactions().toList();
         assertThat(l.size(), equalTo(1));
     }
 

--- a/src/test/java/org/kohsuke/github/GHAppTest.java
+++ b/src/test/java/org/kohsuke/github/GHAppTest.java
@@ -43,7 +43,7 @@ public class GHAppTest extends AbstractGitHubWireMockTest {
     @Test
     public void listInstallations() throws IOException {
         GHApp app = gitHub.getApp();
-        List<GHAppInstallation> installations = app.listInstallations().asList();
+        List<GHAppInstallation> installations = app.listInstallations().toList();
         assertThat(installations.size(), is(1));
 
         GHAppInstallation appInstallation = installations.get(0);

--- a/src/test/java/org/kohsuke/github/GHIssueEventTest.java
+++ b/src/test/java/org/kohsuke/github/GHIssueEventTest.java
@@ -20,7 +20,7 @@ public class GHIssueEventTest extends AbstractGitHubWireMockTest {
         issue.addLabels("test-label");
 
         // Test that the events are present.
-        List<GHIssueEvent> list = issue.listEvents().asList();
+        List<GHIssueEvent> list = issue.listEvents().toList();
         assertEquals(1, list.size());
 
         GHIssueEvent event = list.get(0);
@@ -39,7 +39,7 @@ public class GHIssueEventTest extends AbstractGitHubWireMockTest {
     @Test
     public void testRepositoryEvents() throws Exception {
         GHRepository repo = getRepository();
-        List<GHIssueEvent> list = repo.listIssueEvents().asList();
+        List<GHIssueEvent> list = repo.listIssueEvents().toList();
         assertTrue(list.size() > 0);
 
         int i = 0;

--- a/src/test/java/org/kohsuke/github/GHMarketplacePlanTest.java
+++ b/src/test/java/org/kohsuke/github/GHMarketplacePlanTest.java
@@ -28,30 +28,30 @@ public class GHMarketplacePlanTest extends AbstractGitHubWireMockTest {
 
     @Test
     public void listMarketplacePlans() throws IOException {
-        List<GHMarketplacePlan> plans = gitHub.listMarketplacePlans().asList();
+        List<GHMarketplacePlan> plans = gitHub.listMarketplacePlans().toList();
         assertEquals(3, plans.size());
         plans.forEach(this::testMarketplacePlan);
     }
 
     @Test
     public void listAccounts() throws IOException {
-        List<GHMarketplacePlan> plans = gitHub.listMarketplacePlans().asList();
+        List<GHMarketplacePlan> plans = gitHub.listMarketplacePlans().toList();
         assertEquals(3, plans.size());
-        List<GHMarketplaceAccountPlan> marketplaceUsers = plans.get(0).listAccounts().createRequest().asList();
+        List<GHMarketplaceAccountPlan> marketplaceUsers = plans.get(0).listAccounts().createRequest().toList();
         assertEquals(2, marketplaceUsers.size());
         marketplaceUsers.forEach(this::testMarketplaceAccount);
     }
 
     @Test
     public void listAccountsWithDirection() throws IOException {
-        List<GHMarketplacePlan> plans = gitHub.listMarketplacePlans().asList();
+        List<GHMarketplacePlan> plans = gitHub.listMarketplacePlans().toList();
         assertEquals(3, plans.size());
 
         for (GHMarketplacePlan plan : plans) {
             List<GHMarketplaceAccountPlan> marketplaceUsers = plan.listAccounts()
                     .direction(DESC)
                     .createRequest()
-                    .asList();
+                    .toList();
             assertEquals(2, marketplaceUsers.size());
             marketplaceUsers.forEach(this::testMarketplaceAccount);
         }
@@ -60,7 +60,7 @@ public class GHMarketplacePlanTest extends AbstractGitHubWireMockTest {
 
     @Test
     public void listAccountsWithSortAndDirection() throws IOException {
-        List<GHMarketplacePlan> plans = gitHub.listMarketplacePlans().asList();
+        List<GHMarketplacePlan> plans = gitHub.listMarketplacePlans().toList();
         assertEquals(3, plans.size());
 
         for (GHMarketplacePlan plan : plans) {
@@ -68,7 +68,7 @@ public class GHMarketplacePlanTest extends AbstractGitHubWireMockTest {
                     .sort(UPDATED)
                     .direction(DESC)
                     .createRequest()
-                    .asList();
+                    .toList();
             assertEquals(2, marketplaceUsers.size());
             marketplaceUsers.forEach(this::testMarketplaceAccount);
         }

--- a/src/test/java/org/kohsuke/github/GHPullRequestTest.java
+++ b/src/test/java/org/kohsuke/github/GHPullRequestTest.java
@@ -56,7 +56,7 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
         assertThat(p2.getNumber(), is(p.getNumber()));
         assertThat(p2.isDraft(), is(true));
 
-        p = repo.queryPullRequests().state(GHIssueState.OPEN).head("test/stable").list().asList().get(0);
+        p = repo.queryPullRequests().state(GHIssueState.OPEN).head("test/stable").list().toList().get(0);
         assertThat(p2.getNumber(), is(p.getNumber()));
         assertThat(p.isDraft(), is(true));
 
@@ -91,14 +91,14 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
         assertThat(draftReview.getState(), is(GHPullRequestReviewState.PENDING));
         assertThat(draftReview.getBody(), is("Some draft review"));
         assertThat(draftReview.getCommitId(), notNullValue());
-        List<GHPullRequestReview> reviews = p.listReviews().asList();
+        List<GHPullRequestReview> reviews = p.listReviews().toList();
         assertThat(reviews.size(), is(1));
         GHPullRequestReview review = reviews.get(0);
         assertThat(review.getState(), is(GHPullRequestReviewState.PENDING));
         assertThat(review.getBody(), is("Some draft review"));
         assertThat(review.getCommitId(), notNullValue());
         draftReview.submit("Some review comment", GHPullRequestReviewEvent.COMMENT);
-        List<GHPullRequestReviewComment> comments = review.listReviewComments().asList();
+        List<GHPullRequestReviewComment> comments = review.listReviewComments().toList();
         assertEquals(1, comments.size());
         GHPullRequestReviewComment comment = comments.get(0);
         assertEquals("Some niggle", comment.getBody());
@@ -111,21 +111,21 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
         String name = "pullRequestReviewComments";
         GHPullRequest p = getRepository().createPullRequest(name, "test/stable", "master", "## test");
         // System.out.println(p.getUrl());
-        assertTrue(p.listReviewComments().asList().isEmpty());
+        assertTrue(p.listReviewComments().toList().isEmpty());
         p.createReviewComment("Sample review comment", p.getHead().getSha(), "README.md", 1);
-        List<GHPullRequestReviewComment> comments = p.listReviewComments().asList();
+        List<GHPullRequestReviewComment> comments = p.listReviewComments().toList();
         assertEquals(1, comments.size());
         GHPullRequestReviewComment comment = comments.get(0);
         assertEquals("Sample review comment", comment.getBody());
 
         comment.update("Updated review comment");
-        comments = p.listReviewComments().asList();
+        comments = p.listReviewComments().toList();
         assertEquals(1, comments.size());
         comment = comments.get(0);
         assertEquals("Updated review comment", comment.getBody());
 
         comment.delete();
-        comments = p.listReviewComments().asList();
+        comments = p.listReviewComments().toList();
         assertTrue(comments.isEmpty());
     }
 
@@ -254,7 +254,7 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
                 .head("github-api-test-org:test/stable")
                 .base("master")
                 .list()
-                .asList();
+                .toList();
         assertNotNull(prs);
         assertEquals(1, prs.size());
         assertEquals("test/stable", prs.get(0).getHead().getRef());
@@ -273,7 +273,7 @@ public class GHPullRequestTest extends AbstractGitHubWireMockTest {
                 .head("test/stable")
                 .base("master")
                 .list()
-                .asList();
+                .toList();
         assertNotNull(prs);
         assertEquals(1, prs.size());
         assertEquals("test/stable", prs.get(0).getHead().getRef());

--- a/src/test/java/org/kohsuke/github/GHRepositoryStatisticsTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryStatisticsTest.java
@@ -24,7 +24,7 @@ public class GHRepositoryStatisticsTest extends AbstractGitHubWireMockTest {
         }
 
         // check the statistics are accurate
-        List<GHRepositoryStatistics.ContributorStats> list = stats.asList();
+        List<GHRepositoryStatistics.ContributorStats> list = stats.toList();
         assertEquals(99, list.size());
 
         // find a particular developer
@@ -79,7 +79,7 @@ public class GHRepositoryStatisticsTest extends AbstractGitHubWireMockTest {
         }
 
         // check the statistics are accurate
-        List<GHRepositoryStatistics.CommitActivity> list = stats.asList();
+        List<GHRepositoryStatistics.CommitActivity> list = stats.toList();
 
         // TODO: Return this as a map with the timestamp as the key.
         // Either that or wrap in an object an accessor method.

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -394,7 +394,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
     @Test
     public void listRefs() throws Exception {
         GHRepository repo = getTempRepository();
-        List<GHRef> refs = repo.listRefs().asList();
+        List<GHRef> refs = repo.listRefs().toList();
         assertThat(refs, notNullValue());
         assertThat(refs.size(), equalTo(1));
         assertThat(refs.get(0).getRef(), equalTo("refs/heads/master"));
@@ -403,7 +403,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
     @Test
     public void listRefsHeads() throws Exception {
         GHRepository repo = getTempRepository();
-        List<GHRef> refs = repo.listRefs("heads").asList();
+        List<GHRef> refs = repo.listRefs("heads").toList();
         assertThat(refs, notNullValue());
         assertThat(refs.size(), equalTo(1));
         assertThat(refs.get(0).getRef(), equalTo("refs/heads/master"));
@@ -411,6 +411,19 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
 
     @Test
     public void listRefsEmptyTags() throws Exception {
+        try {
+            GHRepository repo = getTempRepository();
+            repo.listRefs("tags").toList();
+            fail();
+        } catch (Exception e) {
+            assertThat(e, instanceOf(GHFileNotFoundException.class));
+            assertThat(e.getMessage(),
+                    containsString("/repos/github-api-test-org/temp-listRefsEmptyTags/git/refs/tags"));
+        }
+    }
+
+    @Test
+    public void listRefsEmptyTagsAsList() throws Exception {
         try {
             GHRepository repo = getTempRepository();
             repo.listRefs("tags").asList();
@@ -427,7 +440,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
     @Test
     public void listTagsEmpty() throws Exception {
         GHRepository repo = getTempRepository();
-        List<GHTag> refs = repo.listTags().asList();
+        List<GHTag> refs = repo.listTags().toList();
         assertThat(refs, notNullValue());
         assertThat(refs.size(), equalTo(0));
     }
@@ -435,7 +448,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
     @Test
     public void listTags() throws Exception {
         GHRepository repo = getRepository();
-        List<GHTag> refs = repo.listTags().withPageSize(33).asList();
+        List<GHTag> refs = repo.listTags().withPageSize(33).toList();
         assertThat(refs, notNullValue());
         assertThat(refs.size(), greaterThan(90));
     }
@@ -459,7 +472,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
     @Test
     public void listCollaborators() throws Exception {
         GHRepository repo = getRepository();
-        List<GHUser> collaborators = repo.listCollaborators().asList();
+        List<GHUser> collaborators = repo.listCollaborators().toList();
         assertThat(collaborators.size(), greaterThan(10));
     }
 }

--- a/src/test/java/org/kohsuke/github/GHRepositoryTest.java
+++ b/src/test/java/org/kohsuke/github/GHRepositoryTest.java
@@ -420,10 +420,7 @@ public class GHRepositoryTest extends AbstractGitHubWireMockTest {
             assertThat(e.getMessage(),
                     containsString("/repos/github-api-test-org/temp-listRefsEmptyTags/git/refs/tags"));
         }
-    }
 
-    @Test
-    public void listRefsEmptyTagsAsList() throws Exception {
         try {
             GHRepository repo = getTempRepository();
             repo.listRefs("tags").asList();

--- a/src/test/java/org/kohsuke/github/GitHubTest.java
+++ b/src/test/java/org/kohsuke/github/GitHubTest.java
@@ -112,7 +112,7 @@ public class GitHubTest extends AbstractGitHubWireMockTest {
 
     @Test
     public void getMyMarketplacePurchases() throws IOException {
-        List<GHMarketplaceUserPurchase> userPurchases = gitHub.getMyMarketplacePurchases().asList();
+        List<GHMarketplaceUserPurchase> userPurchases = gitHub.getMyMarketplacePurchases().toList();
         assertEquals(2, userPurchases.size());
 
         for (GHMarketplaceUserPurchase userPurchase : userPurchases) {


### PR DESCRIPTION
# Description 
`asList()` and `asSet` do not throw `IOException` but they are just as likely as any other server interaction to get errors.  They wrap their exceptions in `GHException` which is really not needed and generally just causes an extra layer of stack trace.  I'm deprecating them in favor of `toList()` and `toSet()` which throw `IOException` just like `toArray()`.   

While I was at this I also did some internal clean up around lists and arrays. For example, `fetchArray` is no longer needed.  `PagedIterable().toArray()` does the same thing now. 

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn -D enable-ci clean install site` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.
