### PR TITLE
Enable injection of GitHub and other values into mapping

### DIFF
--- a/src/main/java/org/kohsuke/github/GHEventInfo.java
+++ b/src/main/java/org/kohsuke/github/GHEventInfo.java
@@ -142,7 +142,7 @@ public class GHEventInfo {
      *             if payload cannot be parsed
      */
     public <T extends GHEventPayload> T getPayload(Class<T> type) throws IOException {
-        T v = GitHubClient.getMappingObjectReader().readValue(payload.traverse(), type);
+        T v = GitHubClient.getMappingObjectReader(root).readValue(payload.traverse(), type);
         v.wrapUp(root);
         return v;
     }

--- a/src/main/java/org/kohsuke/github/GHGistBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHGistBuilder.java
@@ -72,6 +72,6 @@ public class GHGistBuilder {
      */
     public GHGist create() throws IOException {
         req.with("files", files);
-        return req.withUrlPath("/gists").fetch(GHGist.class).wrapUp(root);
+        return req.withUrlPath("/gists").fetch(GHGist.class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHGistUpdater.java
+++ b/src/main/java/org/kohsuke/github/GHGistUpdater.java
@@ -94,6 +94,6 @@ public class GHGistUpdater {
      */
     public GHGist update() throws IOException {
         builder.with("files", files);
-        return builder.method("PATCH").withUrlPath(base.getApiTailUrl("")).fetch(GHGist.class).wrap(base.owner);
+        return builder.method("PATCH").withUrlPath(base.getApiTailUrl("")).fetch(GHGist.class);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHUser.java
+++ b/src/main/java/org/kohsuke/github/GHUser.java
@@ -217,7 +217,7 @@ public class GHUser extends GHPerson {
     public PagedIterable<GHGist> listGists() throws IOException {
         return root.createRequest()
                 .withUrlPath(String.format("/users/%s/gists", login))
-                .toIterable(GHGist[].class, item -> item.wrapUp(this));
+                .toIterable(GHGist[].class, null);
     }
 
     @Override

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -1184,7 +1184,7 @@ public class GitHub {
 
     @Nonnull
     Requester createRequest() {
-        return new Requester(client).inject(this);
+        return new Requester(client).injectMappingValue(this);
     }
 
     GHUser intern(GHUser user) throws IOException {

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -772,7 +772,7 @@ public class GitHub {
      *             the io exception
      */
     public <T extends GHEventPayload> T parseEventPayload(Reader r, Class<T> type) throws IOException {
-        T t = GitHubClient.getMappingObjectReader().forType(type).readValue(r);
+        T t = GitHubClient.getMappingObjectReader(this).forType(type).readValue(r);
         t.wrapUp(this);
         return t;
     }
@@ -1184,7 +1184,7 @@ public class GitHub {
 
     @Nonnull
     Requester createRequest() {
-        return new Requester(client);
+        return new Requester(client).inject(this);
     }
 
     GHUser intern(GHUser user) throws IOException {

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -743,7 +743,7 @@ public class GitHub {
      *             the io exception
      */
     public GHGist getGist(String id) throws IOException {
-        return createRequest().withUrlPath("/gists/" + id).fetch(GHGist.class).wrapUp(this);
+        return createRequest().withUrlPath("/gists/" + id).fetch(GHGist.class);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GitHubClient.java
+++ b/src/main/java/org/kohsuke/github/GitHubClient.java
@@ -742,7 +742,7 @@ abstract class GitHubClient {
 
         if (responseInfo != null) {
             injected.put(GitHubResponse.ResponseInfo.class.getName(), responseInfo);
-            injected.putAll(responseInfo.request().injected());
+            injected.putAll(responseInfo.request().injectedMappingValues());
         }
         return MAPPER.reader(new InjectableValues.Std(injected));
     }

--- a/src/main/java/org/kohsuke/github/GitHubClient.java
+++ b/src/main/java/org/kohsuke/github/GitHubClient.java
@@ -706,11 +706,16 @@ abstract class GitHubClient {
     /**
      * Helper for {@link #getMappingObjectReader(GitHubResponse.ResponseInfo)}
      *
+     * @param root
+     *            the root GitHub object for this reader
+     *
      * @return an {@link ObjectReader} instance that can be further configured.
      */
     @Nonnull
-    static ObjectReader getMappingObjectReader() {
-        return getMappingObjectReader(null);
+    static ObjectReader getMappingObjectReader(@Nonnull GitHub root) {
+        ObjectReader reader = getMappingObjectReader((GitHubResponse.ResponseInfo) null);
+        ((InjectableValues.Std) reader.getInjectableValues()).addValue(GitHub.class, root);
+        return reader;
     }
 
     /**
@@ -724,13 +729,21 @@ abstract class GitHubClient {
      *
      * @param responseInfo
      *            the {@link GitHubResponse.ResponseInfo} to inject for this reader.
+     *
      * @return an {@link ObjectReader} instance that can be further configured.
      */
     @Nonnull
     static ObjectReader getMappingObjectReader(@CheckForNull GitHubResponse.ResponseInfo responseInfo) {
-        InjectableValues.Std inject = new InjectableValues.Std();
-        inject.addValue(GitHubResponse.ResponseInfo.class, responseInfo);
+        Map<String, Object> injected = new HashMap<>();
 
-        return MAPPER.reader(inject);
+        // Required or many things break
+        injected.put(GitHubResponse.ResponseInfo.class.getName(), null);
+        injected.put(GitHub.class.getName(), null);
+
+        if (responseInfo != null) {
+            injected.put(GitHubResponse.ResponseInfo.class.getName(), responseInfo);
+            injected.putAll(responseInfo.request().injected());
+        }
+        return MAPPER.reader(new InjectableValues.Std(injected));
     }
 }

--- a/src/main/java/org/kohsuke/github/GitHubRequest.java
+++ b/src/main/java/org/kohsuke/github/GitHubRequest.java
@@ -1,5 +1,6 @@
 package org.kohsuke.github;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.InputStream;
@@ -40,7 +41,7 @@ class GitHubRequest {
     private static final List<String> METHODS_WITHOUT_BODY = asList("GET", "DELETE");
     private final List<Entry> args;
     private final Map<String, String> headers;
-    private final Map<String, Object> injected;
+    private final Map<String, Object> injectedMappingValues;
     private final String apiUrl;
     private final String urlPath;
     private final String method;
@@ -51,7 +52,7 @@ class GitHubRequest {
 
     private GitHubRequest(@Nonnull List<Entry> args,
             @Nonnull Map<String, String> headers,
-            @Nonnull Map<String, Object> injected,
+            @Nonnull Map<String, Object> injectedMappingValues,
             @Nonnull String apiUrl,
             @Nonnull String urlPath,
             @Nonnull String method,
@@ -59,7 +60,7 @@ class GitHubRequest {
             boolean forceBody) throws MalformedURLException {
         this.args = Collections.unmodifiableList(new ArrayList<>(args));
         this.headers = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
-        this.injected = Collections.unmodifiableMap(new LinkedHashMap<>(injected));
+        this.injectedMappingValues = Collections.unmodifiableMap(new LinkedHashMap<>(injectedMappingValues));
         this.apiUrl = apiUrl;
         this.urlPath = urlPath;
         this.method = method;
@@ -145,8 +146,8 @@ class GitHubRequest {
      * @return the {@link Map} of headers
      */
     @Nonnull
-    public Map<String, Object> injected() {
-        return injected;
+    public Map<String, Object> injectedMappingValues() {
+        return injectedMappingValues;
     }
 
     /**
@@ -216,7 +217,7 @@ class GitHubRequest {
      * @return a {@link Builder} based on this request.
      */
     public Builder<?> toBuilder() {
-        return new Builder<>(args, headers, injected, apiUrl, urlPath, method, body, forceBody);
+        return new Builder<>(args, headers, injectedMappingValues, apiUrl, urlPath, method, body, forceBody);
     }
 
     private String buildTailApiUrl() {
@@ -265,7 +266,7 @@ class GitHubRequest {
          * Injected local data map
          */
         @Nonnull
-        private final Map<String, Object> injected;
+        private final Map<String, Object> injectedMappingValues;
 
         /**
          * The base GitHub API for this request.
@@ -299,7 +300,7 @@ class GitHubRequest {
 
         private Builder(@Nonnull List<Entry> args,
                 @Nonnull Map<String, String> headers,
-                @Nonnull Map<String, Object> injected,
+                @Nonnull Map<String, Object> injectedMappingValues,
                 @Nonnull String apiUrl,
                 @Nonnull String urlPath,
                 @Nonnull String method,
@@ -307,7 +308,7 @@ class GitHubRequest {
                 boolean forceBody) {
             this.args = new ArrayList<>(args);
             this.headers = new LinkedHashMap<>(headers);
-            this.injected = new LinkedHashMap<>(injected);
+            this.injectedMappingValues = new LinkedHashMap<>(injectedMappingValues);
             this.apiUrl = apiUrl;
             this.urlPath = urlPath;
             this.method = method;
@@ -323,7 +324,7 @@ class GitHubRequest {
          *             if the GitHub API URL cannot be constructed
          */
         public GitHubRequest build() throws MalformedURLException {
-            return new GitHubRequest(args, headers, injected, apiUrl, urlPath, method, body, forceBody);
+            return new GitHubRequest(args, headers, injectedMappingValues, apiUrl, urlPath, method, body, forceBody);
         }
 
         /**
@@ -373,8 +374,21 @@ class GitHubRequest {
          *            the value
          * @return the request builder
          */
-        public B inject(Object value) {
-            this.injected.put(value.getClass().getName(), value);
+        public B injectMappingValue(@NonNull Object value) {
+            return injectMappingValue(value.getClass().getName(), value);
+        }
+
+        /**
+         * Object to inject into binding.
+         *
+         * @param name
+         *            the name
+         * @param value
+         *            the value
+         * @return the request builder
+         */
+        public B injectMappingValue(@NonNull String name, Object value) {
+            this.injectedMappingValues.put(name, value);
             return (B) this;
         }
 


### PR DESCRIPTION
# Description 
Progress on #599.  While there will alway be a need for late binding in some scenarios, binding of `GitHub` reference can always be done during mapping.   Other actions that were being done after mapping can also sometimes be done during mapping by using a constructor.  Values not initialized in the constructor are bound via reflection as they always were.

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn -D enable-ci clean install site` locally. This may reformat your code, commit those changes. If this command doesn't succeed, your change will not pass CI.
