### PR TITLE
Add global node_id to GHObject + GHTeam extends GHObject

### DIFF
--- a/src/main/java/org/kohsuke/github/GHObject.java
+++ b/src/main/java/org/kohsuke/github/GHObject.java
@@ -28,6 +28,7 @@ public abstract class GHObject {
 
     protected String url;
     protected long id;
+    protected String node_id;
     protected String created_at;
     protected String updated_at;
 
@@ -121,6 +122,17 @@ public abstract class GHObject {
     @WithBridgeMethods(value = { String.class, int.class }, adapterMethod = "longToStringOrInt")
     public long getId() {
         return id;
+    }
+
+    /**
+     * Get Global node_id from Github object.
+     * 
+     * @see <a href="https://developer.github.com/v4/guides/using-global-node-ids/">Using Global Node IDs</a>
+     * 
+     * @return Global Node ID.
+     */
+    public String getNodeId() {
+        return node_id;
     }
 
     @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Bridge method of getId")

--- a/src/main/java/org/kohsuke/github/GHObject.java
+++ b/src/main/java/org/kohsuke/github/GHObject.java
@@ -115,6 +115,17 @@ public abstract class GHObject {
     }
 
     /**
+     * Get Global node_id from Github object.
+     *
+     * @see <a href="https://developer.github.com/v4/guides/using-global-node-ids/">Using Global Node IDs</a>
+     *
+     * @return Global Node ID.
+     */
+    public String getNodeId() {
+        return node_id;
+    }
+
+    /**
      * Gets id.
      *
      * @return Unique ID number of this resource.
@@ -122,17 +133,6 @@ public abstract class GHObject {
     @WithBridgeMethods(value = { String.class, int.class }, adapterMethod = "longToStringOrInt")
     public long getId() {
         return id;
-    }
-
-    /**
-     * Get Global node_id from Github object.
-     * 
-     * @see <a href="https://developer.github.com/v4/guides/using-global-node-ids/">Using Global Node IDs</a>
-     * 
-     * @return Global Node ID.
-     */
-    public String getNodeId() {
-        return node_id;
     }
 
     @SuppressFBWarnings(value = "UPM_UNCALLED_PRIVATE_METHOD", justification = "Bridge method of getId")

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -127,7 +127,7 @@ public class GHOrganization extends GHPerson {
                 .withUrlPath(String.format("/orgs/%s/teams", login))
                 .toIterable(GHTeam[].class, item -> item.wrapUp(this));
     }
-
+    
     /**
      * Gets a single team by ID.
      *
@@ -144,6 +144,21 @@ public class GHOrganization extends GHPerson {
                 .withUrlPath(String.format("/organizations/%d/team/%d", id, teamId))
                 .fetch(GHTeam.class)
                 .wrapUp(this);
+    }
+    
+    /**
+     * Gets a single team by ID.
+     *
+     * @param teamId
+     *            id of the team that we want to query for
+     * @return the team
+     * @throws IOException
+     *             the io exception
+     *
+     * @deprecated Use {@link GHOrganization#getTeam(long)}
+     */
+    public GHTeam getTeam(int teamId) throws IOException {
+        return getTeam((long)teamId);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -139,7 +139,7 @@ public class GHOrganization extends GHPerson {
      *
      * @see <a href= "https://developer.github.com/v3/teams/#get-team-by-name">documentation</a>
      */
-    public GHTeam getTeam(int teamId) throws IOException {
+    public GHTeam getTeam(long teamId) throws IOException {
         return root.createRequest()
                 .withUrlPath(String.format("/organizations/%d/team/%d", id, teamId))
                 .fetch(GHTeam.class)

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -137,13 +137,11 @@ public class GHOrganization extends GHPerson {
      * @throws IOException
      *             the io exception
      *
-     * @see <a href= "https://developer.github.com/v3/teams/#get-team-by-name">documentation</a>
+     * @deprecated Use {@link GHOrganization#getTeam(long)}
      */
-    public GHTeam getTeam(long teamId) throws IOException {
-        return root.createRequest()
-                .withUrlPath(String.format("/organizations/%d/team/%d", id, teamId))
-                .fetch(GHTeam.class)
-                .wrapUp(this);
+    @Deprecated
+    public GHTeam getTeam(int teamId) throws IOException {
+        return getTeam((long) teamId);
     }
 
     /**
@@ -155,10 +153,13 @@ public class GHOrganization extends GHPerson {
      * @throws IOException
      *             the io exception
      *
-     * @deprecated Use {@link GHOrganization#getTeam(long)}
+     * @see <a href= "https://developer.github.com/v3/teams/#get-team-by-name">documentation</a>
      */
-    public GHTeam getTeam(int teamId) throws IOException {
-        return getTeam((long) teamId);
+    public GHTeam getTeam(long teamId) throws IOException {
+        return root.createRequest()
+                .withUrlPath(String.format("/organizations/%d/team/%d", id, teamId))
+                .fetch(GHTeam.class)
+                .wrapUp(this);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHOrganization.java
+++ b/src/main/java/org/kohsuke/github/GHOrganization.java
@@ -127,7 +127,7 @@ public class GHOrganization extends GHPerson {
                 .withUrlPath(String.format("/orgs/%s/teams", login))
                 .toIterable(GHTeam[].class, item -> item.wrapUp(this));
     }
-    
+
     /**
      * Gets a single team by ID.
      *
@@ -145,7 +145,7 @@ public class GHOrganization extends GHPerson {
                 .fetch(GHTeam.class)
                 .wrapUp(this);
     }
-    
+
     /**
      * Gets a single team by ID.
      *
@@ -158,7 +158,7 @@ public class GHOrganization extends GHPerson {
      * @deprecated Use {@link GHOrganization#getTeam(long)}
      */
     public GHTeam getTeam(int teamId) throws IOException {
-        return getTeam((long)teamId);
+        return getTeam((long) teamId);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHProject.java
+++ b/src/main/java/org/kohsuke/github/GHProject.java
@@ -42,7 +42,6 @@ public class GHProject extends GHObject {
 
     private String owner_url;
     private String html_url;
-    private String node_id;
     private String name;
     private String body;
     private int number;
@@ -105,10 +104,12 @@ public class GHProject extends GHObject {
     /**
      * Gets node id.
      *
+     * @deprecated Use {@link GHObject#getNodeId()}
      * @return the node id
      */
+    @Deprecated
     public String getNode_id() {
-        return node_id;
+        return getNodeId();
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHTeam.java
+++ b/src/main/java/org/kohsuke/github/GHTeam.java
@@ -1,6 +1,7 @@
 package org.kohsuke.github;
 
 import java.io.IOException;
+import java.net.URL;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
@@ -10,14 +11,14 @@ import java.util.TreeMap;
  *
  * @author Kohsuke Kawaguchi
  */
-public class GHTeam implements Refreshable {
+public class GHTeam extends GHObject implements Refreshable {
+    private String html_url;
     private String name;
     private String permission;
     private String slug;
     private String description;
     private Privacy privacy;
 
-    private int id;
     private GHOrganization organization; // populated by GET /user/teams where Teams+Orgs are returned together
 
     protected /* final */ GitHub root;
@@ -127,15 +128,6 @@ public class GHTeam implements Refreshable {
      */
     public void setPrivacy(Privacy privacy) throws IOException {
         root.createRequest().method("PATCH").with("privacy", privacy).withUrlPath(api("")).send();
-    }
-
-    /**
-     * Gets id.
-     *
-     * @return the id
-     */
-    public int getId() {
-        return id;
     }
 
     /**
@@ -320,5 +312,10 @@ public class GHTeam implements Refreshable {
     @Override
     public void refresh() throws IOException {
         root.createRequest().withUrlPath(api("")).fetchInto(this).wrapUp(root);
+    }
+
+    @Override
+    public URL getHtmlUrl() {
+        return GitHubClient.parseURL(html_url);
     }
 }

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -731,7 +731,7 @@ public class GitHub {
      * @see <a href= "https://developer.github.com/v3/teams/#get-team-legacy">deprecation notice</a>
      */
     @Deprecated
-    public GHTeam getTeam(int id) throws IOException {
+    public GHTeam getTeam(long id) throws IOException {
         return createRequest().withUrlPath("/teams/" + id).fetch(GHTeam.class).wrapUp(this);
     }
 

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -413,7 +413,7 @@ public class GitHub {
      * @throws IOException
      *             the io exception
      */
-    @WithBridgeMethods(GHUser.class)
+    @WithBridgeMethods(value = GHUser.class)
     public GHMyself getMyself() throws IOException {
         client.requireCredential();
         synchronized (this) {

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -731,7 +731,7 @@ public class GitHub {
      * @see <a href= "https://developer.github.com/v3/teams/#get-team-legacy">deprecation notice</a>
      */
     @Deprecated
-    public GHTeam getTeam(long id) throws IOException {
+    public GHTeam getTeam(int id) throws IOException {
         return createRequest().withUrlPath("/teams/" + id).fetch(GHTeam.class).wrapUp(this);
     }
 

--- a/src/main/java/org/kohsuke/github/GitHub.java
+++ b/src/main/java/org/kohsuke/github/GitHub.java
@@ -727,7 +727,7 @@ public class GitHub {
      * @throws IOException
      *             the io exception
      * 
-     * @deprecated Use {@link GHOrganization#getTeam(int)}
+     * @deprecated Use {@link GHOrganization#getTeam(long)}
      * @see <a href= "https://developer.github.com/v3/teams/#get-team-legacy">deprecation notice</a>
      */
     @Deprecated

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -308,6 +308,13 @@ public class AppTest extends AbstractGitHubWireMockTest {
 
         assertEquals(teamByName.getId(), teamById.getId());
         assertEquals(teamByName.getDescription(), teamById.getDescription());
+
+        GHTeam teamById2 = organization.getTeam((int) teamByName.getId());
+        assertNotNull(teamById2);
+
+        assertEquals(teamByName.getId(), teamById2.getId());
+        assertEquals(teamByName.getDescription(), teamById2.getDescription());
+
     }
 
     @Ignore("Needs mocking check")

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -291,7 +291,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
         GHOrganization organization = gitHub.getOrganization(GITHUB_API_TEST_ORG);
         GHTeam teamByName = organization.getTeams().get("Core Developers");
 
-        GHTeam teamById = gitHub.getTeam(teamByName.getId());
+        GHTeam teamById = gitHub.getTeam((int) teamByName.getId());
         assertNotNull(teamById);
 
         assertEquals(teamByName.getId(), teamById.getId());


### PR DESCRIPTION
# Description 
That PR is adding Global Node ID according to https://developer.github.com/v4/guides/using-global-node-ids/
Im trying to mix v3 and v4 (graphQL) of GH API together and without Global Node IDs its really hard.

Extending GHObject in GHTeam changed signature of ID, so its back incompatible change (Im not sure why GHTeam was not extending GHObject, in my opinion there is no reason for not doing it).

Please let me know whats best idea to test if it will work on all objects that extends GHObject..

# Before submitting a PR:
- [x] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [x] Add JavaDocs and other comments
- [x] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [x] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [x] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

