### PR TITLE
Deprecate set methods that should not be public

### DIFF
--- a/src/main/java/org/kohsuke/github/GHApp.java
+++ b/src/main/java/org/kohsuke/github/GHApp.java
@@ -39,7 +39,9 @@ public class GHApp extends GHObject {
      *
      * @param owner
      *            the owner
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setOwner(GHUser owner) {
         this.owner = owner;
     }
@@ -58,7 +60,9 @@ public class GHApp extends GHObject {
      *
      * @param name
      *            the name
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setName(String name) {
         this.name = name;
     }
@@ -77,7 +81,9 @@ public class GHApp extends GHObject {
      *
      * @param description
      *            the description
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setDescription(String description) {
         this.description = description;
     }
@@ -96,7 +102,9 @@ public class GHApp extends GHObject {
      *
      * @param externalUrl
      *            the external url
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setExternalUrl(String externalUrl) {
         this.externalUrl = externalUrl;
     }
@@ -115,7 +123,9 @@ public class GHApp extends GHObject {
      *
      * @param events
      *            the events
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setEvents(List<GHEvent> events) {
         this.events = events;
     }
@@ -134,7 +144,9 @@ public class GHApp extends GHObject {
      *
      * @param installationsCount
      *            the installations count
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setInstallationsCount(long installationsCount) {
         this.installationsCount = installationsCount;
     }
@@ -157,7 +169,9 @@ public class GHApp extends GHObject {
      *
      * @param permissions
      *            the permissions
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setPermissions(Map<String, String> permissions) {
         this.permissions = permissions;
     }

--- a/src/main/java/org/kohsuke/github/GHAppInstallation.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallation.java
@@ -59,7 +59,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param root
      *            the root
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setRoot(GitHub root) {
         this.root = root;
     }
@@ -78,7 +80,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param account
      *            the account
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setAccount(GHUser account) {
         this.account = account;
     }
@@ -97,7 +101,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param accessTokenUrl
      *            the access token url
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setAccessTokenUrl(String accessTokenUrl) {
         this.accessTokenUrl = accessTokenUrl;
     }
@@ -116,7 +122,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param repositoriesUrl
      *            the repositories url
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setRepositoriesUrl(String repositoriesUrl) {
         this.repositoriesUrl = repositoriesUrl;
     }
@@ -135,7 +143,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param appId
      *            the app id
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setAppId(long appId) {
         this.appId = appId;
     }
@@ -154,7 +164,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param targetId
      *            the target id
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setTargetId(long targetId) {
         this.targetId = targetId;
     }
@@ -173,7 +185,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param targetType
      *            the target type
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setTargetType(GHTargetType targetType) {
         this.targetType = targetType;
     }
@@ -192,7 +206,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param permissions
      *            the permissions
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setPermissions(Map<String, GHPermissionType> permissions) {
         this.permissions = permissions;
     }
@@ -211,7 +227,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param events
      *            the events
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setEvents(List<GHEvent> events) {
         this.events = events;
     }
@@ -230,7 +248,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param singleFileName
      *            the single file name
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setSingleFileName(String singleFileName) {
         this.singleFileName = singleFileName;
     }
@@ -249,7 +269,9 @@ public class GHAppInstallation extends GHObject {
      *
      * @param repositorySelection
      *            the repository selection
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setRepositorySelection(GHRepositorySelection repositorySelection) {
         this.repositorySelection = repositorySelection;
     }

--- a/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
+++ b/src/main/java/org/kohsuke/github/GHAppInstallationToken.java
@@ -37,7 +37,9 @@ public class GHAppInstallationToken {
      *
      * @param root
      *            the root
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setRoot(GitHub root) {
         this.root = root;
     }
@@ -56,7 +58,9 @@ public class GHAppInstallationToken {
      *
      * @param permissions
      *            the permissions
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setPermissions(Map<String, String> permissions) {
         this.permissions = permissions;
     }
@@ -75,7 +79,9 @@ public class GHAppInstallationToken {
      *
      * @param token
      *            the token
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setToken(String token) {
         this.token = token;
     }
@@ -94,7 +100,9 @@ public class GHAppInstallationToken {
      *
      * @param repositories
      *            the repositories
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setRepositories(List<GHRepository> repositories) {
         this.repositories = repositories;
     }
@@ -113,7 +121,9 @@ public class GHAppInstallationToken {
      *
      * @param repositorySelection
      *            the repository selection
+     * @deprecated Do not use this method. It was added due to incomplete understanding of Jackson binding.
      */
+    @Deprecated
     public void setRepositorySelection(GHRepositorySelection repositorySelection) {
         this.repositorySelection = repositorySelection;
     }


### PR DESCRIPTION
# Description 
These set methods should never have been made public. They serve no purpose. 

@timja @PauloMigAlmeida 

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

